### PR TITLE
SSCS-7617 Add footer to final decision notice and refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'doc-assembly-client', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.4'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.2.37'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.2.38-RC-SSCS-7617'
 
     testCompile group: 'io.rest-assured', name: 'rest-assured'
 

--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'doc-assembly-client', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '6.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.4'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.2.38-RC-SSCS-7617'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.3.0'
 
     testCompile group: 'io.rest-assured', name: 'rest-assured'
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/DecisionIssuedIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/DecisionIssuedIt.java
@@ -97,7 +97,40 @@ public class DecisionIssuedIt extends AbstractEventIt {
         assertEquals(4, result.getData().getSscsDocument().size());
         assertEquals(DocumentType.DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
         assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
-        assertEquals("Addition B - Decision notice issued on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("Addition B - Decision Notice issued on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("B", result.getData().getSscsDocument().get(0).getValue().getBundleAddition());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        assertEquals(STRUCK_OUT.getId(), result.getData().getDwpState());
+        assertEquals("nonCompliantAppealStruckout", result.getData().getOutcome());
+    }
+
+    @Test
+    public void callToAboutToSubmitEventHandler_willSaveTheManuallyUploadedInterlocDirectionDocument() throws Exception {
+        setup("callback/decisionIssuedManualInterloc.json");
+
+        byte[] pdfBytes = IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("pdf/sample.pdf"));
+        when(evidenceManagementService.download(any(), anyString())).thenReturn(pdfBytes);
+
+        UploadResponse uploadResponse = createUploadResponse();
+        when(evidenceManagementService.upload(any(), anyString())).thenReturn(uploadResponse);
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertNull(result.getData().getPreviewDocument());
+        assertNull(result.getData().getSignedRole());
+        assertNull(result.getData().getSignedBy());
+        assertNull(result.getData().getGenerateNotice());
+        assertNull(result.getData().getDateAdded());
+        assertNull(result.getData().getExtensionNextEventDl());
+        assertNull(result.getData().getDirectionTypeDl());
+        assertEquals(4, result.getData().getSscsDocument().size());
+        assertEquals(DocumentType.DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        assertEquals("Addition B - Decision Notice issued on 09-02-2018.pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
         assertEquals("B", result.getData().getSscsDocument().get(0).getValue().getBundleAddition());
         assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
         assertEquals(STRUCK_OUT.getId(), result.getData().getDwpState());

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/DirectionIssuedIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/DirectionIssuedIt.java
@@ -99,7 +99,40 @@ public class DirectionIssuedIt extends AbstractEventIt {
         assertEquals(4, result.getData().getSscsDocument().size());
         assertEquals(DocumentType.DIRECTION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
         assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
-        assertEquals("Addition B - Directions notice issued on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("Addition B - Directions Notice issued on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("B", result.getData().getSscsDocument().get(0).getValue().getBundleAddition());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        assertEquals(DwpState.DIRECTION_ACTION_REQUIRED.getId(), result.getData().getDwpState());
+        assertEquals("awaitingInformation", result.getData().getInterlocReviewState());
+    }
+
+    @Test
+    public void callToAboutToSubmitEventHandler_willSaveTheManuallyUploadedInterlocDirectionDocument() throws Exception {
+        setup("callback/directionIssuedManualInterloc.json");
+
+        byte[] pdfBytes = IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("pdf/sample.pdf"));
+        when(evidenceManagementService.download(any(), anyString())).thenReturn(pdfBytes);
+
+        UploadResponse uploadResponse = createUploadResponse();
+        when(evidenceManagementService.upload(any(), anyString())).thenReturn(uploadResponse);
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertNull(result.getData().getPreviewDocument());
+        assertNull(result.getData().getSignedRole());
+        assertNull(result.getData().getSignedBy());
+        assertNull(result.getData().getGenerateNotice());
+        assertNull(result.getData().getDateAdded());
+        assertNull(result.getData().getExtensionNextEventDl());
+        assertNull(result.getData().getDirectionTypeDl());
+        assertEquals(4, result.getData().getSscsDocument().size());
+        assertEquals(DocumentType.DIRECTION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        assertEquals("Addition B - Directions Notice issued on 09-02-2018.pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
         assertEquals("B", result.getData().getSscsDocument().get(0).getValue().getBundleAddition());
         assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
         assertEquals(DwpState.DIRECTION_ACTION_REQUIRED.getId(), result.getData().getDwpState());

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/IssueFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/IssueFinalDecisionIt.java
@@ -1,13 +1,18 @@
 package uk.gov.hmcts.reform.sscs.callback;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DECISION_NOTICE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.DwpState.FINAL_DECISION_ISSUED;
-import static uk.gov.hmcts.reform.sscs.helper.IntegrationTestHelper.assertHttpStatus;
-import static uk.gov.hmcts.reform.sscs.helper.IntegrationTestHelper.getRequestWithAuthHeader;
+import static uk.gov.hmcts.reform.sscs.helper.IntegrationTestHelper.*;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -17,8 +22,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.service.EvidenceManagementService;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -30,6 +37,9 @@ public class IssueFinalDecisionIt extends AbstractEventIt {
     @MockBean
     private AuthTokenGenerator authTokenGenerator;
 
+    @MockBean
+    private EvidenceManagementService evidenceManagementService;
+
     @Before
     public void setup() throws IOException {
         setup("callback/issueFinalDecisionCallback.json");
@@ -37,6 +47,12 @@ public class IssueFinalDecisionIt extends AbstractEventIt {
 
     @Test
     public void callToAboutToSubmitHandler_willMoveDraftDecisionToDecisionNotice() throws Exception {
+        byte[] pdfBytes = IOUtils.toByteArray(getClass().getClassLoader().getResourceAsStream("pdf/sample.pdf"));
+        when(evidenceManagementService.download(any(), anyString())).thenReturn(pdfBytes);
+
+        UploadResponse uploadResponse = createUploadResponse();
+        when(evidenceManagementService.upload(any(), anyString())).thenReturn(uploadResponse);
+
         MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
         assertHttpStatus(response, HttpStatus.OK);
         PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
@@ -45,5 +61,10 @@ public class IssueFinalDecisionIt extends AbstractEventIt {
 
         assertEquals(DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
         assertEquals(FINAL_DECISION_ISSUED.getId(), result.getData().getDwpState());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        assertEquals("Addition B - Decision Notice issued on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("B", result.getData().getSscsDocument().get(0).getValue().getBundleAddition());
+        assertEquals("some location", result.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+
     }
 }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -45,7 +45,6 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest extends BaseHandler {
             .assertThat().body("writeFinalDecisionDisabilityQualifiedPanelMemberName", equalTo("Fred"))
             .assertThat().body("writeFinalDecisionEndDate", equalTo("2020-10-10"))
             .assertThat().body("writeFinalDecisionEndDateType", equalTo("setEndDate"))
-            .assertThat().body("writeFinalDecisionGenerateNotice", equalTo("Yes"))
             .assertThat().body("writeFinalDecisionMedicallyQualifiedPanelMemberName", equalTo("Ted"))
             .assertThat().body("writeFinalDecisionPageSectionReference", equalTo("B2"))
             .assertThat().body("writeFinalDecisionAppellantAttendedQuestion", equalTo("Yes"))

--- a/src/e2e/resources/handlers/writefinaldecision/writeFinalDecisionCallback.json
+++ b/src/e2e/resources/handlers/writefinaldecision/writeFinalDecisionCallback.json
@@ -42,7 +42,6 @@
       "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Fred",
       "writeFinalDecisionEndDate": "2020-10-10",
       "writeFinalDecisionEndDateType": "setEndDate",
-      "writeFinalDecisionGenerateNotice": "Yes",
       "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Ted",
       "writeFinalDecisionPageSectionReference": "B2",
       "writeFinalDecisionAppellantAttendedQuestion": "Yes",
@@ -776,7 +775,6 @@
       "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
       "writeFinalDecisionStartDate": "2018-10-10",
       "writeFinalDecisionEndDate": "2018-10-10",
-      "writeFinalDecisionGenerateNotice": "Yes",
       "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
       "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
       "writeFinalDecisionPreviewDocument": {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/IssueDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/IssueDocumentHandler.java
@@ -65,7 +65,7 @@ public class IssueDocumentHandler {
     protected PreSubmitCallbackResponse<SscsCaseData> issueDocument(Callback<SscsCaseData> callback, DocumentType documentType, String templateId, GenerateFile generateFile, String userAuthorisation) {
 
         SscsCaseData caseData = callback.getCaseDetails().getCaseData();
-        String documentUrl = Optional.ofNullable(caseData.getPreviewDocument()).map(DocumentLink::getDocumentUrl).orElse(null);
+        String documentUrl = Optional.ofNullable(getDocumentFromCaseData(caseData)).map(DocumentLink::getDocumentUrl).orElse(null);
 
         LocalDate dateAdded = Optional.ofNullable(caseData.getDateAdded()).orElse(LocalDate.now());
 
@@ -99,9 +99,20 @@ public class IssueDocumentHandler {
         return new PreSubmitCallbackResponse<>(caseData);
     }
 
-
+    /**
+     * Override this method if previewDocument is not the correct field to set.
+     */
     protected void setDocumentOnCaseData(SscsCaseData caseData, DocumentLink file) {
         caseData.setPreviewDocument(file);
+    }
+
+    /**
+     * Override this method if previewDocument is not the correct field to use.
+     *
+     * @return DocumentLink
+     */
+    protected DocumentLink getDocumentFromCaseData(SscsCaseData caseData) {
+        return caseData.getPreviewDocument();
     }
 
     protected String buildFullName(SscsCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/IssueDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/IssueDocumentHandler.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit;
 
 import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_NOTICE;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -86,7 +87,9 @@ public class IssueDocumentHandler {
 
         final String generatedFileUrl = generateFile.assemble(params);
 
-        final String filename = String.format("%s issued on %s.pdf", documentTypeLabel, dateAdded.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+        documentTypeLabel = documentTypeLabel + (DRAFT_DECISION_NOTICE.equals(documentType) ? " generated" : " issued");
+
+        final String filename = String.format("%s on %s.pdf", documentTypeLabel, dateAdded.format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
 
         DocumentLink previewFile = DocumentLink.builder()
                 .documentFilename(filename)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/decisionissued/DecisionIssuedAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/decisionissued/DecisionIssuedAboutToSubmitHandler.java
@@ -4,8 +4,6 @@ import static uk.gov.hmcts.reform.sscs.ccd.callback.DecisionType.STRIKE_OUT;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +52,8 @@ public class DecisionIssuedAboutToSubmitHandler extends IssueDocumentHandler imp
             }
         }
 
-        createFooter(url, caseData);
+        footerService.createFooterAndAddDocToCase(url, caseData, DocumentType.DECISION_NOTICE,
+                Optional.ofNullable(caseData.getDateAdded()).orElse(LocalDate.now()).format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
 
         State beforeState = callback.getCaseDetailsBefore().map(CaseDetails::getState).orElse(null);
 
@@ -77,29 +76,5 @@ public class DecisionIssuedAboutToSubmitHandler extends IssueDocumentHandler imp
         log.info("Saved the new interloc decision document for case id: " + caseData.getCcdCaseId());
 
         return sscsCaseDataPreSubmitCallbackResponse;
-    }
-
-    private void createFooter(DocumentLink url, SscsCaseData caseData) {
-        if (url != null) {
-            log.info("Decision issued adding footer appendix document link: {} and caseId {}", url, caseData.getCcdCaseId());
-
-            String bundleAddition = footerService.getNextBundleAddition(caseData.getSscsDocument());
-
-            String bundleFileName = footerService.buildBundleAdditionFileName(bundleAddition, "Decision notice issued on "
-                    + Optional.ofNullable(caseData.getDateAdded()).orElse(LocalDate.now()).format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
-
-            SscsDocument sscsDocument = footerService.createFooterDocument(url, "Decision notice", bundleAddition, bundleFileName,
-                    caseData.getDateAdded(), DocumentType.DECISION_NOTICE);
-
-            List<SscsDocument> documents = new ArrayList<>();
-            documents.add(sscsDocument);
-
-            if (caseData.getSscsDocument() != null) {
-                documents.addAll(caseData.getSscsDocument());
-            }
-            caseData.setSscsDocument(documents);
-        } else {
-            log.info("Could not find decision issued document for caseId {} so skipping generating footer", caseData.getCcdCaseId());
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
@@ -6,8 +6,6 @@ import static uk.gov.hmcts.reform.sscs.helper.SscsHelper.getPreValidStates;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -77,7 +75,8 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
             caseData.setInterlocReviewState(null);
         }
 
-        createFooter(url, caseData);
+        footerService.createFooterAndAddDocToCase(url, caseData, DocumentType.DIRECTION_NOTICE,
+                Optional.ofNullable(caseData.getDateAdded()).orElse(LocalDate.now()).format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
 
         State beforeState = callback.getCaseDetailsBefore().map(e -> e.getState()).orElse(null);
 
@@ -100,27 +99,5 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
         caseData.setState(state);
     }
 
-    private void createFooter(DocumentLink url, SscsCaseData caseData) {
-        if (url != null) {
-            log.info("Direction issued adding footer appendix document link: {} and caseId {}", url, caseData.getCcdCaseId());
 
-            String bundleAddition = footerService.getNextBundleAddition(caseData.getSscsDocument());
-
-            String bundleFileName = footerService.buildBundleAdditionFileName(bundleAddition, "Directions notice issued on "
-                    + Optional.ofNullable(caseData.getDateAdded()).orElse(LocalDate.now()).format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
-
-            SscsDocument sscsDocument = footerService.createFooterDocument(url, "Directions notice", bundleAddition, bundleFileName,
-                    caseData.getDateAdded(), DocumentType.DIRECTION_NOTICE);
-
-            List<SscsDocument> documents = new ArrayList<>();
-            documents.add(sscsDocument);
-
-            if (caseData.getSscsDocument() != null) {
-                documents.addAll(caseData.getSscsDocument());
-            }
-            caseData.setSscsDocument(documents);
-        } else {
-            log.info("Could not find direction issued document for caseId {} so skipping generating footer", caseData.getCcdCaseId());
-        }
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
@@ -1,24 +1,35 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.issuefinaldecision;
 
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DECISION_NOTICE;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_NOTICE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.DwpState.FINAL_DECISION_ISSUED;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.sscs.service.FooterService;
 
 @Component
 @Slf4j
 public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallbackHandler<SscsCaseData> {
+
+    private final FooterService footerService;
+
+    @Autowired
+    public IssueFinalDecisionAboutToSubmitHandler(FooterService footerService) {
+        this.footerService = footerService;
+    }
 
     @Override
     public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {
@@ -40,25 +51,31 @@ public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
 
         sscsCaseData.setDwpState(FINAL_DECISION_ISSUED.getId());
 
-        moveDraftFinalDecision(preSubmitCallbackResponse);
+        createFinalDecisionNoticeFromDraft(preSubmitCallbackResponse);
 
         clearTransientFields(sscsCaseData);
 
         return preSubmitCallbackResponse;
     }
 
-    private void moveDraftFinalDecision(PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+    private void createFinalDecisionNoticeFromDraft(PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
 
         Iterator<SscsDocument> iterator = preSubmitCallbackResponse.getData().getSscsDocument().stream()
                 .filter(e -> e.getValue().getDocumentType().equals(DRAFT_DECISION_NOTICE.getValue())).iterator();
 
         if (iterator.hasNext()) {
             while (iterator.hasNext()) {
-                iterator.next().getValue().setDocumentType(DECISION_NOTICE.getValue());
+                SscsDocument sscsDocument = iterator.next();
+                footerService.createFooterAndAddDocToCase(sscsDocument.getValue().getDocumentLink(), preSubmitCallbackResponse.getData(), DocumentType.DECISION_NOTICE,
+                        LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
             }
+
         } else {
             preSubmitCallbackResponse.addError("There is no Draft Decision Notice on the case so decision cannot be issued");
         }
+
+        preSubmitCallbackResponse.getData().getSscsDocument()
+                .removeIf(doc -> doc.getValue().getDocumentType().equals(DRAFT_DECISION_NOTICE.getValue()));
     }
 
     private void clearTransientFields(SscsCaseData sscsCaseData) {
@@ -91,7 +108,6 @@ public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         sscsCaseData.setPipWriteFinalDecisionMovingAroundQuestion(null);
         sscsCaseData.setWriteFinalDecisionReasonsForDecision(null);
         sscsCaseData.setWriteFinalDecisionPageSectionReference(null);
-        sscsCaseData.setWriteFinalDecisionGenerateNotice(null);
         sscsCaseData.setWriteFinalDecisionPreviewDocument(null);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
@@ -66,8 +67,15 @@ public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         if (iterator.hasNext()) {
             while (iterator.hasNext()) {
                 SscsDocument sscsDocument = iterator.next();
-                footerService.createFooterAndAddDocToCase(sscsDocument.getValue().getDocumentLink(), preSubmitCallbackResponse.getData(), DocumentType.DECISION_NOTICE,
-                        LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")));
+                String now = LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"));
+
+                DocumentLink documentLink = DocumentLink.builder()
+                    .documentUrl(sscsDocument.getValue().getDocumentLink().getDocumentUrl())
+                    .documentFilename(DocumentType.DECISION_NOTICE.getValue() + " issued on " + now + ".pdf")
+                    .documentBinaryUrl(sscsDocument.getValue().getDocumentLink().getDocumentBinaryUrl())
+                    .build();
+
+                footerService.createFooterAndAddDocToCase(documentLink, preSubmitCallbackResponse.getData(), DocumentType.DECISION_NOTICE, now);
             }
 
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
@@ -1,9 +1,10 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_NOTICE;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +12,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Outcome;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeOutcomeService;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeQuestionService;
@@ -53,6 +52,8 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         getDecisionNoticePointsValidationErrorMessages(sscsCaseData).forEach(preSubmitCallbackResponse::addError);
 
         calculateOutcomeCode(sscsCaseData, preSubmitCallbackResponse);
+
+        writePreviewDocumentToSscsDocument(sscsCaseData);
 
         return preSubmitCallbackResponse;
     }
@@ -97,5 +98,25 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         return pointsCondition.getPointsRequirementCondition().test(totalPoints) ? Optional.empty() :
             Optional.of(pointsCondition.getErrorMessage());
 
+    }
+
+    private void writePreviewDocumentToSscsDocument(SscsCaseData sscsCaseData) {
+        final String filename = String.format("%s issued on %s.pdf", DRAFT_DECISION_NOTICE.getValue(), LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+
+        SscsDocument draftDecisionNotice = SscsDocument.builder().value(SscsDocumentDetails.builder()
+                .documentFileName(filename)
+                .documentLink(sscsCaseData.getWriteFinalDecisionPreviewDocument())
+                .documentDateAdded(LocalDate.now().format(DateTimeFormatter.ISO_DATE))
+                .documentType(DRAFT_DECISION_NOTICE.getValue())
+                .build()).build();
+
+        List<SscsDocument> documents = new ArrayList<>();
+
+        documents.add(draftDecisionNotice);
+
+        if (sscsCaseData.getSscsDocument() != null) {
+            documents.addAll(sscsCaseData.getSscsDocument());
+        }
+        sscsCaseData.setSscsDocument(documents);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
@@ -101,7 +101,12 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
     }
 
     private void writePreviewDocumentToSscsDocument(SscsCaseData sscsCaseData) {
-        final String filename = String.format("%s issued on %s.pdf", DRAFT_DECISION_NOTICE.getValue(), LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
+        if (sscsCaseData.getSscsDocument() != null) {
+            sscsCaseData.getSscsDocument()
+                    .removeIf(doc -> DRAFT_DECISION_NOTICE.getValue().equals(doc.getValue().getDocumentType()));
+        }
+
+        final String filename = String.format("%s generated on %s.pdf", DRAFT_DECISION_NOTICE.getLabel(), LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy")));
 
         SscsDocument draftDecisionNotice = SscsDocument.builder().value(SscsDocumentDetails.builder()
                 .documentFileName(filename)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.IssueDocumentHandler;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
+
+
+@Component
+@Slf4j
+public class WriteFinalDecisionMidEventValidationHandler extends IssueDocumentHandler implements PreSubmitCallbackHandler<SscsCaseData> {
+
+    @Override
+    public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {
+        return callbackType == CallbackType.MID_EVENT
+            && callback.getEvent() == EventType.WRITE_FINAL_DECISION
+            && Objects.nonNull(callback.getCaseDetails())
+            && Objects.nonNull(callback.getCaseDetails().getCaseData());
+    }
+
+    @Override
+    public PreSubmitCallbackResponse<SscsCaseData> handle(CallbackType callbackType, Callback<SscsCaseData> callback, String userAuthorisation) {
+        if (!canHandle(callbackType, callback)) {
+            throw new IllegalStateException("Cannot handle callback");
+        }
+
+        SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
+
+        PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
+
+        if (isDecisionNoticeDatesInvalid(sscsCaseData)) {
+            preSubmitCallbackResponse.addError("Decision notice end date must be after decision notice start date");
+        }
+        if (isDecisionNoticeDateOfDecisionInvalid(sscsCaseData)) {
+            preSubmitCallbackResponse.addError("Decision notice date of decision must not be in the future");
+        }
+
+        return preSubmitCallbackResponse;
+    }
+
+    private boolean isDecisionNoticeDatesInvalid(SscsCaseData sscsCaseData) {
+        if (sscsCaseData.getWriteFinalDecisionStartDate() != null && sscsCaseData.getWriteFinalDecisionEndDate() != null) {
+            LocalDate decisionNoticeStartDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionStartDate());
+            LocalDate decisionNoticeEndDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionEndDate());
+            return !decisionNoticeStartDate.isBefore(decisionNoticeEndDate);
+        }
+        return false;
+    }
+
+    private boolean isDecisionNoticeDateOfDecisionInvalid(SscsCaseData sscsCaseData) {
+        if (!isBlank(sscsCaseData.getWriteFinalDecisionDateOfDecision())) {
+            LocalDate decisionNoticeDecisionDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionDateOfDecision());
+            LocalDate today = LocalDate.now();
+            return decisionNoticeDecisionDate.isAfter(today);
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionService.java
@@ -1,13 +1,11 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.commons.lang3.StringUtils.splitByCharacterTypeCamelCase;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
@@ -19,16 +17,13 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
-import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Hearing;
 import uk.gov.hmcts.reform.sscs.ccd.domain.Outcome;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.IssueDocumentHandler;
-import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.docassembly.GenerateFile;
 import uk.gov.hmcts.reform.sscs.model.docassembly.Descriptor;
 import uk.gov.hmcts.reform.sscs.model.docassembly.DirectionOrDecisionIssuedTemplateBody;
@@ -39,10 +34,9 @@ import uk.gov.hmcts.reform.sscs.service.DecisionNoticeOutcomeService;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeQuestionService;
 import uk.gov.hmcts.reform.sscs.util.StringUtils;
 
-
 @Component
 @Slf4j
-public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler implements PreSubmitCallbackHandler<SscsCaseData> {
+public class WriteFinalDecisionPreviewDecisionService extends IssueDocumentHandler {
 
     private final GenerateFile generateFile;
     private final String templateId;
@@ -52,8 +46,8 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
 
 
     @Autowired
-    public WriteFinalDecisionMidEventHandler(GenerateFile generateFile, IdamClient idamClient, DecisionNoticeOutcomeService decisionNoticeOutcomeService,
-        DecisionNoticeQuestionService decisionNoticeQuestionService, @Value("${doc_assembly.issue_final_decision}") String templateId) {
+    public WriteFinalDecisionPreviewDecisionService(GenerateFile generateFile, IdamClient idamClient, DecisionNoticeOutcomeService decisionNoticeOutcomeService,
+                                                    DecisionNoticeQuestionService decisionNoticeQuestionService, @Value("${doc_assembly.issue_final_decision}") String templateId) {
         this.generateFile = generateFile;
         this.templateId = templateId;
         this.idamClient = idamClient;
@@ -61,59 +55,20 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
         this.decisionNoticeQuestionService = decisionNoticeQuestionService;
     }
 
-    @Override
-    public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {
-        return callbackType == CallbackType.MID_EVENT
-            && callback.getEvent() == EventType.WRITE_FINAL_DECISION
-            && Objects.nonNull(callback.getCaseDetails())
-            && Objects.nonNull(callback.getCaseDetails().getCaseData());
-    }
-
-    @Override
-    public PreSubmitCallbackResponse<SscsCaseData> handle(CallbackType callbackType, Callback<SscsCaseData> callback, String userAuthorisation) {
-        if (!canHandle(callbackType, callback)) {
-            throw new IllegalStateException("Cannot handle callback");
-        }
+    public PreSubmitCallbackResponse<SscsCaseData> preview(Callback<SscsCaseData> callback, String userAuthorisation) {
 
         SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 
-        if (isDecisionNoticeDatesInvalid(sscsCaseData)) {
-            preSubmitCallbackResponse.addError("Decision notice end date must be after decision notice start date");
-        }
-        if (isDecisionNoticeDateOfDecisionInvalid(sscsCaseData)) {
-            preSubmitCallbackResponse.addError("Decision notice date of decision must not be in the future");
-        }
-
-        if (sscsCaseData.isWriteFinalDecisionGenerateNotice()) {
-            try {
-                return issueDocument(callback, DocumentType.DRAFT_DECISION_NOTICE, templateId, generateFile, userAuthorisation);
-            } catch (IllegalStateException e) {
-                log.error(e.getMessage() + ". Something has gone wrong for caseId: ", sscsCaseData.getCcdCaseId());
-                preSubmitCallbackResponse.addError(e.getMessage());
-            }
+        try {
+            return issueDocument(callback, DocumentType.DRAFT_DECISION_NOTICE, templateId, generateFile, userAuthorisation);
+        } catch (IllegalStateException e) {
+            log.error(e.getMessage() + ". Something has gone wrong for caseId: ", sscsCaseData.getCcdCaseId());
+            preSubmitCallbackResponse.addError(e.getMessage());
         }
 
         return preSubmitCallbackResponse;
-    }
-
-    private boolean isDecisionNoticeDatesInvalid(SscsCaseData sscsCaseData) {
-        if (sscsCaseData.getWriteFinalDecisionStartDate() != null && sscsCaseData.getWriteFinalDecisionEndDate() != null) {
-            LocalDate decisionNoticeStartDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionStartDate());
-            LocalDate decisionNoticeEndDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionEndDate());
-            return !decisionNoticeStartDate.isBefore(decisionNoticeEndDate);
-        }
-        return false;
-    }
-
-    private boolean isDecisionNoticeDateOfDecisionInvalid(SscsCaseData sscsCaseData) {
-        if (!isBlank(sscsCaseData.getWriteFinalDecisionDateOfDecision())) {
-            LocalDate decisionNoticeDecisionDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionDateOfDecision());
-            LocalDate today = LocalDate.now();
-            return decisionNoticeDecisionDate.isAfter(today);
-        }
-        return false;
     }
 
     @Override
@@ -280,6 +235,10 @@ public class WriteFinalDecisionMidEventHandler extends IssueDocumentHandler impl
         caseData.setWriteFinalDecisionPreviewDocument(file);
     }
 
+    @Override
+    protected DocumentLink getDocumentFromCaseData(SscsCaseData caseData) {
+        return caseData.getWriteFinalDecisionPreviewDocument();
+    }
 
     private String buildSignedInJudgeName(String userAuthorisation) {
         UserDetails userDetails = idamClient.getUserDetails(userAuthorisation);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/CcdMideventCallbackController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/CcdMideventCallbackController.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.sscs.controller;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.ResponseEntity.ok;
+import static uk.gov.hmcts.reform.sscs.service.AuthorisationService.SERVICE_AUTHORISATION_HEADER;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.deserialisation.SscsCaseCallbackDeserializer;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision.WriteFinalDecisionPreviewDecisionService;
+import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
+
+@RestController
+@Slf4j
+public class CcdMideventCallbackController {
+
+    private final AuthorisationService authorisationService;
+    private final SscsCaseCallbackDeserializer deserializer;
+    private final WriteFinalDecisionPreviewDecisionService writeFinalDecisionPreviewDecisionService;
+
+    @Autowired
+    public CcdMideventCallbackController(AuthorisationService authorisationService, SscsCaseCallbackDeserializer deserializer,
+                                         WriteFinalDecisionPreviewDecisionService writeFinalDecisionPreviewDecisionService) {
+        this.authorisationService = authorisationService;
+        this.deserializer = deserializer;
+        this.writeFinalDecisionPreviewDecisionService = writeFinalDecisionPreviewDecisionService;
+    }
+
+    @PostMapping(path = "/ccdMidEventPreviewFinalDecision")
+    public ResponseEntity<PreSubmitCallbackResponse<SscsCaseData>> ccdMidEventPreviewFinalDecision(
+        @RequestHeader(SERVICE_AUTHORISATION_HEADER) String serviceAuthHeader,
+        @RequestHeader(AUTHORIZATION) String userAuthorisation,
+        @RequestBody String message) {
+        Callback<SscsCaseData> callback = deserializer.deserialize(message);
+        log.info("About to start ccdMidEventPreviewFinalDecision callback `{}` received for Case ID `{}`", callback.getEvent(),
+            callback.getCaseDetails().getId());
+
+        authorisationService.authorise(serviceAuthHeader);
+
+        return ok(writeFinalDecisionPreviewDecisionService.preview(callback, userAuthorisation));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/decisionissued/DecisionIssuedAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/decisionissued/DecisionIssuedAboutToSubmitHandlerTest.java
@@ -62,16 +62,7 @@ public class DecisionIssuedAboutToSubmitHandlerTest {
         initMocks(this);
 
         handler = new DecisionIssuedAboutToSubmitHandler(footerService);
-
         when(callback.getEvent()).thenReturn(EventType.DECISION_ISSUED);
-        when(footerService.createFooterDocument(any(), any(), any(), any(), any(), any()))
-            .thenReturn(SscsDocument.builder()
-                .value(SscsDocumentDetails.builder()
-                    .documentType(DocumentType.DECISION_NOTICE.getValue())
-                    .bundleAddition("A").documentLink(DocumentLink.builder()
-                        .documentUrl("footerUrl").build()).build())
-                .build());
-        when(footerService.getNextBundleAddition(any())).thenReturn("A");
 
         SscsDocument document = SscsDocument.builder().value(SscsDocumentDetails.builder().documentFileName("myTest.doc").build()).build();
         List<SscsDocument> docs = new ArrayList<>();
@@ -154,32 +145,8 @@ public class DecisionIssuedAboutToSubmitHandlerTest {
         assertNull(response.getData().getGenerateNotice());
         assertNull(response.getData().getDateAdded());
 
-        assertEquals(2, response.getData().getSscsDocument().size());
-        assertEquals("myTest.doc",
-            response.getData().getSscsDocument().get(1).getValue().getDocumentFileName());
-        assertEquals(expectedDocument.getValue().getDocumentType(),
-            response.getData().getSscsDocument().get(0).getValue().getDocumentType());
-        verify(footerService).createFooterDocument(eq(expectedDocument.getValue().getDocumentLink()),
-            eq("Decision notice"), eq("A"), any(), any(), eq(DocumentType.DECISION_NOTICE));
-    }
-
-    @Test
-    public void givenManuallyUploadedDecisionDocument_thenOverwriteOriginalWithFooterDocument() {
-        sscsCaseData.setPreviewDocument(null);
-        sscsCaseData.setSscsDocument(null);
-
-        SscsInterlocDecisionDocument theDocument = SscsInterlocDecisionDocument.builder()
-            .documentType(DocumentType.DECISION_NOTICE.getValue())
-            .documentLink(DocumentLink.builder().documentUrl(DOCUMENT_URL).build())
-            .documentDateAdded(LocalDate.now()).build();
-
-        sscsCaseData.setSscsInterlocDecisionDocument(theDocument);
-
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals(1, response.getData().getSscsDocument().size());
-        assertEquals("A", response.getData().getSscsDocument().get(0).getValue().getBundleAddition());
-        assertEquals("footerUrl", response.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        verify(footerService).createFooterAndAddDocToCase(eq(expectedDocument.getValue().getDocumentLink()),
+             any(), eq(DocumentType.DECISION_NOTICE), any());
     }
 
     @Test
@@ -204,10 +171,7 @@ public class DecisionIssuedAboutToSubmitHandlerTest {
 
         final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        verify(footerService).createFooterDocument(eq(theDocument.getDocumentLink()), eq("Decision notice"), eq("A"), any(), any(), eq(DocumentType.DECISION_NOTICE));
-        assertEquals(2, response.getData().getSscsDocument().size());
-        assertEquals("A", response.getData().getSscsDocument().get(0).getValue().getBundleAddition());
-        assertEquals("footerUrl", response.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+        verify(footerService).createFooterAndAddDocToCase(eq(theDocument.getDocumentLink()), any(), eq(DocumentType.DECISION_NOTICE), any());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.directionissued;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandlerTest.java
@@ -12,6 +12,8 @@ import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_
 import static uk.gov.hmcts.reform.sscs.ccd.domain.DwpState.FINAL_DECISION_ISSUED;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
@@ -102,7 +104,7 @@ public class IssueFinalDecisionAboutToSubmitHandlerTest {
     public void givenAnIssueFinalDecisionEvent_thenCreateDecisionWithFooterAndClearTransientFields() {
         SscsDocument doc = SscsDocument.builder().value(
                 SscsDocumentDetails.builder()
-                        .documentLink(DocumentLink.builder().documentUrl("test.com").build())
+                        .documentLink(DocumentLink.builder().documentFilename(String.format("Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")))).build())
                         .documentFileName("myTest.doc")
                         .documentType(DRAFT_DECISION_NOTICE.getValue()).build())
                 .build();

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -5,11 +5,16 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_NOTICE;
 import static uk.gov.hmcts.reform.sscs.domain.wrapper.ComparedRate.Higher;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
@@ -19,10 +24,7 @@ import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
-import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeOutcomeService;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeQuestionService;
 
@@ -492,6 +494,21 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
         assertEquals("You have previously selected a standard rate award for Daily Living. The points awarded don't match. Please review your previous selection.", error1);
         assertEquals("You have previously selected a standard rate award for Mobility. The points awarded don't match. Please review your previous selection.", error2);
 
+    }
+
+    @Test
+    public void givenDraftFinalDecisionAlreadyExistsOnCase_thenOverwriteExistingDraft() {
+        SscsDocument doc = SscsDocument.builder().value(SscsDocumentDetails.builder().documentFileName("oldDraft.doc").documentType(DRAFT_DECISION_NOTICE.getValue()).build()).build();
+        List<SscsDocument> docs = new ArrayList<>();
+        docs.add(doc);
+        callback.getCaseDetails().getCaseData().setSscsDocument(docs);
+
+        callback.getCaseDetails().getCaseData().setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion(null);
+        callback.getCaseDetails().getCaseData().setPipWriteFinalDecisionComparedToDwpMobilityQuestion(null);
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getData().getSscsDocument().size());
+        assertEquals((String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")))), response.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
@@ -1,0 +1,181 @@
+package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.MID_EVENT;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.converters.Nullable;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.idam.client.models.UserDetails;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+
+@RunWith(JUnitParamsRunner.class)
+public class WriteFinalDecisionMidEventValidationHandlerTest {
+
+    private static final String USER_AUTHORISATION = "Bearer token";
+    private static final String URL = "http://dm-store/documents/123";
+    private WriteFinalDecisionMidEventValidationHandler handler;
+
+    @Mock
+    private Callback<SscsCaseData> callback;
+
+    @Mock
+    private CaseDetails<SscsCaseData> caseDetails;
+
+    @Mock
+    private IdamClient idamClient;
+
+    @Mock
+    private UserDetails userDetails;
+
+    private SscsCaseData sscsCaseData;
+
+    @Before
+    public void setUp() throws IOException {
+        initMocks(this);
+        handler = new WriteFinalDecisionMidEventValidationHandler();
+
+        when(callback.getEvent()).thenReturn(EventType.WRITE_FINAL_DECISION);
+        when(callback.getCaseDetails()).thenReturn(caseDetails);
+
+        when(userDetails.getFullName()).thenReturn("Judge Full Name");
+
+        when(idamClient.getUserDetails("Bearer token")).thenReturn(userDetails);
+
+        sscsCaseData = SscsCaseData.builder()
+            .ccdCaseId("ccdId")
+            .directionTypeDl(new DynamicList(DirectionType.APPEAL_TO_PROCEED.toString()))
+            .regionalProcessingCenter(RegionalProcessingCenter.builder().name("Birmingham").build())
+            .appeal(Appeal.builder()
+                .appellant(Appellant.builder()
+                    .name(Name.builder().firstName("APPELLANT")
+                        .lastName("LastNamE")
+                        .build())
+                    .identity(Identity.builder().build())
+                    .build())
+                .build()).build();
+
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+    }
+
+    @Test
+    public void givenANonWriteFinalDecisionEvent_thenReturnFalse() {
+        when(callback.getEvent()).thenReturn(EventType.APPEAL_RECEIVED);
+        assertFalse(handler.canHandle(MID_EVENT, callback));
+    }
+
+    @Test
+    @Parameters({"ABOUT_TO_START", "ABOUT_TO_SUBMIT", "SUBMITTED"})
+    public void givenANonCallbackType_thenReturnFalse(CallbackType callbackType) {
+        assertFalse(handler.canHandle(callbackType, callback));
+    }
+
+    @Test
+    public void givenAnEndDateIsBeforeStartDate_thenDisplayAnError() {
+        sscsCaseData.setWriteFinalDecisionStartDate("2020-01-01");
+        sscsCaseData.setWriteFinalDecisionEndDate("2019-01-01");
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Decision notice end date must be after decision notice start date", error);
+    }
+
+    @Test
+    public void givenADecisionDateIsInFuture_thenDisplayAnError() {
+
+        LocalDate tomorrow = LocalDate.now().plusDays(1);
+        sscsCaseData.setWriteFinalDecisionDateOfDecision(tomorrow.toString());
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Decision notice date of decision must not be in the future", error);
+    }
+
+    @Test
+    public void givenADecisionDateIsToday_thenDoNotDisplayAnError() {
+
+        LocalDate today = LocalDate.now();
+        sscsCaseData.setWriteFinalDecisionDateOfDecision(today.toString());
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test
+    public void givenADecisionDateIsInPast_thenDoNotDisplayAnError() {
+
+        LocalDate yesterday = LocalDate.now().plusDays(-1);
+        sscsCaseData.setWriteFinalDecisionDateOfDecision(yesterday.toString());
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test
+    @Parameters({"null", ""})
+    public void givenAnFinalDecisionDateIsEmpty_thenIgnoreEndDate(@Nullable String endDate) {
+        sscsCaseData.setWriteFinalDecisionDateOfDecision(endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test
+    public void givenAnEndDateIsSameAsStartDate_thenDisplayAnError() {
+        sscsCaseData.setWriteFinalDecisionStartDate("2020-01-01");
+        sscsCaseData.setWriteFinalDecisionEndDate("2020-01-01");
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        String error = response.getErrors().stream().findFirst().orElse("");
+        assertEquals("Decision notice end date must be after decision notice start date", error);
+    }
+
+    @Test
+    public void givenAnEndDateIsAfterStartDate_thenDoNotDisplayAnError() {
+        sscsCaseData.setWriteFinalDecisionStartDate("2019-01-01");
+        sscsCaseData.setWriteFinalDecisionEndDate("2020-01-01");
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void throwsExceptionIfItCannotHandleTheAppeal() {
+        when(callback.getEvent()).thenReturn(EventType.APPEAL_RECEIVED);
+        handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTest.java
@@ -179,7 +179,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -246,7 +246,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -433,7 +433,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -605,7 +605,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -688,7 +688,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -718,7 +718,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());
@@ -747,7 +747,7 @@ public class WriteFinalDecisionPreviewDecisionServiceTest {
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
-            .documentFilename(String.format("Draft Decision Notice issued on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
             .documentBinaryUrl(URL + "/binary")
             .documentUrl(URL)
             .build(), response.getData().getWriteFinalDecisionPreviewDocument());

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.MID_EVENT;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -15,7 +14,6 @@ import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.NamedParameters;
 import junitparams.Parameters;
-import junitparams.converters.Nullable;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,23 +22,8 @@ import org.mockito.Mock;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
-import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Appointee;
-import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DirectionType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
-import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Hearing;
-import uk.gov.hmcts.reform.sscs.ccd.domain.HearingDetails;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Identity;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Name;
-import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.Venue;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.docassembly.GenerateFile;
 import uk.gov.hmcts.reform.sscs.model.docassembly.DirectionOrDecisionIssuedTemplateBody;
 import uk.gov.hmcts.reform.sscs.model.docassembly.GenerateFileParams;
@@ -49,12 +32,12 @@ import uk.gov.hmcts.reform.sscs.service.DecisionNoticeOutcomeService;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeQuestionService;
 
 @RunWith(JUnitParamsRunner.class)
-public class WriteFinalDecisionMidEventHandlerTest {
+public class WriteFinalDecisionPreviewDecisionServiceTest {
 
     private static final String USER_AUTHORISATION = "Bearer token";
     private static final String TEMPLATE_ID = "nuts.docx";
     private static final String URL = "http://dm-store/documents/123";
-    private WriteFinalDecisionMidEventHandler handler;
+    private WriteFinalDecisionPreviewDecisionService service;
 
     @Mock
     private Callback<SscsCaseData> callback;
@@ -84,7 +67,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         initMocks(this);
         this.decisionNoticeOutcomeService = new DecisionNoticeOutcomeService();
         this.decisionNoticeQuestionService = new DecisionNoticeQuestionService();
-        handler = new WriteFinalDecisionMidEventHandler(generateFile, idamClient, decisionNoticeOutcomeService,
+        service = new WriteFinalDecisionPreviewDecisionService(generateFile, idamClient, decisionNoticeOutcomeService,
             decisionNoticeQuestionService, TEMPLATE_ID);
 
         when(callback.getEvent()).thenReturn(EventType.WRITE_FINAL_DECISION);
@@ -113,114 +96,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
         capture = ArgumentCaptor.forClass(GenerateFileParams.class);
 
         when(generateFile.assemble(any())).thenReturn(URL);
-    }
-
-    @Test
-    public void givenANonWriteFinalDecisionEvent_thenReturnFalse() {
-        when(callback.getEvent()).thenReturn(EventType.APPEAL_RECEIVED);
-        assertFalse(handler.canHandle(MID_EVENT, callback));
-    }
-
-    @Test
-    @Parameters({"ABOUT_TO_START", "ABOUT_TO_SUBMIT", "SUBMITTED"})
-    public void givenANonCallbackType_thenReturnFalse(CallbackType callbackType) {
-        assertFalse(handler.canHandle(callbackType, callback));
-    }
-
-    @Test
-    public void givenAnEndDateIsBeforeStartDate_thenDisplayAnError() {
-        sscsCaseData.setWriteFinalDecisionStartDate("2020-01-01");
-        sscsCaseData.setWriteFinalDecisionEndDate("2019-01-01");
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        String error = response.getErrors().stream().findFirst().orElse("");
-        assertEquals("Decision notice end date must be after decision notice start date", error);
-    }
-
-    @Test
-    public void givenADecisionDateIsInFuture_thenDisplayAnError() {
-
-        LocalDate tomorrow = LocalDate.now().plusDays(1);
-        sscsCaseData.setWriteFinalDecisionDateOfDecision(tomorrow.toString());
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        String error = response.getErrors().stream().findFirst().orElse("");
-        assertEquals("Decision notice date of decision must not be in the future", error);
-    }
-
-    @Test
-    public void givenADecisionDateIsToday_thenDoNotDisplayAnError() {
-
-        LocalDate today = LocalDate.now();
-        sscsCaseData.setWriteFinalDecisionDateOfDecision(today.toString());
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        assertEquals(0, response.getErrors().size());
-    }
-
-    @Test
-    public void givenADecisionDateIsInPast_thenDoNotDisplayAnError() {
-
-        LocalDate yesterday = LocalDate.now().plusDays(-1);
-        sscsCaseData.setWriteFinalDecisionDateOfDecision(yesterday.toString());
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        assertEquals(0, response.getErrors().size());
-    }
-
-    @Test
-    @Parameters({"null", ""})
-    public void givenAnFinalDecisionDateIsEmpty_thenIgnoreEndDate(@Nullable String endDate) {
-        sscsCaseData.setWriteFinalDecisionDateOfDecision(endDate);
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        assertEquals(0, response.getErrors().size());
-    }
-
-    @Test
-    public void givenAnEndDateIsSameAsStartDate_thenDisplayAnError() {
-        sscsCaseData.setWriteFinalDecisionStartDate("2020-01-01");
-        sscsCaseData.setWriteFinalDecisionEndDate("2020-01-01");
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        String error = response.getErrors().stream().findFirst().orElse("");
-        assertEquals("Decision notice end date must be after decision notice start date", error);
-    }
-
-    @Test
-    public void givenAnEndDateIsAfterStartDate_thenDoNotDisplayAnError() {
-        sscsCaseData.setWriteFinalDecisionStartDate("2019-01-01");
-        sscsCaseData.setWriteFinalDecisionEndDate("2020-01-01");
-
-        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        assertEquals(0, response.getErrors().size());
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void throwsExceptionIfItCannotHandleTheAppeal() {
-        when(callback.getEvent()).thenReturn(EventType.APPEAL_RECEIVED);
-        handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
     }
 
     @NamedParameters("previewEndDateAndRateCombinations")
@@ -262,7 +137,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     private void setCommonPreviewParams(SscsCaseData sscsCaseData, String endDate) {
         sscsCaseData.setWriteFinalDecisionStartDate("2018-10-11");
         sscsCaseData.setWriteFinalDecisionEndDate(endDate);
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
         sscsCaseData.setWriteFinalDecisionReasonsForDecision("My reasons for decision");
         sscsCaseData.setWriteFinalDecisionTypeOfHearing("telephone");
@@ -301,7 +175,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(Arrays.asList("movingAround"));
         sscsCaseData.setPipWriteFinalDecisionMovingAroundQuestion("movingAround12d");
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -368,7 +242,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(Arrays.asList("preparingFood"));
         sscsCaseData.setPipWriteFinalDecisionPreparingFoodQuestion("preparingFood1f");
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -424,7 +298,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenDateOfDecisionNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
 
@@ -432,7 +305,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
 
@@ -443,7 +316,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenSignedInJudgeNameNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -453,7 +325,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to obtain signed in user name", error);
@@ -463,7 +335,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenSignedInJudgeUserDetailsNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -473,7 +344,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to obtain signed in user details", error);
@@ -483,7 +354,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenComparedToDwpMobilityQuestionNotSet_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
@@ -491,7 +361,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Outcome cannot be empty. Please check case data. If problem continues please contact support", error);
@@ -501,7 +371,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenComparedToDwpDailyLivingSetIncorrectly_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("someValue");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -511,7 +380,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Outcome cannot be empty. Please check case data. If problem continues please contact support", error);
@@ -521,7 +390,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenComparedToDwpMobilityQuestionSetIncorrectly_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("someValue");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -529,7 +397,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
 
@@ -538,19 +406,9 @@ public class WriteFinalDecisionMidEventHandlerTest {
     }
 
     @Test
-    public void givenGenerateNoticeSetToNo_willNotSetPreviewFile() {
-
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("No");
-
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-
-        assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
-    }
-
-    @Test
     public void givenGenerateNoticeNotSet_willNotSetPreviewFile() {
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
     }
@@ -558,7 +416,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithVenues_thenCorrectlySetHeldAtUsingTheFirstHearingInList() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -572,7 +429,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -592,7 +449,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoVenueName_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -606,7 +462,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to determine hearing venue", error);
@@ -617,7 +473,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoVenue_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -631,7 +486,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to determine hearing venue", error);
@@ -642,7 +497,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstHearingInListNull_thenDisplayAnErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -654,7 +508,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
 
         sscsCaseData.setHearings(Arrays.asList(hearing2, hearing1));
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to determine hearing date or venue", error);
@@ -665,7 +519,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoHearingDetails_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -678,7 +531,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to determine hearing date or venue", error);
@@ -689,7 +542,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithEmptyHearingsList_thenDefaultHearingData() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -697,7 +549,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = new ArrayList<>();
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertTrue(response.getErrors().isEmpty());
         DirectionOrDecisionIssuedTemplateBody payload = verifyTemplateBody(DirectionOrDecisionIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", "2018-10-10", true);
@@ -714,12 +566,11 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithNullHearingsList_thenDefaultHearingData() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
 
         assertTrue(response.getErrors().isEmpty());
@@ -737,7 +588,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithHearingDates_thenCorrectlySetTheHeldOnUsingTheFirstHearingInList() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -751,7 +601,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -772,7 +622,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstInListWithNoHearingDate_thenDisplayErrorAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -787,7 +636,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("Unable to determine hearing date", error);
@@ -797,7 +646,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithMultipleHearingsWithFirstHearingInListNull_thenDisplayTwoErrorsAndDoNotGenerateDocument() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -811,7 +659,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         List<Hearing> hearings = Arrays.asList(hearing2, hearing1);
         sscsCaseData.setHearings(hearings);
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNull(response.getData().getWriteFinalDecisionPreviewDocument());
 
@@ -825,7 +673,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithTwoPanelMembers_thenCorrectlySetTheHeldBefore() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -837,7 +684,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -858,7 +705,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithOnePanelMember_thenCorrectlySetTheHeldBefore() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -868,7 +714,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -890,7 +736,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithNoPanelMembers_thenCorrectlySetTheHeldBefore() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -898,7 +743,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
-        final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, USER_AUTHORISATION);
 
         assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
         assertEquals(DocumentLink.builder()
@@ -918,7 +763,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void scottishRpcWillShowAScottishImage() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -928,7 +772,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
         sscsCaseData.setHearings(Arrays.asList(Hearing.builder().value(HearingDetails.builder()
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
-        handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        service.preview(callback, USER_AUTHORISATION);
 
         verifyTemplateBody(DirectionOrDecisionIssuedTemplateBody.SCOTTISH_IMAGE, "Appellant Lastname", "2018-10-10", true);
     }
@@ -936,7 +780,6 @@ public class WriteFinalDecisionMidEventHandlerTest {
     @Test
     public void givenCaseWithAppointee_thenCorrectlySetTheNoticeNameWithAppellantAndAppointeeAppended() {
 
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("Yes");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpDailyLivingQuestion("higher");
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
         sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
@@ -952,7 +795,7 @@ public class WriteFinalDecisionMidEventHandlerTest {
             .hearingDate("2019-01-01").venue(Venue.builder().name("Venue Name").build()).build()).build()));
 
 
-        handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        service.preview(callback, USER_AUTHORISATION);
 
         verifyTemplateBody(DirectionOrDecisionIssuedTemplateBody.ENGLISH_IMAGE, "Appointee Surname, appointee for Appellant Lastname", "2018-10-10", true);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controller/CcdMideventCallbackControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controller/CcdMideventCallbackControllerTest.java
@@ -1,0 +1,94 @@
+package uk.gov.hmcts.reform.sscs.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.INTERLOC_INFORMATION_RECEIVED;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import junitparams.JUnitParamsRunner;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.rules.SpringClassRule;
+import org.springframework.test.context.junit4.rules.SpringMethodRule;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.deserialisation.SscsCaseCallbackDeserializer;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision.WriteFinalDecisionPreviewDecisionService;
+import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
+
+@SuppressWarnings("unchecked")
+@RunWith(JUnitParamsRunner.class)
+public class CcdMideventCallbackControllerTest {
+
+    // begin: needed to use spring runner and junitparamsRunner together
+    @ClassRule
+    public static final SpringClassRule SPRING_CLASS_RULE = new SpringClassRule();
+    public static final String JURISDICTION = "SSCS";
+    public static final long ID = 1234L;
+
+    @Rule
+    public final SpringMethodRule springMethodRule = new SpringMethodRule();
+
+    // end
+
+    private MockMvc mockMvc;
+
+    @SuppressWarnings("PMD.UnusedPrivateField")
+    @MockBean
+    private AuthorisationService authorisationService;
+
+    @MockBean
+    private SscsCaseCallbackDeserializer deserializer;
+
+    @MockBean
+    private WriteFinalDecisionPreviewDecisionService writeFinalDecisionPreviewDecisionService;
+
+    private CcdMideventCallbackController controller;
+
+    @Before
+    public void setUp() {
+        controller = new CcdMideventCallbackController(authorisationService, deserializer, writeFinalDecisionPreviewDecisionService);
+        mockMvc = standaloneSetup(controller).build();
+    }
+
+    @Test
+    public void handleCcdMidEventPreviewFinalDecisionAndUpdateCaseData() throws Exception {
+        String path = getClass().getClassLoader().getResource("sya/allDetailsForGeneratePdf.json").getFile();
+        String content = FileUtils.readFileToString(new File(path), StandardCharsets.UTF_8.name());
+
+        SscsCaseData sscsCaseData = SscsCaseData.builder().build();
+        when(deserializer.deserialize(content)).thenReturn(new Callback<>(
+                new CaseDetails<>(ID, JURISDICTION, State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now()),
+                Optional.empty(), INTERLOC_INFORMATION_RECEIVED, false));
+
+        PreSubmitCallbackResponse response = new PreSubmitCallbackResponse(SscsCaseData.builder().interlocReviewState("new_state").build());
+        when(writeFinalDecisionPreviewDecisionService.preview(any(), anyString()))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/ccdMidEventPreviewFinalDecision")
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("ServiceAuthorization", "")
+                .header("Authorization", "")
+                .content(content))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{'data': {'interlocReviewState': 'new_state'}}"));
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/AppellantStatementServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/AppellantStatementServiceTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/FooterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/FooterServiceTest.java
@@ -26,9 +26,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import uk.gov.hmcts.reform.document.domain.UploadResponse;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.pdf.PdfWatermarker;
 
 @RunWith(JUnitParamsRunner.class)
@@ -53,6 +51,8 @@ public class FooterServiceTest {
     @Mock private List<uk.gov.hmcts.reform.document.domain.Document> uploadedDocuments;
     private uk.gov.hmcts.reform.document.domain.Document uploadedDocument = new uk.gov.hmcts.reform.document.domain.Document();
 
+    private SscsCaseData sscsCaseData;
+
     private String fileName = "some-file.pdf";
     private String expectedDocumentUrl = "document-self-href";
     private String expectedBinaryUrl = "document-binary-href";
@@ -71,6 +71,29 @@ public class FooterServiceTest {
         when(uploadResponse.getEmbedded()).thenReturn(uploadResponseEmbedded);
         when(uploadResponseEmbedded.getDocuments()).thenReturn(uploadedDocuments);
         when(uploadedDocuments.get(0)).thenReturn(uploadedDocument);
+
+        SscsDocument document = SscsDocument.builder().value(SscsDocumentDetails.builder().documentFileName("myTest.doc").build()).build();
+        List<SscsDocument> docs = new ArrayList<>();
+        docs.add(document);
+
+        sscsCaseData = SscsCaseData.builder()
+                .generateNotice("Yes")
+                .signedBy("User")
+                .directionTypeDl(new DynamicList(DirectionType.APPEAL_TO_PROCEED.toString()))
+                .signedRole("Judge")
+                .dateAdded(LocalDate.now().minusDays(1))
+                .sscsDocument(docs)
+                .previewDocument(DocumentLink.builder()
+                        .documentUrl("dm-store/documents/123")
+                        .documentBinaryUrl("dm-store/documents/123/binary")
+                        .documentFilename("directionIssued.pdf")
+                        .build())
+                .appeal(Appeal.builder()
+                        .appellant(Appellant.builder()
+                                .name(Name.builder().build())
+                                .identity(Identity.builder().build())
+                                .build())
+                        .build()).build();
     }
 
     @Test
@@ -82,18 +105,20 @@ public class FooterServiceTest {
 
         when(pdfWatermarker.shrinkAndWatermarkPdf(any(), stringCaptor.capture(), stringCaptor.capture())).thenReturn(new byte[]{});
 
-        LocalDate now = LocalDate.now();
+        String now = LocalDate.now().toString();
 
-        SscsDocument result = footerService.createFooterDocument(DocumentLink.builder().documentUrl("MyUrl").build(), "leftText", "rightText",
-                "fileName.jpg", now, DocumentType.DIRECTION_NOTICE);
+        footerService.createFooterAndAddDocToCase(DocumentLink.builder().documentUrl("MyUrl").build(),
+                sscsCaseData, DocumentType.DIRECTION_NOTICE, now);
 
-        assertEquals(DocumentType.DIRECTION_NOTICE.getValue(), result.getValue().getDocumentType());
-        assertEquals("fileName.jpg", result.getValue().getDocumentFileName());
-        assertEquals(now.toString(), result.getValue().getDocumentDateAdded());
-        assertEquals(expectedDocumentUrl, result.getValue().getDocumentLink().getDocumentUrl());
+        assertEquals(2, sscsCaseData.getSscsDocument().size());
+        SscsDocumentDetails footerDoc = sscsCaseData.getSscsDocument().get(0).getValue();
+        assertEquals(DocumentType.DIRECTION_NOTICE.getValue(), footerDoc.getDocumentType());
+        assertEquals("Addition A - Directions Notice issued on " + now + ".pdf", footerDoc.getDocumentFileName());
+        assertEquals(LocalDate.now().minusDays(1).toString(), footerDoc.getDocumentDateAdded());
+        assertEquals(expectedDocumentUrl, footerDoc.getDocumentLink().getDocumentUrl());
         verify(evidenceManagementService).upload(any(), eq(DM_STORE_USER_ID));
-        assertEquals("leftText", stringCaptor.getAllValues().get(0));
-        assertEquals("Addition rightText", stringCaptor.getAllValues().get(1));
+        assertEquals("Directions Notice", stringCaptor.getAllValues().get(0));
+        assertEquals("Addition A", stringCaptor.getAllValues().get(1));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/TribunalsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/TribunalsServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/evidence/EvidenceUploadServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/evidence/EvidenceUploadServiceTest.java
@@ -3,7 +3,7 @@ package uk.gov.hmcts.reform.sscs.service.evidence;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.AdditionalMatchers.and;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/util/PostcodeUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/util/PostcodeUtilTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscs.util;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/resources/callback/decisionIssuedManualInterloc.json
+++ b/src/test/resources/callback/decisionIssuedManualInterloc.json
@@ -24,22 +24,18 @@
     ],
     "security_classification": "PUBLIC",
     "case_data": {
-      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
-      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
-      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
-      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
-      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
-      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
-      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
-      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
-      "writeFinalDecisionDateOfDecision" : "2018-09-01",
-      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
-      "writeFinalDecisionEndDate": "2018-11-10",
-      "writeFinalDecisionReasonsForDecision" : "My reasons for decision",
-      "writeFinalDecisionPreviewDocument": {
-        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
-        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
-        "document_filename": "decisionIssued.pdf"
+      "generateNotice" : "Yes",
+      "bodyContent": "Hello, you have been instructed to provide further information. Please do so at your earliest convenience.",
+      "signedBy": "Maple Magoo",
+      "signedRole": "Proxy Judge",
+      "decisionType": "strikeOut",
+      "sscsInterlocDecisionDocument": {
+        "documentDateAdded": "2018-02-09",
+        "documentLink": {
+          "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+          "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+          "document_filename": "sscsInterlocDecisionDocument.pdf"
+        }
       },
       "dwpTimeExtension": [
       ],
@@ -48,35 +44,23 @@
         {
           "value": {
             "venue": {
-              "name": "Chester Magistrate's Court",
-              "address": {
-                "line1": "Chester Magistrate's Court",
-                "line2": "Grosvenor Street",
-                "town": "Chester",
-                "postcode": "CH1 2XA"
-              },
-              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
-            },
-            "hearingDate": "2017-07-17",
-            "time": "23:00"
-          }
-        },
-        {
-          "value": {
-            "venue": {
               "name": "Prudential House",
               "address": {
-                "line1": "36 Dale Street",
+                "line1": "2-10 Topping Street",
                 "line2": "",
-                "town": "Liverpool",
-                "postcode": "L2 5UZ"
+                "town": "Blackpool",
+                "county": "",
+                "postcode": "FY1 3AB"
               },
-              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+              "googleMapLink": "https://www.google.com/maps/place/2-10+Topping+Street+Blackpool+FY1+3AB/@53.820175,-3.050717"
             },
-            "hearingDate": "2017-07-12",
-            "time": "23:00",
-            "eventDate": "2017-06-24T18:11:34.013"
-          }
+            "hearingDate": "2018-06-01",
+            "time": "11:40:00",
+            "adjourned": "No",
+            "eventDate": null,
+            "hearingId": "3698764"
+          },
+          "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
         }
       ],
       "subscriptions": {
@@ -97,34 +81,46 @@
           "tya": ""
         }
       },
-      "sscsDocument": [
+      "sscsDocument" : [ {
+        "value" : {
+          "documentType" : "appellantEvidence",
+          "documentFileName" : "11111.pdf",
+          "documentDateAdded" : "2018-10-10",
+          "evidenceIssued": "Yes",
+          "documentLink" : {
+            "document_url" : "http://www.bbc.com",
+            "document_binary_url" : "http://www.bbc.com/binary",
+            "document_filename" : "myfile1.jpg"
+          }
+        }
+      },
         {
-          "value": {
-            "documentType": "appellantEvidence",
-            "documentFileName": "11111.pdf",
-            "documentDateAdded": "2018-10-10",
+          "value" : {
+            "documentType" : "representativeEvidence",
+            "documentFileName" : "22222.pdf",
+            "documentDateAdded" : "2018-10-11",
             "evidenceIssued": "Yes",
-            "documentLink": {
-              "document_url": "http://www.bbc.com",
-              "document_binary_url": "http://www.bbc.com/binary",
-              "document_filename": "myfile1.jpg"
+            "documentLink" : {
+              "document_url" : "http://www.itv.com",
+              "document_binary_url" : "http://www.itv.com/binary",
+              "document_filename" : "myfile2.jpg"
             }
           }
         },
         {
-          "value": {
-            "documentType": "representativeEvidence",
-            "documentFileName": "22222.pdf",
-            "documentDateAdded": "2018-10-11",
+          "value" : {
+            "documentType" : "decisionIssued",
+            "documentFileName" : "oldDecisionIssued.pdf",
+            "documentDateAdded" : "2018-10-12",
             "evidenceIssued": "Yes",
-            "documentLink": {
-              "document_url": "http://www.itv.com",
-              "document_binary_url": "http://www.itv.com/binary",
-              "document_filename": "myfile2.jpg"
+            "bundleAddition": "A",
+            "documentLink" : {
+              "document_url" : "http://www.itv3.com",
+              "document_binary_url" : "http://www.itv3.com/binary",
+              "document_filename" : "myfile3.jpg"
             }
           }
-        }
-      ],
+        }],
       "reissueFurtherEvidenceDocument": {},
       "resendToAppellant": "NO",
       "resendToRepresentative": "NO",
@@ -254,72 +250,38 @@
         ]
       },
       "generatedNino": "PUBLIC",
-      "hearings": [
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
               },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        },
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
-              },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        }
-      ],
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
       "subscriptions": {
         "classification": "PUBLIC",
         "value": {
@@ -496,72 +458,38 @@
         ]
       },
       "generatedNino": "PUBLIC",
-      "hearings": [
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
               },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        },
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
-              },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        }
-      ],
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
       "subscriptions": {
         "classification": "PUBLIC",
         "value": {
@@ -752,19 +680,12 @@
     ],
     "security_classification": "PUBLIC",
     "case_data": {
-      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
-      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
-      "writeFinalDecisionDateOfDecision" : "2018-09-01",
-      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
-      "writeFinalDecisionEndDate": "2018-11-10",
-      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
-      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
-      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
-      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
-      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
-      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
-      "writeFinalDecisionReasonsForDecision" : "My reasons for decision",
-      "writeFinalDecisionPreviewDocument": {
+      "generateNotice" : "Yes",
+      "bodyContent": "Hello, you have been instructed to provide further information. Please do so at your earliest convenience.",
+      "signedBy": "Maple Magoo",
+      "signedRole": "Proxy Judge",
+      "decisionType": "strikeOut",
+      "previewDocument" : {
         "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
         "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
         "document_filename": "decisionIssued.pdf"
@@ -776,35 +697,23 @@
         {
           "value": {
             "venue": {
-              "name": "Chester Magistrate's Court",
-              "address": {
-                "line1": "Chester Magistrate's Court",
-                "line2": "Grosvenor Street",
-                "town": "Chester",
-                "postcode": "CH1 2XA"
-              },
-              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
-            },
-            "hearingDate": "2017-07-17",
-            "time": "23:00"
-          }
-        },
-        {
-          "value": {
-            "venue": {
               "name": "Prudential House",
               "address": {
-                "line1": "36 Dale Street",
+                "line1": "2-10 Topping Street",
                 "line2": "",
-                "town": "Liverpool",
-                "postcode": "L2 5UZ"
+                "town": "Blackpool",
+                "county": "",
+                "postcode": "FY1 3AB"
               },
-              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+              "googleMapLink": "https://www.google.com/maps/place/2-10+Topping+Street+Blackpool+FY1+3AB/@53.820175,-3.050717"
             },
-            "hearingDate": "2017-07-12",
-            "time": "23:00",
-            "eventDate": "2017-06-24T18:11:34.013"
-          }
+            "hearingDate": "2018-06-01",
+            "time": "11:40:00",
+            "adjourned": "No",
+            "eventDate": null,
+            "hearingId": "3698764"
+          },
+          "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
         }
       ],
       "subscriptions": {
@@ -825,34 +734,46 @@
           "tya": ""
         }
       },
-      "sscsDocument": [
+      "sscsDocument" : [ {
+        "value" : {
+          "documentType" : "appellantEvidence",
+          "documentFileName" : "11111.pdf",
+          "documentDateAdded" : "2018-10-10",
+          "evidenceIssued": "Yes",
+          "documentLink" : {
+            "document_url" : "http://www.bbc.com",
+            "document_binary_url" : "http://www.bbc.com/binary",
+            "document_filename" : "myfile1.jpg"
+          }
+        }
+      },
         {
-          "value": {
-            "documentType": "appellantEvidence",
-            "documentFileName": "11111.pdf",
-            "documentDateAdded": "2018-10-10",
+          "value" : {
+            "documentType" : "representativeEvidence",
+            "documentFileName" : "22222.pdf",
+            "documentDateAdded" : "2018-10-11",
             "evidenceIssued": "Yes",
-            "documentLink": {
-              "document_url": "http://www.bbc.com",
-              "document_binary_url": "http://www.bbc.com/binary",
-              "document_filename": "myfile1.jpg"
+            "documentLink" : {
+              "document_url" : "http://www.itv.com",
+              "document_binary_url" : "http://www.itv.com/binary",
+              "document_filename" : "myfile2.jpg"
             }
           }
         },
         {
-          "value": {
-            "documentType": "representativeEvidence",
-            "documentFileName": "22222.pdf",
-            "documentDateAdded": "2018-10-11",
+          "value" : {
+            "documentType" : "decisionIssued",
+            "documentFileName" : "oldDecisionIssued.pdf",
+            "documentDateAdded" : "2018-10-12",
             "evidenceIssued": "Yes",
-            "documentLink": {
-              "document_url": "http://www.itv.com",
-              "document_binary_url": "http://www.itv.com/binary",
-              "document_filename": "myfile2.jpg"
+            "bundleAddition": "A",
+            "documentLink" : {
+              "document_url" : "http://www.itv3.com",
+              "document_binary_url" : "http://www.itv3.com/binary",
+              "document_filename" : "myfile3.jpg"
             }
           }
-        }
-      ],
+        }],
       "reissueFurtherEvidenceDocument": {},
       "resendToAppellant": "NO",
       "resendToRepresentative": "NO",
@@ -982,72 +903,38 @@
         ]
       },
       "generatedNino": "PUBLIC",
-      "hearings": [
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
               },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        },
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
-              },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        }
-      ],
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
       "subscriptions": {
         "classification": "PUBLIC",
         "value": {
@@ -1224,72 +1111,38 @@
         ]
       },
       "generatedNino": "PUBLIC",
-      "hearings": [
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
               },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        },
-        {
-          "classification": "PUBLIC",
-          "value": [
-            {
-              "value": {
-                "venue": {
-                  "classification": "PUBLIC",
-                  "value": {
-                    "name": "PUBLIC",
-                    "address": {
-                      "classification": "PUBLIC",
-                      "value": {
-                        "line1": "PUBLIC",
-                        "line2": "PUBLIC",
-                        "town": "PUBLIC",
-                        "county": "PUBLIC",
-                        "postcode": "PUBLIC"
-                      }
-                    },
-                    "googleMapLink": "PUBLIC"
-                  }
-                },
-                "hearingDate": "PUBLIC",
-                "time": "PUBLIC",
-                "adjourned": "PUBLIC",
-                "eventDate": "PUBLIC",
-                "hearingId": "PUBLIC"
-              },
-              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
-            }
-          ]
-        }
-      ],
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
       "subscriptions": {
         "classification": "PUBLIC",
         "value": {
@@ -1455,5 +1308,5 @@
       }
     }
   },
-  "event_id": "writeFinalDecision"
+  "event_id": "decisionIssued"
 }

--- a/src/test/resources/callback/directionIssuedManualInterloc.json
+++ b/src/test/resources/callback/directionIssuedManualInterloc.json
@@ -1,0 +1,660 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "directionTypeDl": "provideInformation",
+      "generateNotice" : "Yes",
+      "bodyContent": "Hello, you have been instructed to provide further information. Please do so at your earliest convenience.",
+      "signedBy": "Maple Magoo",
+      "signedRole": "Proxy Judge",
+      "sscsInterlocDirectionDocument": {
+        "documentDateAdded": "2018-02-09",
+        "documentLink": {
+          "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+          "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+          "document_filename": "sscsInterlocDirectionDocument.pdf"
+        }
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "2-10 Topping Street",
+                "line2": "",
+                "town": "Blackpool",
+                "county": "",
+                "postcode": "FY1 3AB"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/2-10+Topping+Street+Blackpool+FY1+3AB/@53.820175,-3.050717"
+            },
+            "hearingDate": "2018-06-01",
+            "time": "11:40:00",
+            "adjourned": "No",
+            "eventDate": null,
+            "hearingId": "3698764"
+          },
+          "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument" : [ {
+        "value" : {
+          "documentType" : "appellantEvidence",
+          "documentFileName" : "11111.pdf",
+          "documentDateAdded" : "2018-10-10",
+          "evidenceIssued": "Yes",
+          "documentLink" : {
+            "document_url" : "http://www.bbc.com",
+            "document_binary_url" : "http://www.bbc.com/binary",
+            "document_filename" : "myfile1.jpg"
+          }
+        }
+      },
+        {
+          "value" : {
+            "documentType" : "representativeEvidence",
+            "documentFileName" : "22222.pdf",
+            "documentDateAdded" : "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink" : {
+              "document_url" : "http://www.itv.com",
+              "document_binary_url" : "http://www.itv.com/binary",
+              "document_filename" : "myfile2.jpg"
+            }
+          }
+        },
+        {
+          "value" : {
+            "documentType" : "directionIssued",
+            "documentFileName" : "oldDirectionIssued.pdf",
+            "documentDateAdded" : "2018-10-12",
+            "evidenceIssued": "Yes",
+            "bundleAddition": "A",
+            "documentLink" : {
+              "document_url" : "http://www.itv3.com",
+              "document_binary_url" : "http://www.itv3.com/binary",
+              "document_filename" : "myfile3.jpg"
+            }
+          }
+        }],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {},
+      "extensionNextEventDl": "sendToListing"
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
+              },
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "venue": {
+                "classification": "PUBLIC",
+                "value": {
+                  "name": "PUBLIC",
+                  "address": {
+                    "classification": "PUBLIC",
+                    "value": {
+                      "line1": "PUBLIC",
+                      "line2": "PUBLIC",
+                      "town": "PUBLIC",
+                      "county": "PUBLIC",
+                      "postcode": "PUBLIC"
+                    }
+                  },
+                  "googleMapLink": "PUBLIC"
+                }
+              },
+              "hearingDate": "PUBLIC",
+              "time": "PUBLIC",
+              "adjourned": "PUBLIC",
+              "eventDate": "PUBLIC",
+              "hearingId": "PUBLIC"
+            },
+            "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+          }
+        ]
+      },
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "directionIssued"
+}

--- a/src/test/resources/callback/issueFinalDecisionCallback.json
+++ b/src/test/resources/callback/issueFinalDecisionCallback.json
@@ -29,11 +29,6 @@
       "signedBy": "Maple Magoo",
       "signedRole": "Proxy Judge",
       "decisionType": "strikeOut",
-      "previewDocument" : {
-        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
-        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
-        "document_filename": "decisionIssued.pdf"
-      },
       "dwpTimeExtension": [
       ],
       "generatedNino": "JT 12 34 56 D",
@@ -90,33 +85,33 @@
           }
         }
       },
-        {
-          "value" : {
-            "documentType" : "representativeEvidence",
-            "documentFileName" : "22222.pdf",
-            "documentDateAdded" : "2018-10-11",
-            "evidenceIssued": "Yes",
-            "documentLink" : {
-              "document_url" : "http://www.itv.com",
-              "document_binary_url" : "http://www.itv.com/binary",
-              "document_filename" : "myfile2.jpg"
-            }
+      {
+        "value" : {
+          "documentType" : "representativeEvidence",
+          "documentFileName" : "22222.pdf",
+          "documentDateAdded" : "2018-10-11",
+          "evidenceIssued": "Yes",
+          "documentLink" : {
+            "document_url" : "http://www.itv.com",
+            "document_binary_url" : "http://www.itv.com/binary",
+            "document_filename" : "myfile2.jpg"
           }
-        },
-        {
-          "value" : {
-            "documentType" : "decisionIssued",
-            "documentFileName" : "oldDecisionIssued.pdf",
-            "documentDateAdded" : "2018-10-12",
-            "evidenceIssued": "Yes",
-            "bundleAddition": "A",
-            "documentLink" : {
-              "document_url" : "http://www.itv3.com",
-              "document_binary_url" : "http://www.itv3.com/binary",
-              "document_filename" : "myfile3.jpg"
-            }
+        }
+      },
+      {
+        "value" : {
+          "documentType" : "decisionIssued",
+          "documentFileName" : "oldDecisionIssued.pdf",
+          "documentDateAdded" : "2018-10-12",
+          "evidenceIssued": "Yes",
+          "bundleAddition": "A",
+          "documentLink" : {
+            "document_url" : "http://www.itv3.com",
+            "document_binary_url" : "http://www.itv3.com/binary",
+            "document_filename" : "myfile3.jpg"
           }
-        }],
+        }
+      }],
       "reissueFurtherEvidenceDocument": {},
       "resendToAppellant": "NO",
       "resendToRepresentative": "NO",


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-7617

- Add footer to the final decision notice document
- There was duplicated code around the footer in Directions and Decision notices so moved into a generic method in FooterService
- Added a new mid event callback handler to split the logic for previewing a decision and validating the data for a decision. This means that we only generate the decision when required.
- Removed the writeFinalDecisonGenerateNotice field (after above change) as this is no longer required. It also means there is always a draft decision on the case when we come to adding the footer. 
- Some unit tests around Directions and Decision Notices moved to integration tests as cover the end to end process. No point mocking some of the generic functionality that was moved to the FooterService, IMO