### PR TITLE
SSCS-6104 Validate interloc document

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ValidateInterlocDecisionDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ValidateInterlocDecisionDocumentHandler.java
@@ -36,7 +36,10 @@ public class ValidateInterlocDecisionDocumentHandler implements PreSubmitCallbac
         PreSubmitCallbackResponse<SscsCaseData> sscsCaseDataPreSubmitCallbackResponse = new PreSubmitCallbackResponse<>(caseData);
 
         log.info("Checking for case [" + caseData.getCcdCaseId() + "] we have [" + caseData.getSscsInterlocDecisionDocument() + "]");
-        if (caseData.getSscsInterlocDecisionDocument() == null || caseData.getSscsInterlocDecisionDocument().getDocumentDateAdded() == null) {
+        if (
+                caseData.getSscsInterlocDecisionDocument() == null
+                        || caseData.getSscsInterlocDecisionDocument().getDocumentLink() == null
+        ) {
             sscsCaseDataPreSubmitCallbackResponse.addError("Interloc decision document must be set");
         } else if (!isPdf(caseData.getSscsInterlocDecisionDocument())) {
             sscsCaseDataPreSubmitCallbackResponse.addError("Interloc decision document must be a PDF");

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ValidateInterlocDecisionDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ValidateInterlocDecisionDocumentHandlerTest.java
@@ -113,6 +113,30 @@ public class ValidateInterlocDecisionDocumentHandlerTest {
     }
 
     @Test
+    public void errorWhenHandlingCallbackAndInterlocDecisionDocumentLinkHasNotBeenSet() {
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+                .sscsInterlocDecisionDocument(SscsInterlocDecisionDocument.builder()
+                        .documentDateAdded("some date")
+                        .documentFileName("File")
+                        .documentType("Decision Notice")
+                        .build())
+                .build();
+        CaseDetails<SscsCaseData> caseDetails = new CaseDetails<>(
+                1L,
+                "sscs",
+                State.INTERLOCUTORY_REVIEW_STATE,
+                sscsCaseData,
+                LocalDateTime.now()
+        );
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        PreSubmitCallbackResponse<SscsCaseData> response =
+                validateInterlocDecisionDocumentHandler.handle(CallbackType.ABOUT_TO_SUBMIT, callback);
+
+        assertThat(response.getData(), is(sscsCaseData));
+        assertThat(response.getErrors(), is(Sets.newHashSet("Interloc decision document must be set")));
+    }
+
+    @Test
     public void errorWhenHandlingCallbackAndInterlocDecisionDocumentIsNotPdf() {
         SscsCaseData sscsCaseData = SscsCaseData.builder()
                 .sscsInterlocDecisionDocument(SscsInterlocDecisionDocument.builder()


### PR DESCRIPTION
When CCD calls the aboutToSubmit endpoint to validate interloc decision
documents it set the file name, date added and file type but not the
link. Therefore have to check the for absence of the link to determine
an interloc decision document has not beens et.

### JIRA link (if applicable) ###

https://github.com/hmcts/sscs-cor-frontend/pull/367

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
