### PR TITLE
Sscs 4534 configure for docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are using the [sscs-docker](https://github.com/hmcts/sscs-docker) backend
 127.0.0.1       smtp-server
 ```
 
-This allows your locally-running copy of the case api to reference the same URLs as the internally-running docker images.
+This allows your locally-running copy of the case api to reference the same URLs as the internally-running docker images. These are the defaults for their respective services in application.properties.
 
 ### Running in Docker(Work in progress...)
 Create the image of the application by executing the following command:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Once the application running locally, please make sure
     For example:  export TEST_URL=http://localhost:8080
 3. Execute ./gradlew --info smoke
 
+### Configure local hosts
+If you are using the [sscs-docker](https://github.com/hmcts/sscs-docker) backend, add the following to your hosts file
+
+```
+127.0.0.1       dm-store
+127.0.0.1       smtp-server
+```
+
+This allows your locally-running copy of the case api to reference the same URLs as the internally-running docker images.
+
 ### Running in Docker(Work in progress...)
 Create the image of the application by executing the following command:
 

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -14,7 +14,7 @@ robotics.email.subject=${ROBOTICS_EMAIL_SUBJECT:Robotics Data}
 robotics.email.message=${ROBOTICS_EMAIL_MESSAGE:Please find attached the robotics json file \nPlease do not respond to this email}
 robotics.schema.resource.location=/schema/sscs-robotics.json
 
-appeal.email.host=${EMAIL_SERVER_HOST:localhost}
+appeal.email.host=${EMAIL_SERVER_HOST:smtp-server}
 appeal.email.port=${EMAIL_SERVER_PORT:1025}
 appeal.email.smtp.tls.enabled=${EMAIL_SMTP_TLS_ENABLED:true}
 appeal.email.smtp.ssl.trust=${EMAIL_SMTP_SSL_TRUST:*}
@@ -45,7 +45,7 @@ idam.oauth2.client.secret: ${IDAM_OAUTH2_CLIENT_SECRET:QM5RQQ53LZFOSIXJ}
 idam.oauth2.redirectUrl: ${IDAM_OAUTH2_REDIRECT_URL:https://localhost:9000/poc}
 
 #Document store
-document_management.url=${DOCUMENT_MANAGEMENT_URL:http://localhost:4506}
+document_management.url=${DOCUMENT_MANAGEMENT_URL:http://dm-store:4506}
 
 #Management
 management.endpoints.web.base-path=/


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-4534

Modify application.properties to use host names rather than localhost so that a locally-running Tribunals Case API references the same domain names for SMTP and DM-STORE as are being used internally in the docker compose setup for sscs-docker.