### PR TITLE
Bump common lib to 0.144

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.144-RC'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.144'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.142'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.144-RC'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.134-SIDAM-VENUE-PATCHES'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.142'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.133-SIDAM-PATCH'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.134-SIDAM-VENUE-PATCHES'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-4820

### Change description ###

We bump the sscs-common library version to 0.142. This brings in the TYA surname search changes described in the above ticket.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
