### PR TITLE
SSCS-6181 - Set Evidence Handled to "Yes" when there are no errors.

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/CcdCallbackEndpointIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/CcdCallbackEndpointIt.java
@@ -172,6 +172,26 @@ public class CcdCallbackEndpointIt {
     }
 
     @Test
+    public void coversheetFurtherEvidence_shouldNotAddToDocuments() throws Exception {
+        String path = getClass().getClassLoader().getResource("callback/actionFurtherEvidenceWithInterlocOptionCallback.json").getFile();
+        json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+        json = json.replaceFirst("informationReceivedForInterloc", "otherDocumentManual");
+        json = json.replaceFirst("Information received for interlocutory review", "Other document type - action manually");
+        json = json.replaceFirst("appellantEvidence", "coversheet");
+
+        HttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
+
+        assertHttpStatus(response, HttpStatus.OK);
+
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(((MockHttpServletResponse) response).getContentAsString());
+
+        assertNull(result.getData().getInterlocReviewState());
+        assertNull(result.getData().getScannedDocuments());
+        assertNull(result.getData().getSscsDocument());
+        assertEquals("Yes", result.getData().getEvidenceHandled());
+    }
+
+    @Test
     public void shouldHandleInterlocEventEventCallback() throws Exception {
         String path = getClass().getClassLoader().getResource("callback/interlocEventCallback.json").getFile();
         json = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandler.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
@@ -70,17 +69,17 @@ public class HandleEvidenceEventHandler implements PreSubmitCallbackHandler<Sscs
 
         if (sscsCaseData.getScannedDocuments() != null) {
             for (ScannedDocument scannedDocument : sscsCaseData.getScannedDocuments()) {
-                if (scannedDocument != null && scannedDocument.getValue() != null
-                        && !equalsIgnoreCase(scannedDocument.getValue().getType(), COVERSHEET)) {
+                if (scannedDocument != null && scannedDocument.getValue() != null) {
                     List<SscsDocument> documents = new ArrayList<>();
                     if (sscsCaseData.getSscsDocument() != null) {
                         documents = sscsCaseData.getSscsDocument();
                     }
-                    SscsDocument sscsDocument = buildSscsDocument(sscsCaseData, scannedDocument);
-                    documents.add(sscsDocument);
-                    sscsCaseData.setSscsDocument(documents);
-                    sscsCaseData.setEvidenceHandled(workOutEvidenceHandled(sscsCaseData.getEvidenceHandled(),
-                        sscsDocument.getValue().getDocumentType()));
+                    if (!equalsIgnoreCase(scannedDocument.getValue().getType(), COVERSHEET)) {
+                        SscsDocument sscsDocument = buildSscsDocument(sscsCaseData, scannedDocument);
+                        documents.add(sscsDocument);
+                        sscsCaseData.setSscsDocument(documents);
+                    }
+                    sscsCaseData.setEvidenceHandled("Yes");
                 } else {
                     log.info("Not adding any scanned document as there aren't any or the type is a coversheet for case Id {}.", sscsCaseData.getCcdCaseId());
                 }
@@ -88,15 +87,6 @@ public class HandleEvidenceEventHandler implements PreSubmitCallbackHandler<Sscs
         }
         sscsCaseData.setScannedDocuments(null);
 
-    }
-
-    private String workOutEvidenceHandled(String evidenceHandled, String documentType) {
-        if ((StringUtils.isBlank(evidenceHandled) || "No".equalsIgnoreCase(evidenceHandled))
-            && (documentType.equals(APPELLANT_EVIDENCE.getValue())
-            || documentType.equals(REPRESENTATIVE_EVIDENCE.getValue()))) {
-            return "Yes";
-        }
-        return evidenceHandled;
     }
 
     private SscsDocument buildSscsDocument(SscsCaseData sscsCaseData, ScannedDocument scannedDocument) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionfurtherevidence/HandleEvidenceEventHandlerTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.actionfurtherevidence.DocumentType.APPELLANT_EVIDENCE;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -109,8 +110,7 @@ public class HandleEvidenceEventHandlerTest {
     public void givenACaseWithScannedDocuments_shouldMoveToSscsDocuments(@Nullable DynamicList furtherEvidenceActionList,
                                                                          @Nullable DynamicList originalSender,
                                                                          @Nullable String evidenceHandle,
-                                                                         String expectedDocumentType,
-                                                                         @Nullable String expectedEvidenceHandled) {
+                                                                         String expectedDocumentType) {
         sscsCaseData.setFurtherEvidenceAction(furtherEvidenceActionList);
         sscsCaseData.setOriginalSender(originalSender);
         sscsCaseData.setEvidenceHandled(evidenceHandle);
@@ -122,7 +122,7 @@ public class HandleEvidenceEventHandlerTest {
             assertTrue(furtherEvidenceActionList == null || originalSender == null);
         }
         if (null != furtherEvidenceActionList && null != originalSender) {
-            assertHappyPaths(expectedDocumentType, expectedEvidenceHandled, response);
+            assertHappyPaths(expectedDocumentType, response);
         }
     }
 
@@ -140,8 +140,8 @@ public class HandleEvidenceEventHandlerTest {
         scannedDocumentList = new ArrayList<>();
         scannedDocumentList.add(scannedDocument);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
-        sscsCaseData.setFurtherEvidenceAction(buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
-                "Other document type - action manually"));
+        sscsCaseData.setFurtherEvidenceAction(buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
+                "\"Appellant (or Appointee)"));
         sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
                 "Appellant (or Appointee)"));
         sscsCaseData.setEvidenceHandled("No");
