### PR TITLE
SSCS-6181 - Don't create a Document when the scannedDocument.document_type is "Coversheet"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,6 +180,8 @@ def versions = [
         sonarPitest: '0.5',
 ]
 
+ext["rest-assured.version"] = '4.0.0'
+
 ext {
     springCloudVersion = 'Finchley.SR2'
 }
@@ -233,7 +235,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.0.34'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.0.8'
 
-    compile group: 'io.rest-assured', name: 'rest-assured', version: '4.0.0'
+    testCompile group: 'io.rest-assured', name: 'rest-assured'
 
     compile 'org.projectlombok:lombok:1.18.8'
     annotationProcessor 'org.projectlombok:lombok:1.18.6'

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/ActionFurtherEvidenceDropdownHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/ActionFurtherEvidenceDropdownHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.INFORMATION_RECEIVED_FOR_INTERLOC;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.ISSUE_FURTHER_EVIDENCE;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.OTHER_DOCUMENT_MANUAL;
@@ -71,7 +72,7 @@ public class ActionFurtherEvidenceDropdownHandler implements PreSubmitCallbackHa
         listCostOptions.add(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
 
         if (sscsCaseData.getAppeal().getRep() != null
-            && sscsCaseData.getAppeal().getRep().getHasRepresentative().equalsIgnoreCase("yes")) {
+            && equalsIgnoreCase(sscsCaseData.getAppeal().getRep().getHasRepresentative(), "yes")) {
             listCostOptions.add(new DynamicListItem(REPRESENTATIVE.getCode(), REPRESENTATIVE.getLabel()));
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.DocumentType.APPELLANT_EVIDENCE;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.DocumentType.OTHER_DOCUMENT;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.DocumentType.REPRESENTATIVE_EVIDENCE;
@@ -13,6 +14,8 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
@@ -28,7 +31,10 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 
 @Component
+@Slf4j
 public class HandleEvidenceEventHandler implements PreSubmitCallbackHandler<SscsCaseData> {
+
+    private static final String COVERSHEET = "coversheet";
 
     public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {
         requireNonNull(callback, "callback must not be null");
@@ -65,7 +71,8 @@ public class HandleEvidenceEventHandler implements PreSubmitCallbackHandler<Sscs
 
         if (sscsCaseData.getScannedDocuments() != null) {
             for (ScannedDocument scannedDocument : sscsCaseData.getScannedDocuments()) {
-                if (scannedDocument != null && scannedDocument.getValue() != null) {
+                if (scannedDocument != null && scannedDocument.getValue() != null
+                        && !equalsIgnoreCase(scannedDocument.getValue().getType(), COVERSHEET)) {
                     List<SscsDocument> documents = new ArrayList<>();
                     if (sscsCaseData.getSscsDocument() != null) {
                         documents = sscsCaseData.getSscsDocument();
@@ -75,6 +82,8 @@ public class HandleEvidenceEventHandler implements PreSubmitCallbackHandler<Sscs
                     sscsCaseData.setSscsDocument(documents);
                     sscsCaseData.setEvidenceHandled(workOutEvidenceHandled(sscsCaseData.getEvidenceHandled(),
                         sscsDocument.getValue().getDocumentType()));
+                } else {
+                    log.info("Not adding any scanned document as there aren't any or the type is a coversheet for case Id {}.", sscsCaseData.getCcdCaseId());
                 }
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandlerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,7 @@ public class HandleEvidenceEventHandlerTest {
         DynamicList originalSender = new DynamicList(value, Collections.singletonList(value));
 
         sscsCaseData = SscsCaseData.builder()
+            .ccdCaseId("1234")
             .scannedDocuments(scannedDocumentList)
             .furtherEvidenceAction(furtherEvidenceActionList)
             .originalSender(originalSender)
@@ -123,6 +125,31 @@ public class HandleEvidenceEventHandlerTest {
         if (null != furtherEvidenceActionList && null != originalSender) {
             assertHappyPaths(expectedDocumentType, expectedEvidenceHandled, response);
         }
+    }
+
+    @Test
+    public void givenACaseWithScannedDocumentOfTypeCoversheet_shouldNotMoveToSscsDocuments() {
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+                ScannedDocumentDetails.builder()
+                        .type("coversheet")
+                        .fileName("bla.pdf")
+                        .subtype("sscs1")
+                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                        .scannedDate("2019-06-12T00:00:00.000")
+                        .controlNumber("123")
+                        .build()).build();
+        scannedDocumentList = new ArrayList<>();
+        scannedDocumentList.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(scannedDocumentList);
+        sscsCaseData.setFurtherEvidenceAction(buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
+                "Other document type - action manually"));
+        sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
+                "Appellant (or Appointee)"));
+        sscsCaseData.setEvidenceHandled("No");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback);
+
+        assertTrue(CollectionUtils.isEmpty(response.getData().getSscsDocument()));
     }
 
     private void assertHappyPaths(String expectedDocumentType, String expectedEvidenceHandled,

--- a/src/test/resources/callback/actionFurtherEvidenceCallback.json
+++ b/src/test/resources/callback/actionFurtherEvidenceCallback.json
@@ -77,7 +77,7 @@
             "controlNumber": "3",
             "scannedDate": "2010-10-25T00:00:00.000",
             "fileName": "scanned.pdf",
-            "type": "appellantEvidence"
+            "type": "DOCUMENT_TYPE"
           }
         }
       ],


### PR DESCRIPTION
When running "Action Further Evidence" event, don't create a Document when the scannedDocument.document_type is "Coversheet".

JIRA: https://tools.hmcts.net/jira/browse/SSCS-6181