### PR TITLE
Removed old preview env

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -81,8 +81,8 @@ locals {
   aseName       = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
   app_full_name = "${var.product}-${var.component}"
 
-  local_env = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "aat" : "saat" : var.env}"
-  local_ase = "${(var.env == "preview" || var.env == "spreview") ? (var.env == "preview" ) ? "core-compute-aat" : "core-compute-saat" : local.aseName}"
+  local_env = "${var.env}"
+  local_ase = "${local.aseName}"
 
   ccdApi        = "http://ccd-data-store-api-${local.local_env}.service.${local.local_ase}.internal"
   s2sCnpUrl     = "http://rpe-service-auth-provider-${local.local_env}.service.${local.local_ase}.internal"
@@ -104,7 +104,7 @@ module "tribunals-case-api" {
   ilbIp        = "${var.ilbIp}"
   is_frontend  = false
   subscription = "${var.subscription}"
-  capacity     = "${(var.env == "preview") ? 1 : 2}"
+  capacity     = 2
   common_tags  = "${var.common_tags}"
   asp_rg       = "${local.app_service_plan}"
   asp_name     = "${local.app_service_plan}"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -78,18 +78,14 @@ data "azurerm_key_vault_secret" "idam_oauth2_client_secret" {
 }
 
 locals {
-  aseName       = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
-  app_full_name = "${var.product}-${var.component}"
+  local_ase = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 
-  local_env = "${var.env}"
-  local_ase = "${local.aseName}"
+  ccdApi        = "http://ccd-data-store-api-${var.env}.service.${local.local_ase}.internal"
+  s2sCnpUrl     = "http://rpe-service-auth-provider-${var.env}.service.${local.local_ase}.internal"
+  pdfService    = "http://cmc-pdf-service-${var.env}.service.${local.local_ase}.internal"
+  documentStore = "http://dm-store-${var.env}.service.${local.local_ase}.internal"
 
-  ccdApi        = "http://ccd-data-store-api-${local.local_env}.service.${local.local_ase}.internal"
-  s2sCnpUrl     = "http://rpe-service-auth-provider-${local.local_env}.service.${local.local_ase}.internal"
-  pdfService    = "http://cmc-pdf-service-${local.local_env}.service.${local.local_ase}.internal"
-  documentStore = "http://dm-store-${local.local_env}.service.${local.local_ase}.internal"
-
-  azureVaultName = "sscs-${local.local_env}"
+  azureVaultName = "sscs-${var.env}"
 
   shared_app_service_plan     = "${var.product}-${var.env}"
   non_shared_app_service_plan = "${var.product}-${var.component}-${var.env}"
@@ -98,7 +94,7 @@ locals {
 
 module "tribunals-case-api" {
   source       = "git@github.com:hmcts/moj-module-webapp.git?ref=master"
-  product      = "${local.app_full_name}"
+  product      = "${var.product}-${var.component}"
   location     = "${var.location}"
   env          = "${var.env}"
   ilbIp        = "${var.ilbIp}"

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,2 +1,0 @@
-idam_redirect_url = "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
-infrastructure_env = "preprod"


### PR DESCRIPTION
We don't use the old preview environment built by Terraform.
This PR removes the old (Terraform) preview environment in favour of AKS.