### PR TITLE
[PREVIEW]Sscs 4122 tribunals api nulls

### DIFF
--- a/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
@@ -93,6 +93,12 @@ public class SubmitAppealService {
 
         byte[] pdf = generatePdf(appeal, caseDetails.getId(), caseData);
 
+
+        sendPdfByEmail(caseData.getAppeal().getAppellant(), pdf);
+
+        log.info("PDF email sent successfully for Nino - {} and benefit type {}", caseData.getAppeal().getAppellant().getIdentity().getNino(),
+                caseData.getAppeal().getBenefitType().getCode());
+
         prepareCaseForPdf(caseDetails.getId(), caseData, pdf, idamTokens);
 
         sendCaseToRobotics(caseData, caseDetails.getId(), postcode, pdf);
@@ -116,19 +122,13 @@ public class SubmitAppealService {
         log.info("Appeal PDF stored in DM for Nino - {} and benefit type {}", caseData.getAppeal().getAppellant().getIdentity().getNino(),
                 caseData.getAppeal().getBenefitType().getCode());
 
-        List<SscsDocument> allDocuments = combineEvidenceAndAppealPdf(caseData, pdfDocuments);
-
         if (caseId == null) {
             log.info("caseId is empty - skipping step to update CCD with PDF");
         } else {
+            List<SscsDocument> allDocuments = combineEvidenceAndAppealPdf(caseData, pdfDocuments);
             SscsCaseData caseDataWithAppealPdf = caseData.toBuilder().sscsDocument(allDocuments).build();
             updateCaseInCcd(caseDataWithAppealPdf, caseId, "uploadDocument", idamTokens);
         }
-
-        sendPdfByEmail(caseData.getAppeal().getAppellant(), pdf);
-
-        log.info("PDF email sent successfully for Nino - {} and benefit type {}", caseData.getAppeal().getAppellant().getIdentity().getNino(),
-                caseData.getAppeal().getBenefitType().getCode());
     }
 
 

--- a/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
+++ b/src/main/java/uk/gov/hmcts/sscs/service/SubmitAppealService.java
@@ -118,8 +118,12 @@ public class SubmitAppealService {
 
         List<SscsDocument> allDocuments = combineEvidenceAndAppealPdf(caseData, pdfDocuments);
 
-        SscsCaseData caseDataWithAppealPdf = caseData.toBuilder().sscsDocument(allDocuments).build();
-        updateCaseInCcd(caseDataWithAppealPdf, caseId, "uploadDocument", idamTokens);
+        if (caseId == null) {
+            log.info("caseId is empty - skipping step to update CCD with PDF");
+        } else {
+            SscsCaseData caseDataWithAppealPdf = caseData.toBuilder().sscsDocument(allDocuments).build();
+            updateCaseInCcd(caseDataWithAppealPdf, caseId, "uploadDocument", idamTokens);
+        }
 
         sendPdfByEmail(caseData.getAppeal().getAppellant(), pdf);
 

--- a/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
@@ -133,8 +133,9 @@ public class SubmitAppealServiceTest {
 
         submitAppealService.submitAppeal(appealData);
 
-        then(pdfServiceClient).should(times(1)).generateFromHtml(any(), any());
-        then(emailService).should(times(2)).sendEmail(any(Email.class));
+        verify(ccdService, never()).updateCase(any(), any(), any(), any(), any(), any());
+        verify(pdfServiceClient).generateFromHtml(any(), any());
+        verify(emailService, times(2).sendEmail(any(Email.class));
 
         assertNull(getPdfWrapper().getCcdCaseId());
     }

--- a/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
@@ -135,7 +135,7 @@ public class SubmitAppealServiceTest {
 
         verify(ccdService, never()).updateCase(any(), any(), any(), any(), any(), any());
         verify(pdfServiceClient).generateFromHtml(any(), any());
-        verify(emailService, times(2).sendEmail(any(Email.class));
+        verify(emailService, times(2).sendEmail(any(Email.class)));
 
         assertNull(getPdfWrapper().getCcdCaseId());
     }

--- a/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/sscs/service/SubmitAppealServiceTest.java
@@ -135,7 +135,7 @@ public class SubmitAppealServiceTest {
 
         verify(ccdService, never()).updateCase(any(), any(), any(), any(), any(), any());
         verify(pdfServiceClient).generateFromHtml(any(), any());
-        verify(emailService, times(2).sendEmail(any(Email.class)));
+        verify(emailService, times(2)).sendEmail(any(Email.class));
 
         assertNull(getPdfWrapper().getCcdCaseId());
     }


### PR DESCRIPTION
Fix to prevent CCD being touched a second time if the first call fails to create a case.