### PR TITLE
SSCS-7730 - CCD UI – Have directionIssued validate prior to submitting the event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -261,7 +261,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'doc-assembly-client', version: '1.0.4'
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.4'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.3.10'
+    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.3.13'
 
     testCompile group: 'io.rest-assured', name: 'rest-assured'
 

--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,6 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.3.17'
     compile group: 'uk.gov.hmcts.reform', name: 'sscs-pdf-email-common', version: '1.4.4'
-    compile group: 'uk.gov.hmcts.reform', name: 'sscs-common', version: '3.3.13'
 
     testCompile group: 'io.rest-assured', name: 'rest-assured'
 

--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.16
+version: 0.0.17
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team

--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.17
+version: 0.0.18
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team

--- a/charts/sscs-tribunals-api/values.yaml
+++ b/charts/sscs-tribunals-api/values.yaml
@@ -46,6 +46,7 @@ java:
     CORE_CASE_DATA_API_URL: "http://ccd-data-store-api-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     DOCUMENT_MANAGEMENT_URL: "http://dm-store-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     IDAM_S2S_AUTH: "http://rpe-service-auth-provider-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
+    BULK_SCAN_URL: "http://sscs-bulk-scan-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     IDAM_API_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net
     IDAM_API_JWK_URL: https://idam-api.{{ .Values.global.environment }}.platform.hmcts.net/jwks
     BUNDLE_URL: http://em-ccd-orchestrator-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createbundle/CreateBundleAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createbundle/CreateBundleAboutToStartHandler.java
@@ -15,21 +15,21 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
-import uk.gov.hmcts.reform.sscs.service.BundleRequestExecutor;
+import uk.gov.hmcts.reform.sscs.service.ServiceRequestExecutor;
 
 @Service
 public class CreateBundleAboutToStartHandler implements PreSubmitCallbackHandler<SscsCaseData> {
 
-    private BundleRequestExecutor bundleRequestExecutor;
+    private ServiceRequestExecutor serviceRequestExecutor;
 
     private String bundleUrl;
 
     private static String CREATE_BUNDLE_ENDPOINT = "/api/new-bundle";
 
     @Autowired
-    public CreateBundleAboutToStartHandler(BundleRequestExecutor bundleRequestExecutor,
+    public CreateBundleAboutToStartHandler(ServiceRequestExecutor serviceRequestExecutor,
                                            @Value("${bundle.url}") String bundleUrl) {
-        this.bundleRequestExecutor = bundleRequestExecutor;
+        this.serviceRequestExecutor = serviceRequestExecutor;
         this.bundleUrl = bundleUrl;
     }
 
@@ -73,7 +73,7 @@ public class CreateBundleAboutToStartHandler implements PreSubmitCallbackHandler
                     }
                 }
             }
-            return bundleRequestExecutor.post(callback, bundleUrl + CREATE_BUNDLE_ENDPOINT);
+            return serviceRequestExecutor.post(callback, bundleUrl + CREATE_BUNDLE_ENDPOINT);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.directionissued;
 
+import static org.apache.commons.lang3.StringUtils.trimToEmpty;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState.AWAITING_ADMIN_ACTION;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState.AWAITING_INFORMATION;
 import static uk.gov.hmcts.reform.sscs.helper.SscsHelper.getPreValidStates;
