### PR TITLE
SSCS-5105: Archive Draft once submitted.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,8 +248,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.6'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.1.5.RELEASE'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.27.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '2.27.0'
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.23.2'
     testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '2.6.1'
     testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
 
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '2.0.11-RC1'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '2.0.12'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version:  '1.0.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -248,7 +248,6 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.6'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '2.1.5.RELEASE'
-    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: '2.1'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.27.0'
     testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.23.2'
     testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '2.6.1'

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
 
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '2.0.9'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '2.0.11-RC1'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version:  '1.0.3'
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ccd/CreateCaseInCcdTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/ccd/CreateCaseInCcdTest.java
@@ -79,7 +79,7 @@ public class CreateCaseInCcdTest {
     @Test
     public void givenASyaCaseShouldBeSavedIntoCcdViaSubmitAppealService() {
         try {
-            submitAppealService.submitAppeal(ALL_DETAILS.getDeserializeMessage());
+            submitAppealService.submitAppeal(ALL_DETAILS.getDeserializeMessage(), "");
         } catch (EmailSendFailedException | PdfGenerationException ep) {
             assertTrue(true);
         } catch (Exception ex) {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -166,7 +166,16 @@ public class SubmitDraftTest {
 
         archiveDraft(caseData);
 
-        assertTrue(citizenCcdService.findCase(citizenIdamTokens).isEmpty());
+        assertEquals(0, citizenCcdService.findCase(citizenIdamTokens).size());
+    }
+
+    @Test
+    public void archiveAllDraftsDeleteMeOnceItIsRunOnAAT() {
+        List<SscsCaseData> savedDrafts = citizenCcdService.findCase(citizenIdamTokens);
+        for (SscsCaseData caseData : savedDrafts) {
+            archiveDraft(caseData);
+        }
+        assertTrue("This is to remove records in AAT. It is not a test.",true);
     }
 
     private Response saveDraft(SyaCaseWrapper draftAppeal) {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -2,7 +2,9 @@ package uk.gov.hmcts.reform.sscs.functional.sya;
 
 import static io.restassured.RestAssured.baseURI;
 import static io.restassured.RestAssured.useRelaxedHTTPSValidation;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
@@ -120,7 +122,7 @@ public class SubmitDraftTest {
         SyaCaseWrapper draftAppeal = buildTestDraftAppeal();
         Response response = saveDraft(draftAppeal);
         response.then()
-            .statusCode(HttpStatus.SC_OK)
+            .statusCode(anyOf(is(HttpStatus.SC_OK), is(HttpStatus.SC_CREATED)))
             .assertThat().header(LOCATION_HEADER_NAME, not(isEmptyOrNullString())).log().all(true);
         String responseHeader = response.getHeader(LOCATION_HEADER_NAME);
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -16,6 +16,7 @@ import io.restassured.response.Response;
 import java.util.Base64;
 import java.util.List;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -159,9 +160,9 @@ public class SubmitDraftTest {
 
         saveDraft(draftAppeal);
 
-        List<SscsCaseData> savedDraft = citizenCcdService.findCase(citizenIdamTokens);
-        assertEquals(1, savedDraft.size());
-        SscsCaseData caseData = savedDraft.get(0);
+        List<SscsCaseData> savedDrafts = citizenCcdService.findCase(citizenIdamTokens);
+        assertTrue(CollectionUtils.isNotEmpty(savedDrafts));
+        SscsCaseData caseData = savedDrafts.get(0);
 
         archiveDraft(caseData);
 

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -170,7 +170,7 @@ public class SubmitDraftTest {
     }
 
     @Test
-    public void archiveAllDraftsDeleteMeOnceItIsRunOnAAT() {
+    public void archiveAllDraftsDeleteMeOnceItIsRunOnAat() {
         List<SscsCaseData> savedDrafts = citizenCcdService.findCase(citizenIdamTokens);
         for (SscsCaseData caseData : savedDrafts) {
             archiveDraft(caseData);

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import io.restassured.RestAssured;
@@ -13,7 +14,9 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import java.util.Base64;
-import org.eclipse.jetty.http.HttpStatus;
+import java.util.List;
+
+import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,12 +25,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.config.CitizenCcdService;
 import uk.gov.hmcts.reform.sscs.domain.wrapper.SyaBenefitType;
 import uk.gov.hmcts.reform.sscs.domain.wrapper.SyaCaseWrapper;
 import uk.gov.hmcts.reform.sscs.idam.Authorize;
 import uk.gov.hmcts.reform.sscs.idam.IdamApiClient;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.util.SyaServiceHelper;
 
 @RunWith(SpringRunner.class)
@@ -50,9 +56,6 @@ public class SubmitDraftTest {
     @Autowired
     private CitizenCcdService citizenCcdService;
 
-    @Autowired
-    private IdamService idamService;
-
     @Value("${idam.oauth2.client.secret}")
     private String idamOauth2ClientSecret;
 
@@ -65,13 +68,34 @@ public class SubmitDraftTest {
     @Value("${idam.oauth2.citizen.password}")
     private String password;
 
-    private String userToken;
+    @Autowired
+    private AuthTokenGenerator authTokenGenerator;
+
+    @Autowired
+    private IdamService idamService;
+
+    private String citizenToken;
+
+    private IdamTokens citizenIdamTokens;
+
+    private IdamTokens userIdamTokens;
 
     @Before
     public void setUp() {
         baseURI = testUrl;
         useRelaxedHTTPSValidation();
-        userToken = getIdamOauth2Token(username, password);
+        citizenToken = getIdamOauth2Token(username, password);
+        citizenIdamTokens = IdamTokens.builder()
+                .idamOauth2Token(citizenToken)
+                .serviceAuthorization(authTokenGenerator.generate())
+                .userId(getUserId(citizenToken))
+                .build();
+
+        userIdamTokens = idamService.getIdamTokens();
+    }
+
+    private String getUserId(String userToken) {
+        return idamApiClient.getUserDetails(userToken).getId();
     }
 
     @Test
@@ -79,12 +103,13 @@ public class SubmitDraftTest {
         SyaCaseWrapper draftAppeal = buildTestDraftAppeal();
         Response response = saveDraft(draftAppeal);
         response.then()
-            .statusCode(HttpStatus.OK_200)
+            .statusCode(HttpStatus.SC_OK)
             .assertThat().header(LOCATION_HEADER_NAME, not(isEmptyOrNullString())).log().all(true);
     }
 
     private SyaCaseWrapper buildTestDraftAppeal() {
         SyaCaseWrapper draftAppeal = new SyaCaseWrapper();
+        draftAppeal.setCaseType("draft");
         draftAppeal.setBenefitType(new SyaBenefitType("Personal Independence Payment", "PIP"));
         return draftAppeal;
     }
@@ -94,13 +119,13 @@ public class SubmitDraftTest {
         SyaCaseWrapper draftAppeal = buildTestDraftAppeal();
         Response response = saveDraft(draftAppeal);
         response.then()
-            .statusCode(HttpStatus.OK_200)
+            .statusCode(HttpStatus.SC_OK)
             .assertThat().header(LOCATION_HEADER_NAME, not(isEmptyOrNullString())).log().all(true);
         String responseHeader = response.getHeader(LOCATION_HEADER_NAME);
 
         Response response2 = saveDraft(draftAppeal);
         response2.then()
-            .statusCode(HttpStatus.OK_200)
+            .statusCode(HttpStatus.SC_OK)
             .assertThat().header(LOCATION_HEADER_NAME, not(isEmptyOrNullString())).log().all(true);
         String response2Header = response.getHeader(LOCATION_HEADER_NAME);
 
@@ -112,10 +137,10 @@ public class SubmitDraftTest {
         SyaCaseWrapper draftAppeal = buildTestDraftAppeal();
         saveDraft(draftAppeal);
         RestAssured.given()
-            .header(new Header(AUTHORIZATION, userToken))
+            .header(new Header(AUTHORIZATION, citizenToken))
             .get("/drafts")
             .then()
-            .statusCode(HttpStatus.OK_200)
+            .statusCode(HttpStatus.SC_OK)
             .assertThat().body("BenefitType.benefitType", equalTo("Personal Independence Payment (PIP)"));
     }
 
@@ -125,17 +150,35 @@ public class SubmitDraftTest {
             .header(new Header(AUTHORIZATION, "thisTokenIsIncorrect"))
             .get("/drafts")
             .then()
-            .statusCode(HttpStatus.INTERNAL_SERVER_ERROR_500);
+            .statusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     }
 
+    @Test
+    public void onceADraftIsArchived_itCannotBeRetrievedByTheCitizenUser() {
+        SyaCaseWrapper draftAppeal = buildTestDraftAppeal();
+
+        saveDraft(draftAppeal);
+
+        List<SscsCaseData> savedDraft = citizenCcdService.findCase(citizenIdamTokens);
+        assertEquals(1, savedDraft.size());
+        SscsCaseData caseData = savedDraft.get(0);
+
+        archiveDraft(caseData);
+
+        assertTrue(citizenCcdService.findCase(citizenIdamTokens).isEmpty());
+    }
 
     private Response saveDraft(SyaCaseWrapper draftAppeal) {
         return RestAssured.given()
             .log().method().log().headers().log().uri().log().body(true)
             .contentType(ContentType.JSON)
-            .header(new Header(AUTHORIZATION, userToken))
+            .header(new Header(AUTHORIZATION, citizenToken))
             .body(SyaServiceHelper.asJsonString(draftAppeal))
             .put("/drafts");
+    }
+
+    private void archiveDraft(SscsCaseData draftAppeal) {
+        citizenCcdService.draftArchived(draftAppeal, citizenIdamTokens, userIdamTokens);
     }
 
     public String getIdamOauth2Token(String username, String password) {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitDraftTest.java
@@ -169,15 +169,6 @@ public class SubmitDraftTest {
         assertEquals(0, citizenCcdService.findCase(citizenIdamTokens).size());
     }
 
-    @Test
-    public void archiveAllDraftsDeleteMeOnceItIsRunOnAat() {
-        List<SscsCaseData> savedDrafts = citizenCcdService.findCase(citizenIdamTokens);
-        for (SscsCaseData caseData : savedDrafts) {
-            archiveDraft(caseData);
-        }
-        assertTrue("This is to remove records in AAT. It is not a test.",true);
-    }
-
     private Response saveDraft(SyaCaseWrapper draftAppeal) {
         return RestAssured.given()
             .log().method().log().headers().log().uri().log().body(true)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/CitizenCcdService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/CitizenCcdService.java
@@ -1,8 +1,12 @@
 package uk.gov.hmcts.reform.sscs.config;
 
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.DRAFT_ARCHIVED;
+
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
@@ -10,6 +14,8 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.ccd.service.SscsCcdConvertService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.model.SaveCaseOperation;
@@ -19,13 +25,17 @@ import uk.gov.hmcts.reform.sscs.model.SaveCaseResult;
 @Slf4j
 public class CitizenCcdService {
 
-    private CitizenCcdClient citizenCcdClient;
-    private SscsCcdConvertService sscsCcdConvertService;
+    private final CitizenCcdClient citizenCcdClient;
+    private final SscsCcdConvertService sscsCcdConvertService;
+    private final CcdService ccdService;
 
     @Autowired
-    CitizenCcdService(CitizenCcdClient citizenCcdClient, SscsCcdConvertService sscsCcdConvertService) {
+    CitizenCcdService(CitizenCcdClient citizenCcdClient,
+                      SscsCcdConvertService sscsCcdConvertService,
+                      CcdService ccdService) {
         this.citizenCcdClient = citizenCcdClient;
         this.sscsCcdConvertService = sscsCcdConvertService;
+        this.ccdService = ccdService;
     }
 
 
@@ -40,7 +50,7 @@ public class CitizenCcdService {
         List<CaseDetails> caseDetailsList = citizenCcdClient.searchForCitizen(idamTokens);
 
         CaseDetails caseDetails;
-        if (caseDetailsList.size() > 0) {
+        if (CollectionUtils.isNotEmpty(caseDetailsList)) {
             String caseId = caseDetailsList.get(0).getId().toString();
             caseDetails = updateCase(caseData, EventType.UPDATE_DRAFT.getCcdType(), "Update draft",
                 "Update draft in CCD", idamTokens, caseId);
@@ -56,6 +66,21 @@ public class CitizenCcdService {
                 .saveCaseOperation(SaveCaseOperation.CREATE)
                 .build();
         }
+    }
+
+    public Optional<SscsCaseDetails> draftArchived(SscsCaseData caseData, IdamTokens citizenIdamTokens,
+                                                   IdamTokens userIdamTokens) {
+        List<CaseDetails> caseDetailsList = citizenCcdClient.searchForCitizen(citizenIdamTokens);
+
+        if (!caseDetailsList.isEmpty()) {
+            Long caseId = caseDetailsList.get(0).getId();
+
+            SscsCaseDetails sscsCaseDetails = ccdService.updateCase(caseData, caseId, DRAFT_ARCHIVED.getCcdType(),
+                    "SSCS - draft archived", "SSCS - draft archived", userIdamTokens);
+
+            return Optional.of(sscsCaseDetails);
+        }
+        return Optional.empty();
     }
 
     private CaseDetails newCase(SscsCaseData caseData, String eventType, String summary, String description, IdamTokens idamTokens) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/SyaController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/SyaController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.controller;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.created;
 import static org.springframework.http.ResponseEntity.status;
 
 import com.google.common.base.Preconditions;
@@ -45,10 +46,11 @@ public class SyaController {
     @ApiResponses(value = {@ApiResponse(code = 201, message = "Submitted appeal successfully",
         response = String.class)})
     @PostMapping(value = "/appeals", consumes = APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> createAppeals(@RequestBody SyaCaseWrapper syaCaseWrapper) {
+    public ResponseEntity<String> createAppeals(@RequestHeader(value = AUTHORIZATION, required = false)
+                                                            String authorisation, @RequestBody SyaCaseWrapper syaCaseWrapper) {
         log.info("Appeal with Nino - {} and benefit type {} received", syaCaseWrapper.getAppellant().getNino(),
             syaCaseWrapper.getBenefitType().getCode());
-        Long caseId = submitAppealService.submitAppeal(syaCaseWrapper);
+        Long caseId = submitAppealService.submitAppeal(syaCaseWrapper, authorisation);
         log.info("Case {} with benefit type - {} processed successfully",
             caseId,
             syaCaseWrapper.getBenefitType().getCode());
@@ -87,9 +89,9 @@ public class SyaController {
         URI location = ServletUriComponentsBuilder.fromCurrentRequest().path("/{id}")
             .buildAndExpand(draft.getId()).toUri();
         if (submitDraftResult.getSaveCaseOperation().equals(SaveCaseOperation.CREATE)) {
-            return ResponseEntity.created(location).build();
+            return created(location).build();
         } else {
-            return ResponseEntity.status(HttpStatus.OK).location(location).build();
+            return status(HttpStatus.OK).location(location).build();
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealService.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
@@ -65,7 +66,7 @@ public class SubmitAppealService {
         this.convertAintoBService = convertAintoBService;
     }
 
-    public Long submitAppeal(SyaCaseWrapper appeal) {
+    public Long submitAppeal(SyaCaseWrapper appeal, String userToken) {
         String firstHalfOfPostcode = regionalProcessingCenterService
             .getFirstHalfOfPostcode(appeal.getContactDetails().getPostCode());
         SscsCaseData caseData = prepareCaseForCcd(appeal, firstHalfOfPostcode);
@@ -73,7 +74,7 @@ public class SubmitAppealService {
         EventType event = findEventType(caseData);
         IdamTokens idamTokens = idamService.getIdamTokens();
         SscsCaseDetails caseDetails = createCaseInCcd(caseData, event, idamTokens);
-        postCreateCaseInCcdProcess(appeal, firstHalfOfPostcode, caseData, idamTokens, caseDetails, event);
+        postCreateCaseInCcdProcess(appeal, firstHalfOfPostcode, caseData, idamTokens, caseDetails, event, userToken);
         // in case of duplicate case the caseDetails will be null
         return (caseDetails != null) ? caseDetails.getId() : null;
     }
@@ -102,13 +103,17 @@ public class SubmitAppealService {
     }
 
     private void postCreateCaseInCcdProcess(SyaCaseWrapper appeal, String firstHalfOfPostcode, SscsCaseData caseData,
-                                            IdamTokens idamTokens, SscsCaseDetails caseDetails, EventType event) {
+                                            IdamTokens idamTokens, SscsCaseDetails caseDetails, EventType event,
+                                            String userToken) {
         if (null != caseDetails) {
             byte[] pdf = sscsPdfService.generateAndSendPdf(caseData, caseDetails.getId(), idamTokens, "sscs1");
             Map<String, byte[]> additionalEvidence = downloadEvidence(appeal);
             if (event.equals(SYA_APPEAL_CREATED)) {
                 roboticsService.sendCaseToRobotics(caseData, caseDetails.getId(), firstHalfOfPostcode, pdf,
                     additionalEvidence);
+            }
+            if (StringUtils.isNotEmpty(userToken)) {
+                citizenCcdService.draftArchived(caseData, getUserTokens(userToken), idamTokens);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controller/SyaControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controller/SyaControllerTest.java
@@ -45,7 +45,7 @@ public class SyaControllerTest {
 
     @Test
     public void shouldReturnHttpStatusCode201ForTheSubmittedAppeal() throws Exception {
-        when(submitAppealService.submitAppeal(any(SyaCaseWrapper.class))).thenReturn(1L);
+        when(submitAppealService.submitAppeal(any(SyaCaseWrapper.class), any(String.class))).thenReturn(1L);
 
         String json = getSyaCaseWrapperJson();
 
@@ -75,7 +75,7 @@ public class SyaControllerTest {
     @Test
     public void shouldHandleErrorWhileSubmitAppeal() throws Exception {
         doThrow(new PdfGenerationException("malformed html template", new Exception()))
-            .when(submitAppealService).submitAppeal(any(SyaCaseWrapper.class));
+            .when(submitAppealService).submitAppeal(any(SyaCaseWrapper.class), any());
         String json = getSyaCaseWrapperJson();
 
         mockMvc.perform(post("/appeals")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealServiceTest.java
@@ -193,7 +193,7 @@ public class SubmitAppealServiceTest {
 
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(), any())).willReturn(null);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(ccdService).createCase(any(SscsCaseData.class), eq(SYA_APPEAL_CREATED.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));
         verify(ccdService, times(0)).updateCase(any(SscsCaseData.class), eq(123L), eq(SENT_TO_DWP.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SubmitAppealServiceTest.java
@@ -117,6 +117,8 @@ public class SubmitAppealServiceTest {
 
     private JSONObject json = new JSONObject();
 
+    private final String userToken = null;
+
     @Mock
     private AuthTokenGenerator authTokenGenerator;
     @Mock
@@ -185,7 +187,7 @@ public class SubmitAppealServiceTest {
 
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(), any())).willReturn(null);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(ccdService).createCase(any(SscsCaseData.class), eq(SYA_APPEAL_CREATED.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));
     }
@@ -199,7 +201,7 @@ public class SubmitAppealServiceTest {
 
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(), any())).willReturn(null);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(ccdService).createCase(any(SscsCaseData.class), eq(INCOMPLETE_APPLICATION_RECEIVED.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));
     }
@@ -213,7 +215,7 @@ public class SubmitAppealServiceTest {
 
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(), any())).willReturn(null);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(ccdService).createCase(any(SscsCaseData.class), eq(NON_COMPLIANT.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));
     }
@@ -253,7 +255,7 @@ public class SubmitAppealServiceTest {
         given(pdfServiceClient.generateFromHtml(any(byte[].class),
             any())).willReturn(expected);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         Email expectedEmail = submitYourAppealEmailTemplate.generateEmail(
             "Bloggs_33C",
@@ -269,7 +271,7 @@ public class SubmitAppealServiceTest {
 
         given(pdfServiceClient.generateFromHtml(any(byte[].class), any(Map.class))).willReturn(expected);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(emailService, times(2)).sendEmail(emailCaptor.capture());
         Email roboticsEmail = emailCaptor.getAllValues().get(1);
@@ -283,15 +285,15 @@ public class SubmitAppealServiceTest {
 
         given(pdfServiceClient.generateFromHtml(any(byte[].class), any(Map.class))).willReturn(expected);
 
-        uk.gov.hmcts.reform.document.domain.Document stubbedDocument = new uk.gov.hmcts.reform.document.domain.Document();
-        uk.gov.hmcts.reform.document.domain.Document.Link stubbedLink = new uk.gov.hmcts.reform.document.domain.Document.Link();
+        Document stubbedDocument = new Document();
+        Document.Link stubbedLink = new Document.Link();
         stubbedLink.href = "http://localhost:4506/documents/eb8cbfaa-37c3-4644-aa77-b9a2e2c72332";
-        uk.gov.hmcts.reform.document.domain.Document.Links stubbedLinks = new Document.Links();
+        Document.Links stubbedLinks = new Document.Links();
         stubbedLinks.binary = stubbedLink;
         stubbedDocument.links = stubbedLinks;
         given(evidenceMetadataDownloadClientApi.getDocumentMetadata(anyString(), anyString(), anyString(), anyString(), anyString())).willReturn(stubbedDocument);
 
-        submitAppealService.submitAppeal(appealDataWithEvidence());
+        submitAppealService.submitAppeal(appealDataWithEvidence(), userToken);
 
         verify(emailService, times(2)).sendEmail(emailCaptor.capture());
         Email roboticsEmail = emailCaptor.getAllValues().get(1);
@@ -329,10 +331,10 @@ public class SubmitAppealServiceTest {
 
     @Test
     public void shouldUpdateCcdWithPdf() {
-        uk.gov.hmcts.reform.document.domain.Document stubbedDocument = new uk.gov.hmcts.reform.document.domain.Document();
-        uk.gov.hmcts.reform.document.domain.Document.Link stubbedLink = new uk.gov.hmcts.reform.document.domain.Document.Link();
+        Document stubbedDocument = new Document();
+        Document.Link stubbedLink = new Document.Link();
         stubbedLink.href = "http://localhost:4506/documents/eb8cbfaa-37c3-4644-aa77-b9a2e2c72332";
-        uk.gov.hmcts.reform.document.domain.Document.Links stubbedLinks = new Document.Links();
+        Document.Links stubbedLinks = new Document.Links();
         stubbedLinks.binary = stubbedLink;
         stubbedDocument.links = stubbedLinks;
         given(evidenceMetadataDownloadClientApi.getDocumentMetadata(anyString(), anyString(), anyString(), anyString(), anyString())).willReturn(stubbedDocument);
@@ -348,7 +350,7 @@ public class SubmitAppealServiceTest {
         roboticsWrapper = RoboticsWrapper.builder()
             .sscsCaseData(convertSyaToCcdCaseData(appealData)).ccdCaseId(987L).evidencePresent("Yes").build();
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, null);
 
         verify(ccdPdfService).mergeDocIntoCcd(
             eq("Bloggs_33C.pdf"),
@@ -375,7 +377,7 @@ public class SubmitAppealServiceTest {
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(SscsCaseData.class), any(IdamTokens.class)))
             .willThrow(RuntimeException.class);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
     }
 
     @Test(expected = CcdException.class)
@@ -386,7 +388,7 @@ public class SubmitAppealServiceTest {
         given(ccdService.createCase(any(SscsCaseData.class), any(String.class), any(String.class), any(String.class), any(IdamTokens.class)))
             .willThrow(RuntimeException.class);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
     }
 
     @Test
@@ -395,7 +397,7 @@ public class SubmitAppealServiceTest {
         given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(SscsCaseData.class), any(IdamTokens.class)))
             .willReturn(duplicateCase);
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         then(pdfServiceClient).should(never()).generateFromHtml(any(byte[].class), anyMap());
     }
@@ -408,8 +410,24 @@ public class SubmitAppealServiceTest {
         roboticsWrapper = RoboticsWrapper.builder()
             .sscsCaseData(convertSyaToCcdCaseData(appealData)).ccdCaseId(null).evidencePresent("No").build();
 
-        submitAppealService.submitAppeal(appealData);
+        submitAppealService.submitAppeal(appealData, userToken);
 
         verify(ccdService, never()).createCase(any(SscsCaseData.class), any(String.class), any(String.class), any(String.class), any(IdamTokens.class));
+    }
+
+    @Test
+    public void willArchiveADraftOnceAppealIsSubmitted() {
+        String userToken = "MyCitizenToken";
+        byte[] expected = {};
+        given(pdfServiceClient.generateFromHtml(any(byte[].class), any())).willReturn(expected);
+
+        given(ccdService.findCcdCaseByNinoAndBenefitTypeAndMrnDate(any(), any())).willReturn(null);
+
+        submitAppealService.submitAppeal(appealData, userToken);
+
+        verify(ccdService).createCase(any(SscsCaseData.class), eq(SYA_APPEAL_CREATED.getCcdType()), any(String.class), any(String.class), any(IdamTokens.class));
+        verify(citizenCcdService).draftArchived(any(SscsCaseData.class), any(IdamTokens.class), any(IdamTokens.class));
+
+
     }
 }


### PR DESCRIPTION
# SSCS-5105: User can't return to a draft appeal once submitted

Requires SSCS-5604 to be completed first. i.e. SYA requires to send the Authorisation header if it exists.

Also requires CCD xlsx [4.3.51] change and a [sscs-commons change](https://github.com/hmcts/sscs-common/pull/149) 

