### PR TITLE
SSCS-5495: replace dots and dashes with underscores in environment variables

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -19,9 +19,9 @@ def secrets = [
         secret('idam-sscs-systemupdate-user', 'IDAM_SSCS_SYSTEMUPDATE_USER'),
         secret('idam-sscs-systemupdate-password', 'IDAM_SSCS_SYSTEMUPDATE_PASSWORD'),
         secret('idam-sscs-oauth2-client-secret', 'IDAM_OAUTH2_CLIENT_SECRET'),
-        secret('idam-s2s-api', 'IDAM.S2S-AUTH'),
-        secret('sscs-s2s-secret', 'IDAM.S2S-AUTH.TOTP_SECRET'),
-        secret('s2s-micro', 'IDAM.S2S-AUTH.MICROSERVICE'),
+        secret('idam-s2s-api', 'IDAM_S2S_AUTH'),
+        secret('sscs-s2s-secret', 'IDAM_S2S_AUTH_TOTP_SECRET'),
+        secret('s2s-micro', 'IDAM_S2S_AUTH_MICROSERVICE'),
     ]
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -26,9 +26,9 @@ List<LinkedHashMap<String, Object>> secrets = [
         secret('idam-sscs-systemupdate-password', 'IDAM_SSCS_SYSTEMUPDATE_PASSWORD'),
         secret('idam-sscs-oauth2-client-secret', 'IDAM_OAUTH2_CLIENT_SECRET'),
 
-        secret('idam-s2s-api', 'IDAM.S2S-AUTH'),
-        secret('sscs-s2s-secret', 'IDAM.S2S-AUTH.TOTP_SECRET'),
-        secret('s2s-micro', 'IDAM.S2S-AUTH.MICROSERVICE'),
+        secret('idam-s2s-api', 'IDAM_S2S_AUTH'),
+        secret('sscs-s2s-secret', 'IDAM_S2S_AUTH_TOTP_SECRET'),
+        secret('s2s-micro', 'IDAM_S2S_AUTH_MICROSERVICE'),
 
 ]
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -134,9 +134,9 @@ module "tribunals-case-api" {
     CORE_CASE_DATA_JURISDICTION_ID = "${var.core_case_data_jurisdiction_id}"
     CORE_CASE_DATA_CASE_TYPE_ID    = "${var.core_case_data_case_type_id}"
 
-    IDAM.S2S-AUTH.TOTP_SECRET  = "${data.azurerm_key_vault_secret.sscs_s2s_secret.value}"
-    IDAM.S2S-AUTH              = "${local.s2sCnpUrl}"
-    IDAM.S2S-AUTH.MICROSERVICE = "${var.ccd_idam_s2s_auth_microservice}"
+    IDAM_S2S_AUTH_TOTP_SECRET  = "${data.azurerm_key_vault_secret.sscs_s2s_secret.value}"
+    IDAM_S2S_AUTH              = "${local.s2sCnpUrl}"
+    IDAM_S2S_AUTH_MICROSERVICE = "${var.ccd_idam_s2s_auth_microservice}"
 
     IDAM_SSCS_SYSTEMUPDATE_USER     = "${data.azurerm_key_vault_secret.idam_sscs_systemupdate_user.value}"
     IDAM_SSCS_SYSTEMUPDATE_PASSWORD = "${data.azurerm_key_vault_secret.idam_sscs_systemupdate_password.value}"

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -35,9 +35,9 @@ core_case_data.caseTypeId=${CORE_CASE_DATA_CASE_TYPE_ID:Benefit}
 
 # IDAM
 idam.url=${IDAM_API_URL:http://localhost:4501}
-idam.s2s-auth.totp_secret=${IDAM.S2S-AUTH.TOTP_SECRET:AAAAAAAAAAAAAAAC}
-idam.s2s-auth.microservice=${IDAM.S2S-AUTH.MICROSERVICE:sscs}
-idam.s2s-auth.url=${IDAM.S2S-AUTH:http://localhost:4502}
+idam.s2s-auth.totp_secret=${IDAM_S2S_AUTH_TOTP_SECRET:AAAAAAAAAAAAAAAC}
+idam.s2s-auth.microservice=${IDAM_S2S_AUTH_MICROSERVICE:sscs}
+idam.s2s-auth.url=${IDAM_S2S_AUTH:http://localhost:4502}
 idam.oauth2.user.email=${IDAM_SSCS_SYSTEMUPDATE_USER:SSCS_SYSTEM_UPDATE}
 idam.oauth2.user.password: ${IDAM_SSCS_SYSTEMUPDATE_PASSWORD:SSCS_SYSTEM_UPDATE}
 idam.oauth2.client.id=${IDAM_OAUTH2_CLIENT_ID:sscs}

--- a/src/main/resources/config/bootstrap.yaml
+++ b/src/main/resources/config/bootstrap.yaml
@@ -14,6 +14,6 @@ spring:
         idam-sscs-systemupdate-user: IDAM_SSCS_SYSTEMUPDATE_USER
         idam-sscs-systemupdate-password: IDAM_SSCS_SYSTEMUPDATE_PASSWORD
         idam-sscs-oauth2-client-secret: IDAM_OAUTH2_CLIENT_SECRET
-        idam-s2s-api: IDAM.S2S-AUTH
-        sscs-s2s-secret: IDAM.S2S-AUTH.TOTP_SECRET
-        s2s-micro: IDAM.S2S-AUTH.MICROSERVICE
+        idam-s2s-api: IDAM_S2S_AUTH
+        sscs-s2s-secret: IDAM_S2S_AUTH_TOTP_SECRET
+        s2s-micro: IDAM_S2S_AUTH_MICROSERVICE


### PR DESCRIPTION
kubernetes does not like dots in environment variables.