### PR TITLE
SSCS-7554 Decision Notice Section 1

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
@@ -21,6 +21,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.docassembly.GenerateFile;
@@ -47,6 +48,9 @@ public class FinalDecisionIssuedForPreviewIt extends AbstractEventIt {
     @MockBean
     private GenerateFile generateFile;
 
+    @MockBean
+    private UserDetails userDetails;
+
     @Before
     public void setup() throws IOException {
         setup("callback/finalDecisionIssuedForPreview.json");
@@ -56,6 +60,10 @@ public class FinalDecisionIssuedForPreviewIt extends AbstractEventIt {
     public void callToMidEventHandler_willPreviewTheDocument() throws Exception {
         String documentUrl = "document.url";
         when(generateFile.assemble(any())).thenReturn(documentUrl);
+
+        when(userDetails.getFullName()).thenReturn("Judge Full Name");
+
+        when(idamClient.getUserDetails("Bearer userToken")).thenReturn(userDetails);
 
         MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdMidEvent"));
         assertHttpStatus(response, HttpStatus.OK);
@@ -73,6 +81,6 @@ public class FinalDecisionIssuedForPreviewIt extends AbstractEventIt {
         assertEquals("JT 12 34 56 D", payload.getNino());
         assertEquals(LocalDate.parse("2017-07-17"), payload.getHeldOn());
         assertEquals("Chester Magistrate's Court", payload.getHeldAt());
-        assertEquals("Judge Name Placeholder, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
+        assertEquals("Judge Full Name, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
     }
 }

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
@@ -84,6 +84,8 @@ public class FinalDecisionIssuedForPreviewIt extends AbstractEventIt {
         assertEquals("Judge Full Name, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
         assertEquals(true, payload.isAllowed());
         assertEquals(true, payload.isSetAside());
+        assertEquals("2018-09-01", payload.getDateOfDecision());
+
 
 
     }

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/FinalDecisionIssuedForPreviewIt.java
@@ -82,5 +82,9 @@ public class FinalDecisionIssuedForPreviewIt extends AbstractEventIt {
         assertEquals(LocalDate.parse("2017-07-17"), payload.getHeldOn());
         assertEquals("Chester Magistrate's Court", payload.getHeldAt());
         assertEquals("Judge Full Name, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
+        assertEquals(true, payload.isAllowed());
+        assertEquals(true, payload.isSetAside());
+
+
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
@@ -155,12 +156,20 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
 
 
     private String buildSignedInJudgeName(String userAuthorisation) {
-        return idamClient.getUserDetails(userAuthorisation).getFullName();
+        UserDetails userDetails = idamClient.getUserDetails(userAuthorisation);
+        if (userDetails == null) {
+            throw new IllegalStateException("Unable to obtain signed in user details");
+        }
+        return userDetails.getFullName();
     }
 
     private String buildHeldBefore(SscsCaseData caseData, String userAuthorisation) {
         List<String> names = new ArrayList<>();
-        names.add(buildSignedInJudgeName(userAuthorisation));
+        String signedInJudgeName = buildSignedInJudgeName(userAuthorisation);
+        if (signedInJudgeName == null) {
+            throw new IllegalStateException("Unable to obtain signed in user name");
+        }
+        names.add(signedInJudgeName);
         if (caseData.getWriteFinalDecisionDisabilityQualifiedPanelMemberName() != null) {
             names.add(caseData.getWriteFinalDecisionDisabilityQualifiedPanelMemberName());
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandler.java
@@ -124,17 +124,22 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
         Outcome outcome = decisionNoticeOutcomeService.determineOutcome(caseData);
         if (outcome == null) {
             throw new IllegalStateException("Outcome cannot be empty. Please check case data. If problem continues please contact support");
-        } else if (Outcome.DECISION_IN_FAVOUR_OF_APPELLANT.equals(outcome)) {
-            builder.isAllowed(true);
-            builder.isSetAside(true);
         } else {
-            builder.isAllowed(false);
-            builder.isSetAside(false);
+            builder.isAllowed(Outcome.DECISION_IN_FAVOUR_OF_APPELLANT.equals(outcome));
+            builder.isSetAside(Outcome.DECISION_IN_FAVOUR_OF_APPELLANT.equals(outcome));
         }
 
-        builder.dateOfDecision(caseData.getWriteFinalDecisionDateOfDecision());
+        if (caseData.getWriteFinalDecisionDateOfDecision() != null) {
+            builder.dateOfDecision(caseData.getWriteFinalDecisionDateOfDecision());
+        }
 
         DirectionOrDecisionIssuedTemplateBody payload = builder.build();
+        validateRequiredProperties(payload);
+        return payload;
+    }
+
+
+    private void validateRequiredProperties(DirectionOrDecisionIssuedTemplateBody payload) {
         if (payload.getHeldAt() == null && payload.getHeldOn() == null) {
             throw new IllegalStateException("Unable to determine hearing date or venue");
         } else if (payload.getHeldOn() == null) {
@@ -145,8 +150,6 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
         if (payload.getDateOfDecision() == null) {
             throw new IllegalStateException("Unable to determine date of decision");
         }
-
-        return payload;
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/domain/wrapper/ComparedRate.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/domain/wrapper/ComparedRate.java
@@ -1,7 +1,26 @@
 package uk.gov.hmcts.reform.sscs.domain.wrapper;
 
 public enum ComparedRate {
-    Higher,
-    Lower,
-    Same
+    Higher("higher"),
+    Lower("lower"),
+    Same("same");
+
+    String key;
+
+    ComparedRate(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public static ComparedRate getByKey(String key) {
+        for (ComparedRate comparedRate : ComparedRate.values()) {
+            if (comparedRate.key.equals(key)) {
+                return comparedRate;
+            }
+        }
+        throw new IllegalArgumentException("Unknown ComparedRate for key:" + key);
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DirectionOrDecisionIssuedTemplateBody.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DirectionOrDecisionIssuedTemplateBody.java
@@ -50,6 +50,9 @@ public class DirectionOrDecisionIssuedTemplateBody implements FormPayload {
     @JsonSerialize(using = LocalDateSerializer.class)
     @JsonProperty("held_on")
     private LocalDate heldOn;
-
+    @JsonProperty("is_allowed")
+    private boolean isAllowed;
+    @JsonProperty("is_set_aside")
+    private boolean isSetAside;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DirectionOrDecisionIssuedTemplateBody.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DirectionOrDecisionIssuedTemplateBody.java
@@ -54,5 +54,7 @@ public class DirectionOrDecisionIssuedTemplateBody implements FormPayload {
     private boolean isAllowed;
     @JsonProperty("is_set_aside")
     private boolean isSetAside;
+    @JsonProperty("date_of_decision")
+    private String dateOfDecision;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeService.java
@@ -21,22 +21,29 @@ public class DecisionNoticeOutcomeService {
             return null;
         } else {
 
-            ComparedRate dailyLivingComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpDailyLivingQuestion());
-            ComparedRate mobilityComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpMobilityQuestion());
+            try {
 
-            Set<ComparedRate> comparedRates = new HashSet<>();
-            comparedRates.add(dailyLivingComparedRate);
-            comparedRates.add(mobilityComparedRate);
+                ComparedRate dailyLivingComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpDailyLivingQuestion());
+                ComparedRate mobilityComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpMobilityQuestion());
 
-            // At least one higher,  and non lower, means the decision is in favour of appellant
-            if (comparedRates.contains(ComparedRate.Higher)
-                && !comparedRates.contains(ComparedRate.Lower)) {
-                return DECISION_IN_FAVOUR_OF_APPELLANT;
-            } else {
-                // Otherwise, decision upheld
-                return DECISION_UPHELD;
+                Set<ComparedRate> comparedRates = new HashSet<>();
+                comparedRates.add(dailyLivingComparedRate);
+                comparedRates.add(mobilityComparedRate);
+
+                // At least one higher,  and non lower, means the decision is in favour of appellant
+                if (comparedRates.contains(ComparedRate.Higher)
+                    && !comparedRates.contains(ComparedRate.Lower)) {
+                    return DECISION_IN_FAVOUR_OF_APPELLANT;
+                } else {
+                    // Otherwise, decision upheld
+                    return DECISION_UPHELD;
+                }
+
+            } catch (IllegalArgumentException e) {
+                log.error(e.getMessage());
+                return null;
             }
-        }
 
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeService.java
@@ -1,0 +1,42 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static uk.gov.hmcts.reform.sscs.ccd.domain.Outcome.DECISION_IN_FAVOUR_OF_APPELLANT;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.Outcome.DECISION_UPHELD;
+
+import java.util.HashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Outcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.domain.wrapper.ComparedRate;
+
+@Slf4j
+@Service
+public class DecisionNoticeOutcomeService {
+
+    public Outcome determineOutcome(SscsCaseData sscsCaseData) {
+        if (sscsCaseData.getPipWriteFinalDecisionComparedToDwpDailyLivingQuestion() == null
+            || sscsCaseData.getPipWriteFinalDecisionComparedToDwpMobilityQuestion() == null) {
+            return null;
+        } else {
+
+            ComparedRate dailyLivingComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpDailyLivingQuestion());
+            ComparedRate mobilityComparedRate = ComparedRate.getByKey(sscsCaseData.getPipWriteFinalDecisionComparedToDwpMobilityQuestion());
+
+            Set<ComparedRate> comparedRates = new HashSet<>();
+            comparedRates.add(dailyLivingComparedRate);
+            comparedRates.add(mobilityComparedRate);
+
+            // At least one higher,  and non lower, means the decision is in favour of appellant
+            if (comparedRates.contains(ComparedRate.Higher)
+                && !comparedRates.contains(ComparedRate.Lower)) {
+                return DECISION_IN_FAVOUR_OF_APPELLANT;
+            } else {
+                // Otherwise, decision upheld
+                return DECISION_UPHELD;
+            }
+        }
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
 import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.service.DecisionNoticeOutcomeService;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeQuestionService;
 
 @RunWith(JUnitParamsRunner.class)
@@ -39,20 +40,23 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
     private CaseDetails<SscsCaseData> caseDetails;
 
     private DecisionNoticeQuestionService decisionNoticeQuestionService;
+    private DecisionNoticeOutcomeService decisionNoticeOutcomeService;
     private SscsCaseData sscsCaseData;
 
     @Before
     public void setUp() throws IOException {
         initMocks(this);
         decisionNoticeQuestionService = new DecisionNoticeQuestionService();
-        handler = new WriteFinalDecisionAboutToSubmitHandler(decisionNoticeQuestionService);
+        decisionNoticeOutcomeService = new DecisionNoticeOutcomeService();
+        handler = new WriteFinalDecisionAboutToSubmitHandler(decisionNoticeQuestionService,
+            decisionNoticeOutcomeService);
 
         when(callback.getEvent()).thenReturn(EventType.WRITE_FINAL_DECISION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         sscsCaseData = SscsCaseData.builder().ccdCaseId("ccdId")
             .appeal(Appeal.builder().build())
-            .pipWriteFinalDecisionComparedToDwpDailyLivingQuestion(Higher.name())
-            .pipWriteFinalDecisionComparedToDwpMobilityQuestion(Higher.name())
+            .pipWriteFinalDecisionComparedToDwpDailyLivingQuestion(Higher.getKey())
+            .pipWriteFinalDecisionComparedToDwpMobilityQuestion(Higher.getKey())
             .build();
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
     }
@@ -65,16 +69,16 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
 
     @Test
     @Parameters({
-            "Higher, Higher, decisionInFavourOfAppellant",
-            "Higher, Same, decisionInFavourOfAppellant",
-            "Higher, Lower, decisionInFavourOfAppellant",
-            "Same, Higher, decisionInFavourOfAppellant",
-            "Same, Same, decisionUpheld",
-            "Same, Lower, decisionUpheld",
-            "Lower, Higher, decisionInFavourOfAppellant",
-            "Lower, Same, decisionUpheld",
-            "Lower, Lower, decisionUpheld"})
-    public void givenFinalDecisionComparedToDwpQuestionAndAtLeastOneDecisionIsHigher_thenSetDecisionInFavourOfAppellant(String comparedRateDailyLiving, String comparedRateMobility, String expectedOutcome) {
+            "higher, higher, decisionInFavourOfAppellant",
+            "higher, same, decisionInFavourOfAppellant",
+            "higher, lower, decisionUpheld",
+            "same, higher, decisionInFavourOfAppellant",
+            "same, same, decisionUpheld",
+            "same, lower, decisionUpheld",
+            "lower, higher, decisionUpheld",
+            "lower, same, decisionUpheld",
+            "lower, lower, decisionUpheld"})
+    public void givenFinalDecisionComparedToDwpQuestionAndAtLeastOneDecisionIsHigherAndNeitherIsLower_thenSetDecisionInFavourOfAppellant(String comparedRateDailyLiving, String comparedRateMobility, String expectedOutcome) {
         callback.getCaseDetails().getCaseData().setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion(comparedRateDailyLiving);
         callback.getCaseDetails().getCaseData().setPipWriteFinalDecisionComparedToDwpMobilityQuestion(comparedRateMobility);
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
@@ -212,6 +212,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void willSetPreviewFile() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
@@ -251,6 +254,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithVenues_thenCorrectlySetHeldAtUsingTheFirstHearingInList() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("venue 1 name").build()).build()).build();
@@ -280,6 +286,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoVenueName_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("venue 1 name").build()).build()).build();
@@ -304,6 +313,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoVenue_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("venue 1 name").build()).build()).build();
@@ -328,6 +340,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstHearingInListNull_thenDisplayAnErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .venue(Venue.builder().name("venue 1 name").build()).build()).build();
@@ -348,6 +363,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoHearingDetails_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .venue(Venue.builder().name("venue 1 name").build()).build()).build();
@@ -371,6 +389,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithEmptyHearingsList_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         List<Hearing> hearings = new ArrayList<>();
         sscsCaseData.setHearings(hearings);
@@ -389,6 +410,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithNullHearingsList_thenDisplayAnErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
 
@@ -404,6 +428,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithHearingDates_thenCorrectlySetTheHeldOnUsingTheFirstHearingInList() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build();
@@ -433,6 +460,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoHearingDate_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build();
@@ -458,6 +488,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithMultipleHearingsWithFirstHearingInListNull_thenDisplayTwoErrorsAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         Hearing hearing1 = Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01")
@@ -483,6 +516,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithNullHearingsList_thenDisplayErrorAndDoNotGenerateDocument() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
 
@@ -498,6 +534,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithTwoPanelMembers_thenCorrectlySetTheHeldBefore() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         sscsCaseData.setWriteFinalDecisionDisabilityQualifiedPanelMemberName("Mr Panel Member 1");
         sscsCaseData.setWriteFinalDecisionMedicallyQualifiedPanelMemberName("Ms Panel Member 2");
@@ -525,6 +564,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithOnePanelMember_thenCorrectlySetTheHeldBefore() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         sscsCaseData.setWriteFinalDecisionDisabilityQualifiedPanelMemberName("Mr Panel Member 1");
 
@@ -550,6 +592,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithNoPanelMembers_thenCorrectlySetTheHeldBefore() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
@@ -573,6 +618,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void scottishRpcWillShowAScottishImage() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
         sscsCaseData.setRegionalProcessingCenter(RegionalProcessingCenter.builder().name("Glasgow").build());
 
@@ -588,6 +636,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     public void givenCaseWithAppointee_thenCorrectlySetTheNoticeNameWithAppellantAndAppointeeAppended() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
         sscsCaseData.getAppeal().getAppellant().setIsAppointee("Yes");
         sscsCaseData.getAppeal().getAppellant().setAppointee(Appointee.builder()
             .name(Name.builder().firstName("APPOINTEE")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventHandlerTest.java
@@ -233,6 +233,135 @@ public class WriteFinalDecisionMidEventHandlerTest {
     }
 
     @Test
+    public void givenDateOfDecisionNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Unable to determine date of decision", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
+    public void givenSignedInJudgeNameNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+        when(userDetails.getFullName()).thenReturn(null);
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Unable to obtain signed in user name", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
+    public void givenSignedInJudgeUserDetailsNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+        when(idamClient.getUserDetails("Bearer token")).thenReturn(null);
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Unable to obtain signed in user details", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
+    public void givenComparedToDwpMobilityQuestionNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Outcome cannot be empty. Please check case data. If problem continues please contact support", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
+    public void givenComparedToDwpDailyLivingSetIncorrectly_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("someValue");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Outcome cannot be empty. Please check case data. If problem continues please contact support", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
+    public void givenComparedToDwpMobilityQuestionSetIncorrectly_thenDisplayErrorAndDoNotGenerateDocument() {
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
+        sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("someValue");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+
+
+        sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
+            .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
+
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Outcome cannot be empty. Please check case data. If problem continues please contact support", error);
+        Assert.assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
+    }
+
+    @Test
     public void givenGenerateNoticeSetToNo_willNotSetPreviewFile() {
 
         sscsCaseData.setWriteFinalDecisionGenerateNotice("No");

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/DecisionNoticeOutcomeServiceTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.sscs.service;
+
+import static org.junit.Assert.assertEquals;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Outcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+@RunWith(JUnitParamsRunner.class)
+public class DecisionNoticeOutcomeServiceTest {
+
+    private DecisionNoticeOutcomeService service;
+
+    @Before
+    public void setup() {
+        service = new DecisionNoticeOutcomeService();
+    }
+
+    @Test
+    @Parameters({
+        "higher, higher, decisionInFavourOfAppellant",
+        "higher, same, decisionInFavourOfAppellant",
+        "higher, lower, decisionUpheld",
+        "same, higher, decisionInFavourOfAppellant",
+        "same, same, decisionUpheld",
+        "same, lower, decisionUpheld",
+        "lower, higher, decisionUpheld",
+        "lower, same, decisionUpheld",
+        "lower, lower, decisionUpheld"})
+    public void givenFinalDecisionComparedToDwpQuestionAndAtLeastOneDecisionIsHigherAndNeitherIsLower_thenSetDecisionInFavourOfAppellant(String comparedRateDailyLiving, String comparedRateMobility,
+        String expectedOutcome) {
+
+        SscsCaseData caseData = SscsCaseData.builder().pipWriteFinalDecisionComparedToDwpDailyLivingQuestion(comparedRateDailyLiving)
+            .pipWriteFinalDecisionComparedToDwpMobilityQuestion(comparedRateMobility).build();
+
+        Outcome outcome = service.determineOutcome(caseData);
+
+        Assert.assertNotNull(outcome);
+
+        assertEquals(expectedOutcome, outcome.getId());
+    }
+
+
+    @Test
+    public void givenFinalDecisionComparedToDwpQuestionWithIncorrectValue_ThenReturnNull() {
+
+        SscsCaseData caseData = SscsCaseData.builder().pipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher")
+            .pipWriteFinalDecisionComparedToDwpMobilityQuestion("something").build();
+
+        Outcome outcome = service.determineOutcome(caseData);
+
+        Assert.assertNull(outcome);
+    }
+
+    @Test
+    public void givenFinalDecisionComparedToDwpQuestionWithNullValue_ThenReturnNull() {
+
+        SscsCaseData caseData = SscsCaseData.builder().pipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher")
+            .build();
+
+        Outcome outcome = service.determineOutcome(caseData);
+
+        Assert.assertNull(outcome);
+
+    }
+}

--- a/src/test/resources/callback/finalDecisionIssuedForPreview.json
+++ b/src/test/resources/callback/finalDecisionIssuedForPreview.json
@@ -28,6 +28,7 @@
       "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
       "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
       "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
       "writeFinalDecisionStartDate": "2018-10-10",
       "writeFinalDecisionEndDate": "2018-10-10",
       "writeFinalDecisionGenerateNotice": "Yes",
@@ -763,6 +764,7 @@
     "case_data": {
       "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
       "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
       "writeFinalDecisionStartDate": "2018-10-10",
       "writeFinalDecisionEndDate": "2018-10-10",
       "writeFinalDecisionGenerateNotice": "Yes",


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7554

### Change description ###

Moving outcome calculation logic into shared DecisionNoticeOutcomeService.  Replacing Judge Name Placeholder with call to idam service for current user full name.

Adding is_allowed and is_set_aside flags to DirectionOrDecisionIssuedTemplateBody and setting based on outcome.  
Adding date_of_decision flag to DirectionOrDecisionIssuedTemplateBody and setting from casedata.
Adding key and getByKey method to ComparedRate

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
