### PR TITLE
Introducing InputStreamWrapper to safeClose an input stream automatically from try-with-resources-statements

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/pdf/PdfACompliance.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/pdf/PdfACompliance.java
@@ -86,7 +86,7 @@ public class PdfACompliance {
          * be safely closed eg. try (InputStream inputStream = this.getClass().getResourceAsStream(... )) {
          */
         try (InputStreamWrapper colorProfile = new InputStreamWrapper(log, this.getClass().getResourceAsStream(
-            "/pdfa/sRGB.icc"))){
+            "/pdfa/sRGB.icc"))) {
 
             PDOutputIntent intent = new PDOutputIntent(document, colorProfile.get());
             intent.setInfo("sRGB IEC61966-2.1");

--- a/src/main/java/uk/gov/hmcts/reform/sscs/pdf/PdfWatermarker.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/pdf/PdfWatermarker.java
@@ -62,7 +62,7 @@ public class PdfWatermarker {
          * be safely closed (eg.  try (InputStream inputStream = this.getClass().getResourceAsStream(... )) {
          */
         try (InputStreamWrapper fontStreamWrapper = new InputStreamWrapper(log, this.getClass().getResourceAsStream(
-            "/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"))){
+            "/org/apache/pdfbox/resources/ttf/LiberationSans-Regular.ttf"))) {
 
             font = PDType0Font.load(document, fontStreamWrapper.get(), true);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SscsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SscsPdfService.java
@@ -31,10 +31,10 @@ public class SscsPdfService {
 
     @Autowired
     public SscsPdfService(@Value("${appellant.appeal.html.template.path}") String appellantTemplatePath,
-                          @Value("${appellant.appeal.html.welsh.template.path}") String appellantWelshTemplatePath,
-                          PDFServiceClient pdfServiceClient,
-                          CcdPdfService ccdPdfService,
-                          ResourceManager resourceManager) {
+        @Value("${appellant.appeal.html.welsh.template.path}") String appellantWelshTemplatePath,
+        PDFServiceClient pdfServiceClient,
+        CcdPdfService ccdPdfService,
+        ResourceManager resourceManager) {
         this.pdfServiceClient = pdfServiceClient;
         this.appellantTemplatePath = appellantTemplatePath;
         this.appellantWelshTemplatePath = appellantWelshTemplatePath;
@@ -46,8 +46,8 @@ public class SscsPdfService {
         byte[] pdf = generatePdf(sscsCaseData, caseDetailsId);
 
         log.info("Case {} PDF successfully created for benefit type {}",
-                caseDetailsId,
-                sscsCaseData.getAppeal().getBenefitType().getCode());
+            caseDetailsId,
+            sscsCaseData.getAppeal().getBenefitType().getCode());
 
         return ccdPdfService.updateDoc(fileName, pdf, caseDetailsId, sscsCaseData, documentType);
     }
@@ -60,11 +60,11 @@ public class SscsPdfService {
             throw new PdfGenerationException("Error getting template", e);
         }
         PdfWrapper pdfWrapper = PdfWrapper.builder().sscsCaseData(sscsCaseData).ccdCaseId(caseDetailsId)
-                .isSignLanguageInterpreterRequired(sscsCaseData.getAppeal().getHearingOptions().wantsSignLanguageInterpreter())
-                .isHearingLoopRequired(sscsCaseData.getAppeal().getHearingOptions().wantsHearingLoop())
-                .isAccessibleHearingRoomRequired(sscsCaseData.getAppeal().getHearingOptions().wantsAccessibleHearingRoom())
-                .currentDate(LocalDate.now())
-                .repFullName(getRepFullName(sscsCaseData.getAppeal().getRep())).build();
+            .isSignLanguageInterpreterRequired(sscsCaseData.getAppeal().getHearingOptions().wantsSignLanguageInterpreter())
+            .isHearingLoopRequired(sscsCaseData.getAppeal().getHearingOptions().wantsHearingLoop())
+            .isAccessibleHearingRoomRequired(sscsCaseData.getAppeal().getHearingOptions().wantsAccessibleHearingRoom())
+            .currentDate(LocalDate.now())
+            .repFullName(getRepFullName(sscsCaseData.getAppeal().getRep())).build();
 
         Map<String, Object> placeholders = new HashMap<>();
         placeholders.put("PdfWrapper", pdfWrapper);
@@ -74,7 +74,7 @@ public class SscsPdfService {
             placeholders.put("appellant_appointee_identity_dob",
                 LocalDateToWelshStringConverter.convert(sscsCaseData.getAppeal().getAppellant().getIdentity().getDob()));
             placeholders.put("date_of_decision",
-                    LocalDateToWelshStringConverter.convert(sscsCaseData.getAppeal().getMrnDetails().getMrnDate()));
+                LocalDateToWelshStringConverter.convert(sscsCaseData.getAppeal().getMrnDetails().getMrnDate()));
 
             List<String> welshExcludesDates = new ArrayList<>();
             List<ExcludeDate> excludesDates = sscsCaseData.getAppeal().getHearingOptions().getExcludeDates();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/thirdparty/pdfservice/InputStreamWrapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/thirdparty/pdfservice/InputStreamWrapper.java
@@ -1,0 +1,36 @@
+package uk.gov.hmcts.reform.sscs.thirdparty.pdfservice;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+
+/**
+ * Wraps an InputStream as an AutoCloseable who's close method logs and swallows the exception instead of propagating it.
+ */
+public class InputStreamWrapper implements AutoCloseable, Supplier<InputStream> {
+
+    private Logger log;
+    private InputStream inputStream;
+
+    public InputStreamWrapper(Logger log, InputStream inputStream) {
+        this.log = log;
+        this.inputStream = inputStream;
+    }
+
+    @Override
+    public void close() {
+        if (inputStream != null) {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                log.error(e.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public InputStream get() {
+        return inputStream;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/thirdparty/pdfservice/ResourceManager.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/thirdparty/pdfservice/ResourceManager.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.sscs.thirdparty.pdfservice;
 
 import java.io.IOException;
-import java.io.InputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.util.IOUtils;
 import org.springframework.stereotype.Service;
@@ -11,28 +10,15 @@ import org.springframework.stereotype.Service;
 public class ResourceManager {
 
     public byte[] getResource(String file) throws IOException {
-        InputStream in = null;
-        byte[] byteArray = null;
-        try {
-            in = getClass().getResourceAsStream(file);
-        } finally {
-            if (in != null) {
-                byteArray = IOUtils.toByteArray(in);
-
-                safeClose(in);
-            }
-        }
-        return byteArray;
-    }
-
-    public static void safeClose(InputStream in) {
-        if (in != null) {
-            try {
-                in.close();
-            } catch (IOException e) {
-                log.error(e.getMessage());
-            }
+        /**
+         * The input stream obtained here is wrapped inside an InputStreamWrapper AutoCloseable
+         * and so is automatically closed by this try-with-resource statement.
+         * Any exceptions occurring on actually closing the stream are logged and swallowed by InputStreamWrapper,
+         * whereas any exceptions occurring prior to a close attempt will cause a call to close and
+         * the original exception will propagate
+         */
+        try (InputStreamWrapper inputStreamWrapper = new InputStreamWrapper(log, getClass().getResourceAsStream(file))) {
+            return inputStreamWrapper.get() != null ?  IOUtils.toByteArray(inputStreamWrapper.get()) : null;
         }
     }
-
 }


### PR DESCRIPTION

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
