### PR TITLE
suppress CVE-2020-15824 for a month until v1.4.0 kotlin-stdlib is released

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -15,4 +15,11 @@
         <packageUrl regex="true">^pkg:maven/edu\.usc\.ir/sentiment-analysis-parser@0.*$</packageUrl>
         <cve>CVE-2018-18749</cve>
     </suppress>
+    <suppress until="2020-08-31">
+        <notes><![CDATA[
+         file name: kotlin-stdlib-common-1.3.72.jar
+        ]]></notes>
+        <gav regex="true">^org\.jetbrains\.kotlin:*:.*$</gav>
+        <cve>CVE-2020-15824</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
suppress CVE-2020-15824 for a month until v1.4.0 kotlin-stdlib is released.

See also: https://github.com/square/okhttp/issues/6219