### PR TITLE
SSCS-5812 Update interlocSecondaryState field for Interloc events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ dependencies {
 
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.0.0'
 
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.3'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.8'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.6'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-robotics-common', version:  '1.0.4'
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/EventController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/EventController.java
@@ -4,11 +4,14 @@ import static uk.gov.hmcts.reform.sscs.service.AuthorisationService.SERVICE_AUTH
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
+import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.deserialisation.SscsCaseCallbackDeserializer;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
@@ -17,6 +20,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.model.SscsCaseDataWrapper;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.service.EventService;
+import uk.gov.hmcts.reform.sscs.service.InterlocService;
 
 @RestController
 @Slf4j
@@ -25,14 +29,21 @@ public class EventController {
     private final EventService eventService;
     private final AuthorisationService authorisationService;
     private final SscsCaseCallbackDeserializer deserializer;
+    private final InterlocService interlocService;
+    private final SscsCaseDataSerializer sscsCaseDataSerializer;
 
     @Autowired
     public EventController(EventService eventService,
                            AuthorisationService authorisationService,
-                           SscsCaseCallbackDeserializer deserializer) {
+                           SscsCaseCallbackDeserializer deserializer,
+                           InterlocService interlocService,
+                           SscsCaseDataSerializer sscsCaseDataSerializer
+    ) {
         this.eventService = eventService;
         this.authorisationService = authorisationService;
         this.deserializer = deserializer;
+        this.interlocService = interlocService;
+        this.sscsCaseDataSerializer = sscsCaseDataSerializer;
     }
 
     @PostMapping(value = "/send", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
@@ -40,6 +51,33 @@ public class EventController {
             @RequestHeader(SERVICE_AUTHORISATION_HEADER) String serviceAuthHeader,
             @RequestBody String message) {
 
+        SscsCaseDataWrapper sscsCaseDataWrapper = getSscsCaseDataWrapper(serviceAuthHeader, message);
+        eventService.sendEvent(sscsCaseDataWrapper.getNotificationEventType(),
+                sscsCaseDataWrapper.getNewSscsCaseData());
+
+        log.info("Event handled for case {}, {}", sscsCaseDataWrapper.getNewSscsCaseData().getCcdCaseId(),
+                sscsCaseDataWrapper.getNotificationEventType());
+    }
+
+    @PostMapping(value = "/ccdAboutToSubmit", produces = MimeTypeUtils.APPLICATION_JSON_VALUE)
+    public ResponseEntity<CallbackResponse> updateInterlocSecondaryState(
+            @RequestHeader(SERVICE_AUTHORISATION_HEADER) String serviceAuthHeader,
+            @RequestBody String message) {
+
+        SscsCaseDataWrapper sscsCaseDataWrapper = getSscsCaseDataWrapper(serviceAuthHeader, message);
+
+        SscsCaseData sscsCaseData = interlocService.setInterlocSecondaryState(sscsCaseDataWrapper.getNotificationEventType(), sscsCaseDataWrapper.getNewSscsCaseData());
+
+        log.info("Event handled for case {}, {}", sscsCaseDataWrapper.getNewSscsCaseData().getCcdCaseId(),
+                sscsCaseDataWrapper.getNotificationEventType());
+
+        return ResponseEntity.ok(AboutToStartOrSubmitCallbackResponse.builder()
+                .data(sscsCaseDataSerializer.serialize(sscsCaseData))
+                .build()
+        );
+    }
+
+    private SscsCaseDataWrapper getSscsCaseDataWrapper(String serviceAuthHeader, String message) {
         Callback<SscsCaseData> callback = deserializer.deserialize(message);
 
         CaseDetails<SscsCaseData> caseDetailsBefore = callback.getCaseDetailsBefore().orElse(null);
@@ -51,11 +89,7 @@ public class EventController {
                 sscsCaseDataWrapper.getNotificationEventType());
 
         authorisationService.authorise(serviceAuthHeader);
-        eventService.sendEvent(sscsCaseDataWrapper.getNotificationEventType(),
-                sscsCaseDataWrapper.getNewSscsCaseData());
-
-        log.info("Event handled for case {}, {}", sscsCaseDataWrapper.getNewSscsCaseData().getCcdCaseId(),
-                sscsCaseDataWrapper.getNotificationEventType());
+        return sscsCaseDataWrapper;
     }
 
     private SscsCaseDataWrapper buildSscsCaseDataWrapper(SscsCaseData caseData, SscsCaseData caseDataBefore, EventType event) {
@@ -64,5 +98,4 @@ public class EventController {
                 .oldSscsCaseData(caseDataBefore)
                 .notificationEventType(event).build();
     }
-
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/SscsCaseDataSerializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/SscsCaseDataSerializer.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.sscs.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+@Component
+public class SscsCaseDataSerializer {
+    private final ObjectMapper objectMapper;
+
+    public SscsCaseDataSerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public Map<String, Object> serialize(SscsCaseData sscsCaseData) {
+        return objectMapper.convertValue(sscsCaseData, Map.class);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/InterlocService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/InterlocService.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+@Service
+public class InterlocService {
+    private final Map<EventType, String> eventTypeToSecondaryStatus;
+
+    @Autowired
+    public InterlocService() {
+        eventTypeToSecondaryStatus = new HashMap<>();
+        eventTypeToSecondaryStatus.put(EventType.iNTERLOC_SEND_TO_TCW, "reviewByTcw");
+        eventTypeToSecondaryStatus.put(EventType.TCW_DIRECTION_ISSUED, "awaitingInformation");
+        eventTypeToSecondaryStatus.put(EventType.INTERLOC_INFORMATION_RECEIVED, "interlocutoryReview");
+        eventTypeToSecondaryStatus.put(EventType.INTERLOC_SEND_TO_JUDGE, "reviewByJudge");
+        eventTypeToSecondaryStatus.put(EventType.JUDGE_DIRECTION_ISSUED, "awaitingInformation");
+        eventTypeToSecondaryStatus.put(EventType.TCW_REFER_TO_JUDGE, "reviewByJudge");
+        eventTypeToSecondaryStatus.put(EventType.NON_COMPLIANT, "interlocutoryReview");
+        eventTypeToSecondaryStatus.put(EventType.NON_COMPLIANT_SEND_TO_INTERLOC, "interlocutoryReview");
+        eventTypeToSecondaryStatus.put(EventType.REINSTATE_APPEAL, "interlocutoryReview");
+        eventTypeToSecondaryStatus.put(EventType.TCW_DECISION_APPEAL_TO_PROCEED, null);
+        eventTypeToSecondaryStatus.put(EventType.JUDGE_DECISION_APPEAL_TO_PROCEED, null);
+    }
+
+    public SscsCaseData setInterlocSecondaryState(EventType notificationEventType, SscsCaseData newSscsCaseData) {
+        if (eventTypeToSecondaryStatus.containsKey(notificationEventType)) {
+            String interlocSecondaryStatus = eventTypeToSecondaryStatus.get(notificationEventType);
+            newSscsCaseData.setInterlocSecondaryState(interlocSecondaryStatus);
+        }
+
+        return newSscsCaseData;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controller/EventControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controller/EventControllerTest.java
@@ -1,12 +1,17 @@
 package uk.gov.hmcts.reform.sscs.controller;
 
+import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.INTERLOC_INFORMATION_RECEIVED;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,8 +26,10 @@ import uk.gov.hmcts.reform.sscs.ccd.deserialisation.SscsCaseCallbackDeserializer
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.service.EventService;
+import uk.gov.hmcts.reform.sscs.service.InterlocService;
 
 
 @RunWith(SpringRunner.class)
@@ -46,6 +53,12 @@ public class EventControllerTest {
     @MockBean
     private Callback<SscsCaseData> caseDataCallback;
 
+    @MockBean
+    private InterlocService interlocService;
+
+    @MockBean
+    private SscsCaseDataSerializer sscsCaseDataSerializer;
+
     @Test
     public void checkCreatePdfEvent() throws Exception {
 
@@ -65,4 +78,30 @@ public class EventControllerTest {
                 .content(content)).andExpect(status().isOk());
     }
 
+    @Test
+    public void updateInterlocSecondaryState() throws Exception {
+        String path = getClass().getClassLoader().getResource("sya/allDetailsForGeneratePdf.json").getFile();
+        String content = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder().build();
+        when(deserializer.deserialize(content)).thenReturn(new Callback<>(
+                new CaseDetails<>(1234L, "SSCS", State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now()),
+                Optional.empty(),
+                INTERLOC_INFORMATION_RECEIVED));
+
+        SscsCaseData updatedSscsCaseData = SscsCaseData.builder().interlocSecondaryState("new_state").build();
+        when(interlocService.setInterlocSecondaryState(INTERLOC_INFORMATION_RECEIVED, sscsCaseData))
+                .thenReturn(updatedSscsCaseData);
+
+        when(sscsCaseDataSerializer.serialize(updatedSscsCaseData))
+                .thenReturn(singletonMap("interlocSecondaryState", "new_state"));
+
+        mockMvc.perform(post("/ccdAboutToSubmit")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("ServiceAuthorization", "")
+                .content(content))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{'data': {'interlocSecondaryState': 'new_state'}}"))
+        ;
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/InterlocServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/InterlocServiceTest.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+public class InterlocServiceTest {
+
+    @Test
+    public void setsCorrectInterlocSecondaryStatus() {
+        InterlocService interlocService = new InterlocService();
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .build();
+        EventType eventType = EventType.TCW_DIRECTION_ISSUED;
+
+        SscsCaseData caseData = interlocService.setInterlocSecondaryState(eventType, sscsCaseData);
+
+        assertThat(caseData.getInterlocSecondaryState(), is("awaitingInformation"));
+    }
+
+    @Test
+    public void resetsInterlocSecondaryStatus() {
+        InterlocService interlocService = new InterlocService();
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .interlocSecondaryState("someValue")
+                .build();
+        EventType eventType = EventType.JUDGE_DECISION_APPEAL_TO_PROCEED;
+
+        SscsCaseData caseData = interlocService.setInterlocSecondaryState(eventType, sscsCaseData);
+
+        assertThat(caseData.getInterlocSecondaryState(), is(nullValue()));
+    }
+
+    @Test
+    public void doesNotChangeInterlocSecondaryStateIfNoMapping() {
+        InterlocService interlocService = new InterlocService();
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .interlocSecondaryState("someValue")
+                .build();
+        EventType eventType = EventType.CASE_UPDATED;
+
+        SscsCaseData caseData = interlocService.setInterlocSecondaryState(eventType, sscsCaseData);
+
+        assertThat(caseData.getInterlocSecondaryState(), is("someValue"));
+    }
+}


### PR DESCRIPTION
Set the value of the interlocSecondaryState depending on the event
we receive. This will be handled as a CallBackURLAboutToSubmitEvent
from CCD and we return the updated case details to CCD to save the
changes.

https://tools.hmcts.net/jira/browse/SSCS-5812

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
