### PR TITLE
Add an endpoint to load cases for MYA by case id

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/TyaEndpointsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/TyaEndpointsIt.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED;
+import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED_CASE_ID;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -19,6 +21,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.client.CcdClient;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
@@ -33,6 +37,7 @@ import uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager;
 @AutoConfigureMockMvc
 public class TyaEndpointsIt {
 
+    private static final long CASE_ID = 123456789L;
     @Autowired
     private MockMvc mockMvc;
 
@@ -41,6 +46,9 @@ public class TyaEndpointsIt {
 
     @MockBean
     CcdService ccdService;
+
+    @MockBean
+    CcdClient ccdClient;
 
     @MockBean
     MessageAuthenticationService macService;
@@ -63,6 +71,27 @@ public class TyaEndpointsIt {
         assertJsonEquals(APPEAL_RECEIVED.getSerializedMessage(), result);
 
 
+    }
+
+    @Test
+    public void shouldReturnAnAppealGivenACaseId() throws Exception {
+        idamTokens = IdamTokens.builder().build();
+        when(idamService.getIdamTokens()).thenReturn(idamTokens);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("caseCreated", "2019-06-06");
+        data.put("appeal", Collections.singletonMap(
+                "benefitType", Collections.singletonMap("code", "PIP")
+        ));
+
+        when(ccdClient.readForCaseworker(idamTokens, CASE_ID))
+                .thenReturn(CaseDetails.builder().data(data).id(CASE_ID).build());
+
+        MvcResult mvcResult = mockMvc.perform(get("/appeals?caseId=" + CASE_ID))
+                .andExpect(status().isOk())
+                .andReturn();
+        String result = mvcResult.getResponse().getContentAsString();
+        assertJsonEquals(APPEAL_RECEIVED_CASE_ID.getSerializedMessage(), result);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -64,7 +64,10 @@ public class TrackYourAppealJsonBuilder {
         ObjectNode caseNode = JsonNodeFactory.instance.objectNode();
         caseNode.put("caseId", String.valueOf(caseId));
         caseNode.put("caseReference", caseData.getCaseReference());
-        caseNode.put("appealNumber", caseData.getSubscriptions().getAppellantSubscription().getTya());
+        Subscription appellantSubscription = caseData.getSubscriptions().getAppellantSubscription();
+        if (appellantSubscription != null) {
+            caseNode.put("appealNumber", appellantSubscription.getTya());
+        }
         caseNode.put("status", getAppealStatus(caseData.getEvents()));
         caseNode.put("benefitType", caseData.getAppeal().getBenefitType().getCode().toLowerCase());
         caseNode.put("hearingType", getHearingType(caseData));

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/TyaController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/TyaController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.sscs.model.tya.SurnameResponse;
 import uk.gov.hmcts.reform.sscs.service.TribunalsService;
@@ -46,5 +47,15 @@ public class TyaController {
     public ResponseEntity<String> getAppeal(
             @PathVariable(value = "appealNumber") String appealNumber) {
         return ok(tribunalsService.findAppeal(appealNumber).toString());
+    }
+
+    @ApiOperation(value = "getAppeal",
+            notes = "Returns an appeal given the CCD case id",
+            response = String.class, responseContainer = "Appeal details")
+    @ApiResponses(value = {@ApiResponse(code = 200, message = "Appeal", response = String.class)})
+    @RequestMapping(value = "/appeals", method = GET, produces = APPLICATION_JSON_UTF8_VALUE)
+    public ResponseEntity<String> getAppealByCaseId(
+            @RequestParam(value = "caseId") Long caseId) {
+        return ok(tribunalsService.findAppeal(caseId).toString());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/exception/AppealNotFoundException.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/exception/AppealNotFoundException.java
@@ -11,4 +11,8 @@ public class AppealNotFoundException extends RuntimeException {
         super(String.format("Appeal not found for appeal number: %s ", appealNumber));
     }
 
+    public AppealNotFoundException(Long caseId) {
+        super(String.format("Appeal not found for case id: %s ", caseId));
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controller/TyaControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controller/TyaControllerTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.sscs.service.exceptions.InvalidSurnameException;
 public class TyaControllerTest {
 
     private static final String APPEAL_ID = "appeal-id";
+    private static final Long CASE_ID = 123456789L;
     private static final String SURNAME = "surname";
     private static final String NOT_FOUND_APPEAL_ID = "not-found-appeal-id";
     public static final String CCD_CASE_ID = "ccd-case-id";
@@ -58,6 +59,20 @@ public class TyaControllerTest {
 
         //When
         ResponseEntity<String> receivedAppeal = controller.getAppeal(APPEAL_ID);
+
+        //Then
+        assertThat(receivedAppeal.getStatusCode(), equalTo(HttpStatus.OK));
+        assertThat(receivedAppeal.getBody(), equalTo(node.toString()));
+    }
+
+    @Test
+    public void testToReturnAppealForGivenCaseReference() throws CcdException {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        //Given
+        when(tribunalsService.findAppeal(CASE_ID)).thenReturn(node);
+
+        //When
+        ResponseEntity<String> receivedAppeal = controller.getAppealByCaseId(CASE_ID);
 
         //Then
         assertThat(receivedAppeal.getStatusCode(), equalTo(HttpStatus.OK));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/util/SerializeJsonMessageManager.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/util/SerializeJsonMessageManager.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 public enum SerializeJsonMessageManager {
 
     APPEAL_RECEIVED("tya/appealReceived.json"),
+    APPEAL_RECEIVED_CASE_ID("tya/appealReceived-caseId.json"),
     APPEAL_RECEIVED_CCD("tya/appealReceivedCcd.json"),
     DWP_RESPOND("tya/dwpRespond.json"),
     DWP_RESPOND_CCD("tya/dwpRespondCcd.json"),

--- a/src/test/resources/tya/appealReceived-caseId.json
+++ b/src/test/resources/tya/appealReceived-caseId.json
@@ -1,0 +1,30 @@
+{
+  "appeal": {
+    "caseId": "123456789",
+    "caseReference": null,
+    "status": "APPEAL_RECEIVED",
+    "benefitType": "pip",
+    "hearingType": "oral",
+    "latestEvents": [
+      {
+        "date": "2019-06-06T00:00:00.000Z",
+        "type": "APPEAL_RECEIVED",
+        "contentKey": "status.appealReceived",
+        "dwpResponseDate": "2019-07-11T00:00:00.000Z"
+      }
+    ],
+    "regionalProcessingCenter": {
+      "name": "BIRMINGHAM",
+      "addressLines": [
+        "HM Courts & Tribunals Service",
+        "Social Security & Child Support Appeals",
+        "Administrative Support Centre",
+        "PO Box 14620"
+      ],
+      "city": "BIRMINGHAM",
+      "postcode": "B16 6FR",
+      "phoneNumber": "0300 123 1142",
+      "faxNumber": "0126 434 7983"
+    }
+  }
+}


### PR DESCRIPTION
There used to be one that loaded them by TYA number but we many not have that for MYA.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
