### PR TITLE
Fix daylight savings issue in test

### DIFF
--- a/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
@@ -93,8 +93,8 @@ public class TrackYourAppealJsonBuilderTest {
         LocalDateTime localUtcDate = LocalDateTime.ofInstant(instant, ZoneOffset.UTC).minusHours(2).minusWeeks(PAST_HEARING_BOOKED_IN_WEEKS);
 
         String dwpResponseDateCcd = LocalDateTime.ofInstant(instant, ZoneId.of("Europe/London")).minusHours(2).minusWeeks(PAST_HEARING_BOOKED_IN_WEEKS).toString();
-        String dwpResponseDateUtc = localUtcDate.toString();
-        String hearingContactDate = localUtcDate.plusWeeks(DWP_RESPONSE_HEARING_CONTACT_DATE_IN_WEEKS).toString();
+        String dwpResponseDateUtc = DateTimeUtils.convertLocalDateTimetoUtc(localUtcDate).toString();
+        String hearingContactDate = DateTimeUtils.convertLocalDateTimetoUtc(localUtcDate.plusWeeks(DWP_RESPONSE_HEARING_CONTACT_DATE_IN_WEEKS)).toString();
 
         SscsCaseData caseData = buildHearingBookedEvent(PAST_HEARING_BOOKED_CCD.getDeserializeMessage(), dwpResponseDateCcd);
 
@@ -102,8 +102,8 @@ public class TrackYourAppealJsonBuilderTest {
                 populateRegionalProcessingCenter(), 1L);
 
         String updatedString = PAST_HEARING_BOOKED.getSerializedMessage()
-                .replace("2017-06-29T11:50:11.987Z", dwpResponseDateUtc + "Z")
-                .replace("2017-08-24T11:50:11.437Z", hearingContactDate + "Z");
+                .replace("2017-06-29T11:50:11.987Z", dwpResponseDateUtc)
+                .replace("2017-08-24T11:50:11.437Z", hearingContactDate);
         assertJsonEquals(updatedString, objectNode);
     }
 


### PR DESCRIPTION
After the change in daylight savings this past weekend, a test was failing due to an "off by one hour" error.