### PR TITLE
SSCS-5812 Update interlocReviewState Field

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/InterlocServiceHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/InterlocServiceHandler.java
@@ -27,8 +27,8 @@ public class InterlocServiceHandler extends EventToFieldPreSubmitCallbackHandler
         eventTypeToSecondaryStatus.put(EventType.NON_COMPLIANT_SEND_TO_INTERLOC, "interlocutoryReview");
         eventTypeToSecondaryStatus.put(EventType.REINSTATE_APPEAL, "interlocutoryReview");
         eventTypeToSecondaryStatus.put(EventType.UPLOAD_FURTHER_EVIDENCE, "interlocutoryReview");
-        eventTypeToSecondaryStatus.put(EventType.TCW_DECISION_APPEAL_TO_PROCEED, null);
-        eventTypeToSecondaryStatus.put(EventType.JUDGE_DECISION_APPEAL_TO_PROCEED, null);
+        eventTypeToSecondaryStatus.put(EventType.TCW_DECISION_APPEAL_TO_PROCEED, "none");
+        eventTypeToSecondaryStatus.put(EventType.JUDGE_DECISION_APPEAL_TO_PROCEED, "none");
 
         return eventTypeToSecondaryStatus;
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/InterlocServiceHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/InterlocServiceHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -134,12 +133,21 @@ public class InterlocServiceHandlerTest {
     }
 
     @Test
-    public void resetsInterlocReviewStatus() {
+    public void resetsInterlocReviewStatusJudgeDecisionAppealToProceed() {
         when(callback.getEvent()).thenReturn(EventType.JUDGE_DECISION_APPEAL_TO_PROCEED);
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback);
 
-        assertThat(response.getData().getInterlocReviewState(), is(nullValue()));
+        assertThat(response.getData().getInterlocReviewState(), is("none"));
+    }
+
+    @Test
+    public void resetsInterlocReviewStatusTcwDecisionAppealToProceed() {
+        when(callback.getEvent()).thenReturn(EventType.TCW_DECISION_APPEAL_TO_PROCEED);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response.getData().getInterlocReviewState(), is("none"));
     }
 
     @Test
@@ -150,7 +158,6 @@ public class InterlocServiceHandlerTest {
 
         assertThat(response.getData().getInterlocReviewState(), is("interlocutoryReview"));
     }
-
 
     @Test(expected = IllegalStateException.class)
     public void throwExceptionIfCannotHandleEventType() {


### PR DESCRIPTION
rather than setting the interlocReviewState to null set it to "none"
as it doesn't look like the events can handle null.

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-5812

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
