### PR TITLE
SSCS-7560 - docmosis error fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'doc-assembly-client', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.2.29'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.1'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.2-RC-SSCS-7560'
 
     testCompile group: 'io.rest-assured', name: 'rest-assured'
 


### PR DESCRIPTION
Fix for when docmosis errors and cannot convert files.
Associated PR https://github.com/hmcts/sscs-pdf-email-common/pull/267