### PR TITLE
SSCS-7498 Ensuring date validation fails for start and end date the same

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
@@ -34,7 +34,7 @@ public class WriteFinalDecisionMidEventHandler implements PreSubmitCallbackHandl
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 
         if (isDecisionNoticeDatesInvalid(sscsCaseData)) {
-            preSubmitCallbackResponse.addError("Decision notice start date cannot be after decision notice end date");
+            preSubmitCallbackResponse.addError("Decision notice end date must be after decision notice start date");
         }
         return preSubmitCallbackResponse;
     }
@@ -43,7 +43,7 @@ public class WriteFinalDecisionMidEventHandler implements PreSubmitCallbackHandl
         if (sscsCaseData.getPipWriteFinalDecisionStartDate() != null && sscsCaseData.getPipWriteFinalDecisionEndDate() != null) {
             LocalDate decisionNoticeStartDate = LocalDate.parse(sscsCaseData.getPipWriteFinalDecisionStartDate());
             LocalDate decisionNoticeEndDate = LocalDate.parse(sscsCaseData.getPipWriteFinalDecisionEndDate());
-            return decisionNoticeStartDate.isAfter(decisionNoticeEndDate);
+            return !decisionNoticeStartDate.isBefore(decisionNoticeEndDate);
         }
         return false;
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
@@ -69,7 +69,20 @@ public class WriteFinalDecisionMidEventHandlerTest {
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
-        assertEquals("Decision notice start date cannot be after decision notice end date", error);
+        assertEquals("Decision notice end date must be after decision notice start date", error);
+    }
+
+    @Test
+    public void givenAnEndDateIsSameAsStartDate_thenDisplayAnError() {
+        sscsCaseData.setPipWriteFinalDecisionStartDate("2020-01-01");
+        sscsCaseData.setPipWriteFinalDecisionEndDate("2020-01-01");
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Decision notice end date must be after decision notice start date", error);
     }
 
     @Test


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7498

### Change description ###

* Ensuring date validation fails for start and end date the same
* Changing syntax of error message to make the date requirement more specific

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
