### PR TITLE
Add email_to / email_from + simplification

### DIFF
--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,6 +1,6 @@
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.4
+version: 0.0.5
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team

--- a/charts/sscs-tribunals-api/requirements.yaml
+++ b/charts/sscs-tribunals-api/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.2.2
+    version: ~2.6.0
     repository: '@hmctspublic'

--- a/charts/sscs-tribunals-api/values.aat.template.yaml
+++ b/charts/sscs-tribunals-api/values.aat.template.yaml
@@ -1,10 +1,3 @@
 java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
-  aadIdentityName: sscs
-  environment:
-    PDF_API_URL: "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
-    CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
-    IDAM_OAUTH2_REDIRECT_URL: "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
-    DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
-

--- a/charts/sscs-tribunals-api/values.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.preview.template.yaml
@@ -1,8 +1,10 @@
 java:
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_FQDN}
+  aadIdentityName:
   environment:
     PDF_API_URL: "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
     CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
-    IDAM_OAUTH2_REDIRECT_URL: "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
     DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
+    IDAM_S2S_AUTH: "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
+    IDAM_URL: https://idam-api.aat.platform.hmcts.net

--- a/charts/sscs-tribunals-api/values.yaml
+++ b/charts/sscs-tribunals-api/values.yaml
@@ -1,11 +1,11 @@
 java:
   image: 'https://hmctspublic.azurecr.io/sscs/tribunals-api:latest'
   applicationPort: 8080
+  aadIdentityName: sscs
   keyVaults:
     sscs:
       resourceGroup: sscs
       secrets:
-        - idam-api
         - sscs-email-mac-secret-text
         - idam-oauth-user
         - ccd-api
@@ -15,9 +15,10 @@ java:
         - idam-sscs-systemupdate-user
         - idam-sscs-systemupdate-password
         - idam-sscs-oauth2-client-secret
-        - idam-s2s-api
         - sscs-s2s-secret
         - s2s-micro
+        - appeal-email-to
+        - appeal-email-from
   environment:
     SERVER_PORT: 8080
     REFORM_TEAM: sscs
@@ -26,8 +27,6 @@ java:
     REFORM_ENVIRONMENT: preview
     ROOT_LOGGING_LEVEL: INFO
     LOG_OUTPUT: single
-    EMAIL_FROM: "sscs@hmcts.net"
-    EMAIL_TO: "sscstest+notify@greencroftconsulting.com"
     EMAIL_SUBJECT: "Your appeal"
     EMAIL_MESSAGE: "Your appeal has been created. Please do not respond to this email"
     EMAIL_SERVER_HOST: "mta.reform.hmcts.net"
@@ -36,7 +35,10 @@ java:
     EMAIL_SMTP_SSL_TRUST: "*"
     MAX_FILE_SIZE: "10MB"
     MAX_REQUEST_SIZE: "10MB"
-    PDF_API_URL: "http://cmc-pdf-service-aat.service.core-compute-aat.internal"
-    DOCUMENT_MANAGEMENT_URL: "http://dm-store-aat.service.core-compute-aat.internal"
-    CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     IDAM_OAUTH2_REDIRECT_URL: "https://evidence-sharing-preprod.sscs.reform.hmcts.net"
+    PDF_API_URL: "http://cmc-pdf-service-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    DOCUMENT_MANAGEMENT_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IDAM_S2S_AUTH: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    IDAM_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
+    

--- a/charts/sscs-tribunals-api/values.yaml
+++ b/charts/sscs-tribunals-api/values.yaml
@@ -2,6 +2,7 @@ java:
   image: 'https://hmctspublic.azurecr.io/sscs/tribunals-api:latest'
   applicationPort: 8080
   aadIdentityName: sscs
+  ingressHost: sscs-tribunals-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal
   keyVaults:
     sscs:
       resourceGroup: sscs

--- a/src/main/resources/config/bootstrap.yaml
+++ b/src/main/resources/config/bootstrap.yaml
@@ -4,19 +4,18 @@ spring:
       paths: /mnt/secrets/sscs
       prefixed: false
       aliases:
-        idam-api: IDAM_API_URL
         sscs-email-mac-secret-text: SUBSCRIPTIONS_MAC_SECRET
         idam-oauth-user: IDAM_OAUTH2_CLIENT_ID
-        ccd-api: CORE_CASE_DATA_API_URL
         ccd-jid: CORE_CASE_DATA_JURISDICTION_ID
         ccd-tid: CORE_CASE_DATA_CASE_TYPE_ID
         idam-redirect: IDAM_OAUTH2_REDIRECT_URL
         idam-sscs-systemupdate-user: IDAM_SSCS_SYSTEMUPDATE_USER
         idam-sscs-systemupdate-password: IDAM_SSCS_SYSTEMUPDATE_PASSWORD
         idam-sscs-oauth2-client-secret: IDAM_OAUTH2_CLIENT_SECRET
-        idam-s2s-api: IDAM_S2S_AUTH
         sscs-s2s-secret: IDAM_S2S_AUTH_TOTP_SECRET
         s2s-micro: IDAM_S2S_AUTH_MICROSERVICE
         robotics-email-to: ROBOTICS_EMAIL_TO
         robotics-email-from: ROBOTICS_EMAIL_FROM
         robotics-email-scottish-to: ROBOTICS_EMAIL_SCOTTISH_TO
+        appeal-email-to: EMAIL_TO
+        appeal-email-from: EMAIL_FROM


### PR DESCRIPTION
### JIRA link (if applicable) ###
CHG0034613


### Change description ###
Email to / email from configuration was missing in production causing defaults to be taken, this sets it up so that it's correctly pulled from vault.

I've updated chart-java to allow for templating of env variables, to reduce a lot of duplication

and moved non secret values to env vars to make debugging easier


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
