### PR TITLE
fix tests on master

### DIFF
--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitAppealTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitAppealTest.java
@@ -81,8 +81,8 @@ public class SubmitAppealTest {
     @Test
     @Parameters({"ALL_DETAILS, incompleteApplication",
             "ALL_DETAILS, interlocutoryReviewState",
-            "ALL_DETAILS, appealCreated",
-            "ALL_DETAILS_WITH_APPOINTEE_AND_SAME_ADDRESS, appealCreated"})
+            "ALL_DETAILS, validAppeal",
+            "ALL_DETAILS_WITH_APPOINTEE_AND_SAME_ADDRESS, validAppeal"})
     public void appealShouldBeSavedViaSya(SyaJsonMessageSerializer syaJsonMessageSerializer, String expectedState) {
         String body = syaJsonMessageSerializer.getSerializedMessage();
         String nino = getRandomNino();

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -27,7 +27,7 @@ subscriptions.mac.secret=${SUBSCRIPTIONS_MAC_SECRET:our-big-secret}
 
 spring.application.name=TribunalsCaseApi
 
-feature.send_to_dwp=${SEND_TO_DWP_ENABLED:false}
+feature.send_to_dwp=${SEND_TO_DWP_ENABLED:true}
 
 # CCD
 core_case_data.api.url=${CORE_CASE_DATA_API_URL:http://localhost:4452}


### PR DESCRIPTION
The tribunals api in master is broken because when you submit your appeal, the state of the case is dependant of a flag `sendToDwp`. 

When switched on the status is `validAppeal` otherwise it’s `appealCreated`.