### PR TITLE
suppress vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'org.sonarqube' version '2.7.1'
     id 'jacoco'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
-    id 'org.owasp.dependencycheck' version '5.1.1'
+    id 'org.owasp.dependencycheck' version '5.2.2'
     id 'com.github.ben-manes.versions' version '0.25.0'
     id 'net.ltgt.apt' version '0.21'
     id "info.solidsoft.pitest" version '1.4.0'
@@ -236,10 +236,7 @@ dependencies {
     compile group: 'org.springframework.retry', name: 'spring-retry', version: '1.2.4.RELEASE'
 
     // Safe to remove once Spring update their dependencies - see CVE-2019-14439 and add 'com.fasterxml.jackson.core' configurations.all above
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.9.3'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
-    compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10'
 
     compile group: 'net.objectlab.kit', name: 'datecalc-jdk8', version: '1.4.2'
 

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
-    <suppress>
-        <notes><![CDATA[
-   file name: jackson-databind-2.9.3.jar
-   ]]></notes>
-        <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-        <cpe>cpe:/a:fasterxml:jackson-databind</cpe>
-        <cve>CVE-2019-12814</cve>
-    </suppress>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
    file name: groovy-xml-2.4.15.jar
@@ -102,5 +94,14 @@
         <sha1>c041edaa88886863aa784de15170a08a2b9f17ba</sha1>
         <cve>CVE-2015-9251</cve>
         <cve>CVE-2019-11358</cve>
+    </suppress>
+    <suppress until="2019-10-31">
+        <notes><![CDATA[
+   file name: jackson-databind-2.9.10.jar
+   No fix available
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
+        <cve>CVE-2019-16942</cve>
+        <cve>CVE-2019-16943</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
CVE-2019-16942, CVE-2019-16943 cannot be fixed as yet as we cannot upgrade jackson-databind further.