### PR TITLE
Sscs 5232 tya surnames

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.145-RC2'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.145-RC3'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.145-RC3'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.145'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '1.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.5.0'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.144'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '0.0.145-RC2'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '0.0.98-PATCH'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version: '0.0.8-PATCH'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-5232

### Change description ###
Bump common library version to allow searching for appointee surnames.
Once this has been tested, then the following PR can be merged to master and an 0.0.145 version created of sscs-common. Then, update this PR to point to that new version and merge.

https://github.com/hmcts/sscs-common/pull/105

```
[ ] Yes
[x] No
```