@@ -149,9 +149,10 @@ public class HandleEvidenceEventHandlerTest {
         PreSubmitCallbackResponse<SscsCaseData> response = handleEvidenceEventHandler.handle(ABOUT_TO_SUBMIT, callback);
 
         assertTrue(CollectionUtils.isEmpty(response.getData().getSscsDocument()));
+        assertEquals("Yes", response.getData().getEvidenceHandled());
     }
 
-    private void assertHappyPaths(String expectedDocumentType, String expectedEvidenceHandled,
+    private void assertHappyPaths(String expectedDocumentType,
                                   PreSubmitCallbackResponse<SscsCaseData> response) {
         SscsDocumentDetails sscsDocumentDetail = response.getData().getSscsDocument().get(0).getValue();
         assertEquals("bla.pdf", sscsDocumentDetail.getDocumentFileName());
@@ -161,7 +162,7 @@ public class HandleEvidenceEventHandlerTest {
         assertEquals("123", sscsDocumentDetail.getControlNumber());
         assertEquals("No", response.getData().getSscsDocument().get(0).getValue().getEvidenceIssued());
         assertNull(response.getData().getScannedDocuments());
-        assertEquals(expectedEvidenceHandled, response.getData().getEvidenceHandled());
+        assertEquals("Yes", response.getData().getEvidenceHandled());
     }
 
     private Object[] generateFurtherEvidenceActionListScenarios() {
@@ -184,29 +185,29 @@ public class HandleEvidenceEventHandlerTest {
 
         return new Object[]{
             //other options scenarios
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, null, "Other document", null},
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "No", "Other document", "No"},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "No", "Other document", "No"},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, null, "Other document", null},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "Yes", "Other document", "Yes"},
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "Yes", "Other document", "Yes"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, null, "Other document"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "No", "Other document"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "No", "Other document"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, null, "Other document"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "Yes", "Other document"},
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "Yes", "Other document"},
             //issue parties scenarios
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, null, "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "No", "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "Yes", "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "No", "representativeEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "Yes", "representativeEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, null, "representativeEvidence", "Yes"},
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, null, "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "No", "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "Yes", "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "No", "representativeEvidence"},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "Yes", "representativeEvidence"},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, null, "representativeEvidence"},
             //interloc scenarios
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, null, "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "No", "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "Yes", "appellantEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, null, "representativeEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", "representativeEvidence", "Yes"},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", "representativeEvidence", "Yes"},
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, null, "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "No", "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "Yes", "appellantEvidence"},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, null, "representativeEvidence"},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", "representativeEvidence"},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", "representativeEvidence"},
             //edge cases scenarios
-            new Object[]{null, representativeOriginalSender, "", "", null}, //edge case: furtherEvidenceActionOption is null
-            new Object[]{furtherEvidenceActionListIssueParties, null, null, "", null} //edge case: originalSender is null
+            new Object[]{null, representativeOriginalSender, "", ""}, //edge case: furtherEvidenceActionOption is null
+            new Object[]{furtherEvidenceActionListIssueParties, null, null, ""} //edge case: originalSender is null
         };
     }
 


### PR DESCRIPTION
When running "Action Further Evidence" event, don't create a Document when the scannedDocument.document_type is "Coversheet".

The evidenceHandled should be set to “Yes if there are no errors.

if we remove the Scanned Documents, this must be set to "Yes", otherwise the case is in an incomplete state
If Scanned Document on case, evidenceHandled = "No"
if Scanned Documents were on case, but we remove them , then evidenceHandled = "Yes"
