### PR TITLE
SSCS-5374 - TYA web page – Reps and Appointee – Links

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/TyaEndpointsIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/tya/TyaEndpointsIt.java
@@ -61,10 +61,10 @@ public class TyaEndpointsIt {
         idamTokens = IdamTokens.builder().build();
         when(idamService.getIdamTokens()).thenReturn(idamTokens);
 
-        when(ccdService.findCaseByAppealNumber("1", idamTokens))
+        when(ccdService.findCaseByAppealNumber("abcde12345", idamTokens))
                 .thenReturn(SscsCaseDetails.builder().id(1L).data(SerializeJsonMessageManager.APPEAL_RECEIVED_CCD.getDeserializeMessage()).build());
 
-        MvcResult mvcResult = mockMvc.perform(get("/appeals/1"))
+        MvcResult mvcResult = mockMvc.perform(get("/appeals/abcde12345"))
             .andExpect(status().isOk())
             .andReturn();
         String result = mvcResult.getResponse().getContentAsString();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/TribunalsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/TribunalsService.java
@@ -50,7 +50,12 @@ public class TribunalsService {
             throw new AppealNotFoundException(appealNumber);
         }
 
-        return trackYourAppealJsonBuilder.build(caseByAppealNumber.getData(), getRegionalProcessingCenter(caseByAppealNumber.getData()), caseByAppealNumber.getId());
+        ObjectNode objectNode = trackYourAppealJsonBuilder.build(caseByAppealNumber.getData(), getRegionalProcessingCenter(caseByAppealNumber.getData()), caseByAppealNumber.getId());
+        ObjectNode appealNode = objectNode.with("appeal");
+        if (appealNode != null) {
+            appealNode.put("appealNumber", appealNumber);
+        }
+        return objectNode;
     }
 
     public ObjectNode findAppeal(Long caseId) {


### PR DESCRIPTION
Currently when navigating to the TYA web page as a representative or appointee, the links on the page result in either 404s or directs you to the TYA for the appellant. This issue seems to be a result of the links being rendered on the page with the appellant’s TYA number added at the end, whereas it should be the relevant TYA number added (representative’s if the rep’s was initially used or appointee’s if the appointee’s was used).

 

The reason for 404s is if there is no appellant subscription and therefore TYA number seen against the case, as is the case for appointee only cases.

 

Steps to reproduce

Find a case that has a representative or appointee subscription
Navigate to the TYA page for that user
Enter in the appropriate surname
Click on any of the links seen once in the TYA page
 

Actual

As a user if I click on any of the links I am either taken to a 404 page or I am taken back to the TYA surname confirming page for the appointee

 

Expected

As a user if I click on any of the links I should be taken to the appropriate page or see the history of the case