### PR TITLE
SSCS-6381 - Ready To List Event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/readytolist/ReadyToListAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/readytolist/ReadyToListAboutToSubmitHandler.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.reform.sscs.ccd.presubmit.readytolist;
+
+import static java.util.Objects.requireNonNull;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
+
+@Service
+@Slf4j
+public class ReadyToListAboutToSubmitHandler implements PreSubmitCallbackHandler<SscsCaseData> {
+
+    @Override
+    public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {
+        requireNonNull(callback, "callback must not be null");
+        requireNonNull(callbackType, "callbacktype must not be null");
+
+        return callbackType.equals(CallbackType.ABOUT_TO_SUBMIT)
+                && callback.getEvent() == EventType.READY_TO_LIST;
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<SscsCaseData> handle(CallbackType callbackType, Callback<SscsCaseData> callback,
+                                                          String userAuthorisation) {
+        if (!canHandle(callbackType, callback)) {
+            throw new IllegalStateException("Cannot handle callback.");
+        }
+        final CaseDetails<SscsCaseData> caseDetails = callback.getCaseDetails();
+        final SscsCaseData sscsCaseData = caseDetails.getCaseData();
+
+        PreSubmitCallbackResponse<SscsCaseData> callbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
+
+        log.info(String.format("createdInGapsFrom is %s for caseId %s",
+                sscsCaseData.getCreatedInGapsFrom(), sscsCaseData.getCcdCaseId()));
+
+        if (sscsCaseData.getCreatedInGapsFrom() == null
+                || StringUtils.equalsIgnoreCase(sscsCaseData.getCreatedInGapsFrom(), State.VALID_APPEAL.getId())) {
+            callbackResponse.addError("Case already created in GAPS at valid appeal.");
+        }
+        return callbackResponse;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/readytolist/ReadyToListAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/readytolist/ReadyToListAboutToSubmitHandlerTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.sscs.ccd.presubmit.readytolist;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class ReadyToListAboutToSubmitHandlerTest {
+    private static final String USER_AUTHORISATION = "Bearer token";
+
+    private ReadyToListAboutToSubmitHandler handler;
+
+    @Mock
+    private Callback<SscsCaseData> callback;
+
+    @Mock
+    private CaseDetails<SscsCaseData> caseDetails;
+
+    private SscsCaseData sscsCaseData;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        handler = new ReadyToListAboutToSubmitHandler();
+
+        when(callback.getEvent()).thenReturn(EventType.READY_TO_LIST);
+
+        sscsCaseData = SscsCaseData.builder()
+                .ccdCaseId("1234")
+                .createdInGapsFrom(State.READY_TO_LIST.getId())
+                .appeal(Appeal.builder().build())
+                .build();
+
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+    }
+
+    @Test
+    @Parameters({"APPEAL_RECEIVED", "ACTION_FURTHER_EVIDENCE"})
+    public void givenANonHandleEvidenceEvent_thenReturnFalse(EventType eventType) {
+        when(callback.getEvent()).thenReturn(eventType);
+        assertFalse(handler.canHandle(ABOUT_TO_SUBMIT, callback));
+    }
+
+    @Test
+    @Parameters({"ABOUT_TO_START", "MID_EVENT", "SUBMITTED"})
+    public void givenANonCallbackType_thenReturnFalse(CallbackType callbackType) {
+        assertFalse(handler.canHandle(callbackType, callback));
+    }
+
+
+    @Test
+    public void returnAnErrorIfCreatedInGapsFromIsAtValidAppeal() {
+        sscsCaseData = sscsCaseData.toBuilder().createdInGapsFrom(State.VALID_APPEAL.getId()).build();
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("Case already created in GAPS at valid appeal.", response.getErrors().toArray()[0]);
+    }
+
+    @Test
+    public void returnAnErrorIfCreatedInGapsFromIsNull() {
+        sscsCaseData = sscsCaseData.toBuilder().createdInGapsFrom(null).build();
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("Case already created in GAPS at valid appeal.", response.getErrors().toArray()[0]);
+    }
+
+    @Test
+    public void respondWithNoErrorsIfCreatedFromGapsIsAtReadyToList() {
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throwsExceptionIfItCannotHandleTheAppeal() {
+        when(callback.getEvent()).thenReturn(EventType.APPEAL_RECEIVED);
+        handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+    }
+}


### PR DESCRIPTION
Given a user runs the event "Ready to List"
When the event has completed
And the field "Created in GAPS from" is set to "Valid Appeal"
Then an error message will be displayed saying "Case already created in GAPS at Valid Appeal"
Then an email will NOT be sent to the GAPS Robot with a JSON file attached