@@ -9,7 +10,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
@@ -19,16 +22,23 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.IssueDocumentHandler;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.service.FooterService;
+import uk.gov.hmcts.reform.sscs.service.ServiceRequestExecutor;
 
 @Service
 @Slf4j
 public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler implements PreSubmitCallbackHandler<SscsCaseData> {
 
     private final FooterService footerService;
+    private final ServiceRequestExecutor serviceRequestExecutor;
+    private String bulkScanEndpoint;
 
     @Autowired
-    public DirectionIssuedAboutToSubmitHandler(FooterService footerService) {
+    public DirectionIssuedAboutToSubmitHandler(FooterService footerService, ServiceRequestExecutor serviceRequestExecutor,
+                                               @Value("${bulk_scan.url}") String bulkScanUrl,
+                                               @Value("${bulk_scan.validateEndpoint}") String validateEndpoint) {
         this.footerService = footerService;
+        this.serviceRequestExecutor = serviceRequestExecutor;
+        this.bulkScanEndpoint = String.format("%s%s", trimToEmpty(bulkScanUrl), trimToEmpty(validateEndpoint));
     }
 
     @Override
@@ -42,7 +52,8 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
     @Override
     public PreSubmitCallbackResponse<SscsCaseData> handle(CallbackType callbackType, Callback<SscsCaseData> callback, String userAuthorisation) {
 
-        SscsCaseData caseData = callback.getCaseDetails().getCaseData();
+        CaseDetails<SscsCaseData> caseDetails = callback.getCaseDetails();
+        SscsCaseData caseData = caseDetails.getCaseData();
 
         if (caseData.getDirectionTypeDl() == null || caseData.getDirectionTypeDl().getValue() == null) {
             PreSubmitCallbackResponse<SscsCaseData> errorResponse = new PreSubmitCallbackResponse<>(caseData);
@@ -51,7 +62,7 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
         }
 
         DocumentLink url = null;
-        if (Objects.nonNull(callback.getCaseDetails().getCaseData().getPreviewDocument())) {
+        if (Objects.nonNull(caseData.getPreviewDocument())) {
             url = caseData.getPreviewDocument();
         } else {
             if (caseData.getSscsInterlocDirectionDocument() != null) {
@@ -62,7 +73,7 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
 
         if (DirectionType.PROVIDE_INFORMATION.toString().equals(caseData.getDirectionTypeDl().getValue().getCode())) {
             caseData.setInterlocReviewState(AWAITING_INFORMATION.getId());
-        } else if (getPreValidStates().contains(callback.getCaseDetails().getState()) && DirectionType.APPEAL_TO_PROCEED.toString().equals(caseData.getDirectionTypeDl().getValue().getCode())) {
+        } else if (getPreValidStates().contains(caseDetails.getState()) && DirectionType.APPEAL_TO_PROCEED.toString().equals(caseData.getDirectionTypeDl().getValue().getCode())) {
             caseData.setDateSentToDwp(LocalDate.now().toString());
             caseData.setInterlocReviewState(AWAITING_ADMIN_ACTION.getId());
         } else if (DirectionType.REFUSE_EXTENSION.toString().equals(caseData.getDirectionTypeDl().getValue().getCode())
@@ -88,6 +99,12 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
         caseData.setTimeExtensionRequested("No");
 
         PreSubmitCallbackResponse<SscsCaseData> sscsCaseDataPreSubmitCallbackResponse = new PreSubmitCallbackResponse<>(caseData);
+
+        if (caseDetails.getState().equals(State.INTERLOCUTORY_REVIEW_STATE) && caseData.getDirectionTypeDl() != null && StringUtils.equals(DirectionType.APPEAL_TO_PROCEED.toString(), caseData.getDirectionTypeDl().getValue().getCode())) {
+            // do something
+            PreSubmitCallbackResponse<SscsCaseData> response = serviceRequestExecutor.post(callback, bulkScanEndpoint);
+            sscsCaseDataPreSubmitCallbackResponse.addErrors(response.getErrors());
+        }
         log.info("Saved the new interloc direction document for case id: " + caseData.getCcdCaseId());
 
         return sscsCaseDataPreSubmitCallbackResponse;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/directionissued/DirectionIssuedAboutToSubmitHandler.java
@@ -101,7 +101,6 @@ public class DirectionIssuedAboutToSubmitHandler extends IssueDocumentHandler im
         PreSubmitCallbackResponse<SscsCaseData> sscsCaseDataPreSubmitCallbackResponse = new PreSubmitCallbackResponse<>(caseData);
 
         if (caseDetails.getState().equals(State.INTERLOCUTORY_REVIEW_STATE) && caseData.getDirectionTypeDl() != null && StringUtils.equals(DirectionType.APPEAL_TO_PROCEED.toString(), caseData.getDirectionTypeDl().getValue().getCode())) {
-            // do something
             PreSubmitCallbackResponse<SscsCaseData> response = serviceRequestExecutor.post(callback, bulkScanEndpoint);
             sscsCaseDataPreSubmitCallbackResponse.addErrors(response.getErrors());
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/editbundle/EditBundleAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/editbundle/EditBundleAboutToStartHandler.java
@@ -13,20 +13,20 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
-import uk.gov.hmcts.reform.sscs.service.BundleRequestExecutor;
+import uk.gov.hmcts.reform.sscs.service.ServiceRequestExecutor;
 
 @Service
 public class EditBundleAboutToStartHandler implements PreSubmitCallbackHandler<SscsCaseData> {
 
-    private BundleRequestExecutor bundleRequestExecutor;
+    private ServiceRequestExecutor serviceRequestExecutor;
     private String bundleUrl;
 
     private static String EDIT_BUNDLE_ENDPOINT = "/api/stitch-ccd-bundles";
 
     @Autowired
-    public EditBundleAboutToStartHandler(BundleRequestExecutor bundleRequestExecutor,
+    public EditBundleAboutToStartHandler(ServiceRequestExecutor serviceRequestExecutor,
                                          @Value("${bundle.url}") String bundleUrl) {
-        this.bundleRequestExecutor = bundleRequestExecutor;
+        this.serviceRequestExecutor = serviceRequestExecutor;
         this.bundleUrl = bundleUrl;
     }
 
@@ -67,7 +67,7 @@ public class EditBundleAboutToStartHandler implements PreSubmitCallbackHandler<S
                 preSubmitCallbackResponse.addWarning("No bundle selected to be amended. The stitched PDF will not be updated. Are you sure you want to continue?");
                 return preSubmitCallbackResponse;
             } else {
-                return bundleRequestExecutor.post(callback, bundleUrl + EDIT_BUNDLE_ENDPOINT);
+                return serviceRequestExecutor.post(callback, bundleUrl + EDIT_BUNDLE_ENDPOINT);
             }
         } else {
             return null;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/ServiceRequestExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/ServiceRequestExecutor.java
@@ -20,7 +20,7 @@ import uk.gov.hmcts.reform.sscs.service.exceptions.DocumentServiceResponseExcept
 
 @Slf4j
 @Service
-public class BundleRequestExecutor {
+public class ServiceRequestExecutor {
 
     private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
 
@@ -28,7 +28,7 @@ public class BundleRequestExecutor {
     private final AuthTokenGenerator serviceAuthTokenGenerator;
     private final IdamService idamService;
 
-    public BundleRequestExecutor(RestTemplate restTemplate, AuthTokenGenerator serviceAuthTokenGenerator, IdamService idamService) {
+    public ServiceRequestExecutor(RestTemplate restTemplate, AuthTokenGenerator serviceAuthTokenGenerator, IdamService idamService) {
         this.restTemplate = restTemplate;
         this.serviceAuthTokenGenerator = serviceAuthTokenGenerator;
         this.idamService = idamService;
@@ -48,13 +48,14 @@ public class BundleRequestExecutor {
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
         headers.set(HttpHeaders.AUTHORIZATION, idamService.getIdamOauth2Token());
+        headers.set("user-id", idamService.getIdamTokens().getUserId());
         headers.set(SERVICE_AUTHORIZATION, serviceAuthorizationToken);
 
         HttpEntity<Callback<SscsCaseData>> requestEntity = new HttpEntity<>(payload, headers);
 
         PreSubmitCallbackResponse<SscsCaseData> response;
 
-        log.info("About to hit bundling service with url: " + endpoint + " for case id: " + payload.getCaseDetails().getId());
+        log.info("About to hit the service with url: " + endpoint + " for case id: " + payload.getCaseDetails().getId());
 
         try {
             response =
@@ -68,7 +69,7 @@ public class BundleRequestExecutor {
                     ).getBody();
 
         } catch (RestClientResponseException e) {
-            throw new DocumentServiceResponseException("Couldn't create bundle using API: ", e);
+            throw new DocumentServiceResponseException("Couldn't call service using API: ", e);
         }
 
         return response;

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -60,6 +60,10 @@ docmosis.uri=${PDF_SERVICE_BASE_URL:https://docmosis-development.platform.hmcts.
 evidenceCoverSheet.docmosis.template=TB-SCS-GNO-ENG-00012.docx
 evidenceCoverSheet.docmosis.hmctsImgVal="[userImage:hmcts.png]"
 
+#BulkScan
+bulk_scan.url=${BULK_SCAN_URL:http://localhost:8090}
+bulk_scan.validateEndpoint=/validate-record
+
 #Management
 management.endpoints.web.base-path=/
 management.endpoint.health.show-details=always

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createbundle/CreateBundleAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createbundle/CreateBundleAboutToStartHandlerTest.java
@@ -19,7 +19,7 @@ import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
-import uk.gov.hmcts.reform.sscs.service.BundleRequestExecutor;
+import uk.gov.hmcts.reform.sscs.service.ServiceRequestExecutor;
 
 @RunWith(JUnitParamsRunner.class)
 public class CreateBundleAboutToStartHandlerTest {
@@ -34,14 +34,14 @@ public class CreateBundleAboutToStartHandlerTest {
     private CaseDetails<SscsCaseData> caseDetails;
 
     @Mock
-    private BundleRequestExecutor bundleRequestExecutor;
+    private ServiceRequestExecutor serviceRequestExecutor;
 
     private SscsCaseData sscsCaseData;
 
     @Before
     public void setUp() {
         initMocks(this);
-        handler = new CreateBundleAboutToStartHandler(bundleRequestExecutor, "bundleUrl.com");
+        handler = new CreateBundleAboutToStartHandler(serviceRequestExecutor, "bundleUrl.com");
 
         when(callback.getEvent()).thenReturn(EventType.CREATE_BUNDLE);
 
@@ -49,7 +49,7 @@ public class CreateBundleAboutToStartHandlerTest {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-        when(bundleRequestExecutor.post(any(), any())).thenReturn(new PreSubmitCallbackResponse<>(sscsCaseData));
+        when(serviceRequestExecutor.post(any(), any())).thenReturn(new PreSubmitCallbackResponse<>(sscsCaseData));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class CreateBundleAboutToStartHandlerTest {
 
         handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        verify(bundleRequestExecutor).post(callback, "bundleUrl.com/api/new-bundle");
+        verify(serviceRequestExecutor).post(callback, "bundleUrl.com/api/new-bundle");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/editbundle/EditBundleAboutToStartTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/editbundle/EditBundleAboutToStartTest.java
@@ -16,7 +16,7 @@ import org.mockito.Mock;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
-import uk.gov.hmcts.reform.sscs.service.BundleRequestExecutor;
+import uk.gov.hmcts.reform.sscs.service.ServiceRequestExecutor;
 
 @RunWith(JUnitParamsRunner.class)
 public class EditBundleAboutToStartTest {
@@ -31,14 +31,14 @@ public class EditBundleAboutToStartTest {
     private CaseDetails<SscsCaseData> caseDetails;
 
     @Mock
-    private BundleRequestExecutor bundleRequestExecutor;
+    private ServiceRequestExecutor serviceRequestExecutor;
 
     private SscsCaseData sscsCaseData;
 
     @Before
     public void setUp() {
         initMocks(this);
-        handler = new EditBundleAboutToStartHandler(bundleRequestExecutor, "bundleUrl.com");
+        handler = new EditBundleAboutToStartHandler(serviceRequestExecutor, "bundleUrl.com");
 
         when(callback.getEvent()).thenReturn(EventType.EDIT_BUNDLE);
 
@@ -46,7 +46,7 @@ public class EditBundleAboutToStartTest {
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
-        when(bundleRequestExecutor.post(any(), any())).thenReturn(new PreSubmitCallbackResponse<>(sscsCaseData));
+        when(serviceRequestExecutor.post(any(), any())).thenReturn(new PreSubmitCallbackResponse<>(sscsCaseData));
     }
 
     @Test
@@ -118,7 +118,7 @@ public class EditBundleAboutToStartTest {
         callback.getCaseDetails().getCaseData().setCaseBundles(bundles);
         handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        verify(bundleRequestExecutor).post(callback, "bundleUrl.com/api/stitch-ccd-bundles");
+        verify(serviceRequestExecutor).post(callback, "bundleUrl.com/api/stitch-ccd-bundles");
     }
 
     @Test
@@ -136,7 +136,7 @@ public class EditBundleAboutToStartTest {
                 .orElse("");
         assertEquals("No bundle selected to be amended. The stitched PDF will not be updated. Are you sure you want to continue?", warning);
 
-        verifyNoInteractions(bundleRequestExecutor);
+        verifyNoInteractions(serviceRequestExecutor);
     }
 
     @Test
@@ -149,7 +149,7 @@ public class EditBundleAboutToStartTest {
         callback.getCaseDetails().getCaseData().setCaseBundles(bundles);
         handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        verify(bundleRequestExecutor).post(callback, "bundleUrl.com/api/stitch-ccd-bundles");
+        verify(serviceRequestExecutor).post(callback, "bundleUrl.com/api/stitch-ccd-bundles");
     }
 
     @Test


### PR DESCRIPTION
At the moment we are getting exceptions when users are doing the directionIssued event and they have selected “appealToProcceed” for the directionTypeDl, when the event is submitted this, then makes a call for the “appealToProceed” event to trigger. 

The exception occurs when the event is submitted and there is some data which causes the bulk scan validation to fail, all of which happens asynchronously, so the user is unaware that their case hasn’t progressed.

As part of the investigation into the issue that was seen against SSCS-7695, we want to hit the bulk scan OCR validation end point during the about to submit callback for the direction issued event, if they have selected the “appeal to proceed” direction type, if the validation were to then fail, then the error should be displayed back to the user.

The errors from the screenshot below are propagated from sscs-bulk-scan.

<img width="923" alt="Screenshot 2020-06-30 at 10 14 06" src="https://user-images.githubusercontent.com/369407/86136065-88948a00-bae3-11ea-86b5-02ea719f2ae8.png">
