### PR TITLE
SSCS-7854 Adding workaround for RDM-8200 to set the generated dates on the AboutToSubmit handlers

### DIFF
--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/AdjournCaseIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/AdjournCaseIt.java
@@ -151,14 +151,14 @@ public class AdjournCaseIt extends AbstractEventIt {
     }
 
     /**
-     * This test asserts that if the (correclty set) generated date referenced by the preview document
-     * is submitted as part of the payload to the AdjournCaseAboutToSubmit handler,
-     * then that same date is set on the case data after the AdjournCaseAboutToSubmitHandler
-     * is called.
+     * This test asserts that whatever the value of the existing generated date from CCD
+     * submitted as part of the payload to the AdjournCaseAboutToSubmitHandler,
+     * then that date is updated to now() after the AdjournCaseAboutToSubmitHandler is called.
+     * This is due to a workaround we have implemented in the AdjournCaseAboutToSubmitHandler
      *
      */
     @Test
-    public void callToAboutToSubmitHandler_willWriteAdjournNoticeToCaseWithProvidedGeneratedDateWhenGeneratedDateSet() throws Exception {
+    public void callToAboutToSubmitHandler_willWriteAdjournNoticeToCaseWithGeneratedDateOfNowWhenGeneratedDateSet() throws Exception {
         setup();
         setJsonAndReplace(
             "callback/adjournCaseValidSubmissionWithSetGeneratedDate.json", "DIRECTIONS_DUE_DATE_PLACEHOLDER", "2019-10-10");
@@ -176,7 +176,7 @@ public class AdjournCaseIt extends AbstractEventIt {
         assertEquals("Draft Adjournment Notice generated on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
 
 
-        assertEquals("2018-01-01", result.getData().getAdjournCaseGeneratedDate());
+        assertEquals(LocalDate.now().toString(), result.getData().getAdjournCaseGeneratedDate());
     }
 
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
@@ -320,13 +320,14 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
     }
 
     /**
-     * This test asserts that if the (correclty set) generated date referenced by the preview document
-     * is submitted as part of the payload to the WriteFinalDecisionAboutToSubmitHandler,
-     * then that same date is set on the case data after the WriteFinalDecisionboutToSubmitHandler
-     * is called.
+     * This test asserts that whatever the value of the existing generated date from CCD
+     * submitted as part of the payload to the WriterFinalSubmissionAboutToSubmitHandler,
+     * then that date is updated to now() after the WriterFinalSubmissionAboutToSubmitHandler is called.
+     * This is due to a workaround we have implemented in the WriterFinalSubmissionAboutToSubmitHandler
+     *
      */
     @Test
-    public void callToAboutToSubmitHandler_willWriteDraftFinalDecisionToCaseWithGeneratedDateAsProvidedDateWhenSubmittedGeneratedDateIsSet() throws Exception {
+    public void callToAboutToSubmitHandler_willWriteDraftFinalDecisionToCaseWithGeneratedDateAsNowWhenSubmittedGeneratedDateIsSet() throws Exception {
         setup();
         setJsonAndReplace("callback/writeFinalDecisionDescriptorSetGeneratedDate.json", "START_DATE_PLACEHOLDER", "2018-10-10");
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
@@ -345,7 +345,7 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
         assertEquals(LocalDate.now().toString(), result.getData().getWriteFinalDecisionGeneratedDate());
 
         assertEquals(DRAFT_DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
-        assertEquals("2018-01-01", result.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
+        assertEquals(LocalDate.now().toString(), result.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
         assertEquals("Draft Decision Notice generated on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
     }
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
@@ -285,6 +285,69 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
         assertEquals("Draft Decision Notice generated on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
     }
 
+    /**
+     * Due to a CCD bug ( https://tools.hmcts.net/jira/browse/RDM-8200 ) we have had
+     * to implement a workaround in WriteFinalDecisionAboutToSubmitHandler to set
+     * the generated date to now, even though it is already being determined by the
+     * preview document handler.  This is because on submission, the correct generated date
+     * (the one referenced in the preview document) is being overwritten to a null value.
+     * Once RDM-8200 is fixed and we remove the workaround, this test should be changed
+     * to assert that a "something has gone wrong" error is displayed instead of
+     * previewing the document, as a null generated date would indicate that the
+     * date in the preview document hasn't been set.
+     *
+     */
+    @Test
+    public void callToAboutToSubmitHandler_willWriteDraftFinalDecisionToCaseWithGeneratedDateAsNowWhenSubmittedGeneratedDateIsNull() throws Exception {
+        setup();
+        setJsonAndReplace("callback/writeFinalDecisionDescriptorNullGeneratedDate.json", "START_DATE_PLACEHOLDER", "2018-10-10");
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertNull(result.getData().getOutcome());
+
+
+        assertNotNull(result.getData().getWriteFinalDecisionGeneratedDate());
+        assertEquals(LocalDate.now().toString(), result.getData().getWriteFinalDecisionGeneratedDate());
+
+        assertEquals(DRAFT_DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
+        assertEquals(LocalDate.now().toString(), result.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
+        assertEquals("Draft Decision Notice generated on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+    }
+
+    /**
+     * This test asserts that if the (correclty set) generated date referenced by the preview document
+     * is submitted as part of the payload to the WriteFinalDecisionAboutToSubmitHandler,
+     * then that same date is set on the case data after the WriteFinalDecisionboutToSubmitHandler
+     * is called.
+     */
+    @Test
+    public void callToAboutToSubmitHandler_willWriteDraftFinalDecisionToCaseWithGeneratedDateAsProvidedDateWhenSubmittedGeneratedDateIsSet() throws Exception {
+        setup();
+        setJsonAndReplace("callback/writeFinalDecisionDescriptorSetGeneratedDate.json", "START_DATE_PLACEHOLDER", "2018-10-10");
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdAboutToSubmit"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertNull(result.getData().getOutcome());
+
+
+        assertNotNull(result.getData().getWriteFinalDecisionGeneratedDate());
+
+        assertEquals(LocalDate.now().toString(), result.getData().getWriteFinalDecisionGeneratedDate());
+
+        assertEquals(DRAFT_DECISION_NOTICE.getValue(), result.getData().getSscsDocument().get(0).getValue().getDocumentType());
+        assertEquals("2018-01-01", result.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
+        assertEquals("Draft Decision Notice generated on " + LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY")) + ".pdf", result.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+    }
+
     @Test
     public void callToAboutToSubmitHandler_willWriteDraftFinalDecisionToCaseForNonDescriptorRoute() throws Exception {
         setup();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
@@ -47,7 +47,9 @@ public class AdjournCaseAboutToSubmitHandler implements PreSubmitCallbackHandler
         // on the final submission from CCD, so we need to reset it here
         // See https://tools.hmcts.net/jira/browse/RDM-8200
         // This is a temporary workaround for this issue.
-        sscsCaseData.setAdjournCaseGeneratedDate(LocalDate.now().toString());
+        if (sscsCaseData.getAdjournCaseGeneratedDate() == null) {
+            sscsCaseData.setAdjournCaseGeneratedDate(LocalDate.now().toString());
+        }
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
@@ -43,13 +43,11 @@ public class AdjournCaseAboutToSubmitHandler implements PreSubmitCallbackHandler
 
         SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
 
-        // Due to a bug with CCD related to hidden fields, this field is being nulled out
+        // Due to a bug with CCD related to hidden fields, this field not being set
         // on the final submission from CCD, so we need to reset it here
         // See https://tools.hmcts.net/jira/browse/RDM-8200
         // This is a temporary workaround for this issue.
-        if (sscsCaseData.getAdjournCaseGeneratedDate() == null) {
-            sscsCaseData.setAdjournCaseGeneratedDate(LocalDate.now().toString());
-        }
+        sscsCaseData.setAdjournCaseGeneratedDate(LocalDate.now().toString());
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandler.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.ccd.presubmit.adjourncase;
 
 import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_ADJOURNMENT_NOTICE;
 
+import java.time.LocalDate;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +42,12 @@ public class AdjournCaseAboutToSubmitHandler implements PreSubmitCallbackHandler
         }
 
         SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
+
+        // Due to a bug with CCD related to hidden fields, this field is being nulled out
+        // on the final submission from CCD, so we need to reset it here
+        // See https://tools.hmcts.net/jira/browse/RDM-8200
+        // This is a temporary workaround for this issue.
+        sscsCaseData.setAdjournCaseGeneratedDate(LocalDate.now().toString());
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DRAFT_DECISION_NOTICE;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -45,6 +46,12 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         }
 
         SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
+
+        // Due to a bug with CCD related to hidden fields, this field is being nulled out
+        // on the final submission from CCD, so we need to reset it here
+        // See https://tools.hmcts.net/jira/browse/RDM-8200
+        // This is a temporary workaround for this issue.
+        sscsCaseData.setWriteFinalDecisionGeneratedDate(LocalDate.now().toString());
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
@@ -47,13 +47,11 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
 
         SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
 
-        // Due to a bug with CCD related to hidden fields, this field is being nulled out
+        // Due to a bug with CCD related to hidden fields, this field is not being set
         // on the final submission from CCD, so we need to reset it here
         // See https://tools.hmcts.net/jira/browse/RDM-8200
         // This is a temporary workaround for this issue.
-        if (sscsCaseData.getWriteFinalDecisionGeneratedDate() == null) {
-            sscsCaseData.setWriteFinalDecisionGeneratedDate(LocalDate.now().toString());
-        }
+        sscsCaseData.setWriteFinalDecisionGeneratedDate(LocalDate.now().toString());
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandler.java
@@ -51,7 +51,9 @@ public class WriteFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
         // on the final submission from CCD, so we need to reset it here
         // See https://tools.hmcts.net/jira/browse/RDM-8200
         // This is a temporary workaround for this issue.
-        sscsCaseData.setWriteFinalDecisionGeneratedDate(LocalDate.now().toString());
+        if (sscsCaseData.getWriteFinalDecisionGeneratedDate() == null) {
+            sscsCaseData.setWriteFinalDecisionGeneratedDate(LocalDate.now().toString());
+        }
 
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandlerTest.java
@@ -83,6 +83,42 @@ public class AdjournCaseAboutToSubmitHandlerTest {
         assertEquals("Spanish", response.getData().getAppeal().getHearingOptions().getLanguages());
     }
 
+    /**
+     * Due to a CCD bug ( https://tools.hmcts.net/jira/browse/RDM-8200 ) we have had
+     * to implement a workaround in AdjournCaseAboutToSubmitHandler to set
+     * the generated date to now, even though it is already being determined by the
+     * preview document handler.  This is because on submission, the correct generated date
+     * (the one referenced in the preview document) is being overwritten to a null value.
+     * Once RDM-8200 is fixed and we remove the workaround, this test should be changed
+     * to assert that a "something has gone wrong" error is displayed, as a null generated
+     * date would indicate that the date in the preview document hasn't been set.
+     *
+     */
+    @Test
+    public void givenValidSubmissionWithGeneratedDateNotSet_thenSetGeneratedDateAsNowAndDoNotDisplayAnError() {
+
+        handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(LocalDate.now().toString(), callback.getCaseDetails().getCaseData().getAdjournCaseGeneratedDate());
+    }
+
+    /**
+     * This test asserts that if the (correclty set) generated date referenced by the preview document
+     * is submitted as part of the payload to the AdjournCaseAboutToSubmit handler,
+     * then that same date is set on the case data after the AdjournCaseAboutToSubmitHandler
+     * is called.
+     *
+     */
+    @Test
+    public void givenValidSubmissionWithGeneratedDateSet_thenSetCorrectGeneratedDateAndDoNotDisplayAnError() {
+
+        callback.getCaseDetails().getCaseData().setAdjournCaseGeneratedDate("2018-01-01");
+
+        handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("2018-01-01", callback.getCaseDetails().getCaseData().getAdjournCaseGeneratedDate());
+    }
+
     @Test
     public void givenAnAdjournmentEventWithLanguageInterpreterRequiredAndCaseDoesNotHaveExistingInterpreter_thenSetInterpreterInHearingOptions() {
         callback.getCaseDetails().getCaseData().setAdjournCaseInterpreterRequired("Yes");

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/adjourncase/AdjournCaseAboutToSubmitHandlerTest.java
@@ -103,20 +103,20 @@ public class AdjournCaseAboutToSubmitHandlerTest {
     }
 
     /**
-     * This test asserts that if the (correclty set) generated date referenced by the preview document
-     * is submitted as part of the payload to the AdjournCaseAboutToSubmit handler,
-     * then that same date is set on the case data after the AdjournCaseAboutToSubmitHandler
-     * is called.
+     * This test asserts that whatever the value of the existing generated date from CCD
+     * submitted as part of the payload to the AdjournCaseAboutToSubmitHandler,
+     * then that date is updated to now() after the AdjournCaseAboutToSubmitHandler is called.
+     * This is due to a workaround we have implemented in the AdjournCaseAboutToSubmitHandler
      *
      */
     @Test
-    public void givenValidSubmissionWithGeneratedDateSet_thenSetCorrectGeneratedDateAndDoNotDisplayAnError() {
+    public void givenValidSubmissionWithGeneratedDateSet_thenSetGeneratedDateToNowAndDoNotDisplayAnError() {
 
         callback.getCaseDetails().getCaseData().setAdjournCaseGeneratedDate("2018-01-01");
 
         handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        assertEquals("2018-01-01", callback.getCaseDetails().getCaseData().getAdjournCaseGeneratedDate());
+        assertEquals(LocalDate.now().toString(), callback.getCaseDetails().getCaseData().getAdjournCaseGeneratedDate());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -150,6 +150,84 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
 
     }
 
+    /**
+     * Due to a CCD bug ( https://tools.hmcts.net/jira/browse/RDM-8200 ) we have had
+     * to implement a workaround in WriteFinalDecisionAboutToSubmitHandler to set
+     * the generated date to now, even though it is already being determined by the
+     * preview document handler.  This is because on submission, the correct generated date
+     * (the one referenced in the preview document) is being overwritten to a null value.
+     * Once RDM-8200 is fixed and we remove the workaround, this test should be changed
+     * to assert that a "something has gone wrong" error is displayed, as a null generated
+     * date would indicate that the date in the preview document hasn't been set.
+     *
+     */
+    @Test
+    public void givenValidSubmissionWithGeneratedDateNotSet_thenSetGeneratedDateAsNowAndDoNotDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.setWriteFinalDecisionIsDescriptorFlow("yes");
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion("standardRate");
+        sscsCaseData.setPipWriteFinalDecisionMobilityQuestion("standardRate");
+
+        sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(
+            Arrays.asList("movingAround"));
+
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(
+            Arrays.asList("preparingFood", "takingNutrition"));
+
+        // 8 points - correct for mobility standard award
+        sscsCaseData.setPipWriteFinalDecisionMovingAroundQuestion("movingAround12d");
+
+        // 8 points total - correct for daily living standard award
+        sscsCaseData.setPipWriteFinalDecisionPreparingFoodQuestion("preparingFood1f"); // 8 points
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+
+        assertEquals(LocalDate.now().toString(), sscsCaseData.getWriteFinalDecisionGeneratedDate());
+
+    }
+
+    /**
+     * This test asserts that if the (correclty set) generated date referenced by the preview document
+     * is submitted as part of the payload to the WriterFinalSubmissionAboutToSubmitHandler,
+     * then that same date is set on the case data after the WriterFinalSubmissionAboutToSubmitHandler
+     * is called.
+     *
+     */
+    @Test
+    public void givenValidSubmissionWithGeneratedDateSet_thenSetGeneratedDateCorrectlyAndDoNotDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.setWriteFinalDecisionIsDescriptorFlow("yes");
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion("standardRate");
+        sscsCaseData.setPipWriteFinalDecisionMobilityQuestion("standardRate");
+        sscsCaseData.setWriteFinalDecisionGeneratedDate("2018-01-01");
+
+        sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(
+            Arrays.asList("movingAround"));
+
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(
+            Arrays.asList("preparingFood", "takingNutrition"));
+
+        // 8 points - correct for mobility standard award
+        sscsCaseData.setPipWriteFinalDecisionMovingAroundQuestion("movingAround12d");
+
+        // 8 points total - correct for daily living standard award
+        sscsCaseData.setPipWriteFinalDecisionPreparingFoodQuestion("preparingFood1f"); // 8 points
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+
+        assertEquals("2018-01-01", sscsCaseData.getWriteFinalDecisionGeneratedDate());
+    }
+
     @Test
     public void givenMobilityStandardRateCorrectAndDailyLivingEnhancedRateSelectedAndDailyLivingPointsAreTooLow_thenDisplayAnError() {
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -192,14 +192,14 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
     }
 
     /**
-     * This test asserts that if the (correclty set) generated date referenced by the preview document
-     * is submitted as part of the payload to the WriterFinalSubmissionAboutToSubmitHandler,
-     * then that same date is set on the case data after the WriterFinalSubmissionAboutToSubmitHandler
-     * is called.
+     * This test asserts that whatever the value of the existing generated date from CCD
+     * submitted as part of the payload to the WriterFinalSubmissionAboutToSubmitHandler,
+     * then that date is updated to now() after the WriterFinalSubmissionAboutToSubmitHandler is called.
+     * This is due to a workaround we have implemented in the WriterFinalSubmissionAboutToSubmitHandler
      *
      */
     @Test
-    public void givenValidSubmissionWithGeneratedDateSet_thenSetGeneratedDateCorrectlyAndDoNotDisplayAnError() {
+    public void givenValidSubmissionWithGeneratedDateSet_thenSetUpdateGeneratedDateAndDoNotDisplayAnError() {
 
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
 
@@ -225,7 +225,7 @@ public class WriteFinalDecisionAboutToSubmitHandlerTest {
 
         assertEquals(0, response.getErrors().size());
 
-        assertEquals("2018-01-01", sscsCaseData.getWriteFinalDecisionGeneratedDate());
+        assertEquals(LocalDate.now().toString(), sscsCaseData.getWriteFinalDecisionGeneratedDate());
     }
 
     @Test

--- a/src/test/resources/callback/adjournCaseValidSubmissionWithNullGeneratedDate.json
+++ b/src/test/resources/callback/adjournCaseValidSubmissionWithNullGeneratedDate.json
@@ -1,0 +1,1451 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "adjournCaseGenerateNotice" : "Yes",
+      "adjournCaseTypeOfHearing" : "video",
+      "adjournCaseCanCaseBeListedRightAway" : "No",
+      "adjournCaseAreDirectionsBeingMadeToParties" : "Yes",
+      "adjournCaseTypeOfNextHearing" : "video",
+      "adjournCasePanelMembersExcluded" : "yes",
+      "adjournCaseNextHearingDateType" : "specificDateAndTime",
+      "adjournCaseNextHearingDateOrPeriod" : "provideDate",
+      "adjournCaseNextHearingSpecificDate" : "NEXT_HEARING_SPECIFIC_DATE_PLACEHOLDER",
+      "adjournCaseNextHearingSpecificTime" : "am",
+      "adjournCaseAnythingElse" : "something else",
+      "adjournCaseReasons": [{"id":null,"value":"Reasons 1"}],
+      "adjournCaseDirectionsDueDate" : "DIRECTIONS_DUE_DATE_PLACEHOLDER",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "adjournCaseGenerateNotice" : "Yes",
+      "adjournCaseTypeOfHearing" : "video",
+      "adjournCaseCanCaseBeListedRightAway" : "No",
+      "adjournCaseAreDirectionsBeingMadeToParties" : "Yes",
+      "adjournCaseTypeOfNextHearing" : "video",
+      "adjournCasePanelMembersExcluded" : "yes",
+      "adjournCaseNextHearingDateType" : "specificDateAndTime",
+      "adjournCaseNextHearingDateOrPeriod" : "provideDate",
+      "adjournCaseNextHearingSpecificDate" : "NEXT_HEARING_SPECIFIC_DATE_PLACEHOLDER",
+      "adjournCaseNextHearingSpecificTime" : "am",
+      "adjournCaseAnythingElse" : "something else",
+      "adjournCaseReasons": [{"id":null,"value":"Reasons 1"}],
+      "adjournCaseDirectionsDueDate" : "DIRECTIONS_DUE_DATE_PLACEHOLDER",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "adjournCase"
+}

--- a/src/test/resources/callback/adjournCaseValidSubmissionWithSetGeneratedDate.json
+++ b/src/test/resources/callback/adjournCaseValidSubmissionWithSetGeneratedDate.json
@@ -1,0 +1,1453 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "adjournCaseGenerateNotice" : "Yes",
+      "adjournCaseGeneratedDate" : "2018-01-01",
+      "adjournCaseTypeOfHearing" : "video",
+      "adjournCaseCanCaseBeListedRightAway" : "No",
+      "adjournCaseAreDirectionsBeingMadeToParties" : "Yes",
+      "adjournCaseTypeOfNextHearing" : "video",
+      "adjournCasePanelMembersExcluded" : "yes",
+      "adjournCaseNextHearingDateType" : "specificDateAndTime",
+      "adjournCaseNextHearingDateOrPeriod" : "provideDate",
+      "adjournCaseNextHearingSpecificDate" : "NEXT_HEARING_SPECIFIC_DATE_PLACEHOLDER",
+      "adjournCaseNextHearingSpecificTime" : "am",
+      "adjournCaseAnythingElse" : "something else",
+      "adjournCaseReasons": [{"id":null,"value":"Reasons 1"}],
+      "adjournCaseDirectionsDueDate" : "DIRECTIONS_DUE_DATE_PLACEHOLDER",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "adjournCaseGenerateNotice" : "Yes",
+      "adjournCaseGeneratedDate" : "2018-01-01",
+      "adjournCaseTypeOfHearing" : "video",
+      "adjournCaseCanCaseBeListedRightAway" : "No",
+      "adjournCaseAreDirectionsBeingMadeToParties" : "Yes",
+      "adjournCaseTypeOfNextHearing" : "video",
+      "adjournCasePanelMembersExcluded" : "yes",
+      "adjournCaseNextHearingDateType" : "specificDateAndTime",
+      "adjournCaseNextHearingDateOrPeriod" : "provideDate",
+      "adjournCaseNextHearingSpecificDate" : "NEXT_HEARING_SPECIFIC_DATE_PLACEHOLDER",
+      "adjournCaseNextHearingSpecificTime" : "am",
+      "adjournCaseAnythingElse" : "something else",
+      "adjournCaseReasons": [{"id":null,"value":"Reasons 1"}],
+      "adjournCaseDirectionsDueDate" : "DIRECTIONS_DUE_DATE_PLACEHOLDER",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "adjournCase"
+}

--- a/src/test/resources/callback/writeFinalDecisionDescriptorNullGeneratedDate.json
+++ b/src/test/resources/callback/writeFinalDecisionDescriptorNullGeneratedDate.json
@@ -1,0 +1,1467 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "writeFinalDecisionIsDescriptorFlow" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "writeFinalDecisionGeneratedDate" : null,
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
+      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
+      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
+      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
+      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
+      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "writeFinalDecisionIsDescriptorFlow" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "writeFinalDecisionGeneratedDate" : null,
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
+      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
+      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
+      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
+      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
+      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "writeFinalDecision"
+}

--- a/src/test/resources/callback/writeFinalDecisionDescriptorSetGeneratedDate.json
+++ b/src/test/resources/callback/writeFinalDecisionDescriptorSetGeneratedDate.json
@@ -1,0 +1,1467 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "writeFinalDecisionIsDescriptorFlow" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "writeFinalDecisionGeneratedDate" : "2018-01-01",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
+      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
+      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
+      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
+      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
+      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "writeFinalDecisionIsDescriptorFlow" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "writeFinalDecisionGeneratedDate" : "2018-01-01",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "pipWriteFinalDecisionComparedToDWPDailyLivingQuestion": "higher",
+      "pipWriteFinalDecisionComparedToDWPMobilityQuestion": "higher",
+      "pipWriteFinalDecisionDailyLivingQuestion" : "enhancedRate",
+      "pipWriteFinalDecisionDailyLivingActivitiesQuestion" : ["preparingFood", "takingNutrition"],
+      "pipWriteFinalDecisionPreparingFoodQuestion" : "preparingFood1f",
+      "pipWriteFinalDecisionTakingNutritionQuestion" : "takingNutrition2f",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "writeFinalDecision"
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7854

### Change description ###

*   Adding workaround for RDM-8200 to set the generated dates on the AboutToSubmit handlers.  Due to the generated dates being a hidden field, these values which are already set are being nulled out.   This is a workaround for that issue

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
