### PR TITLE
SSCS - 8112 - Activities are Optional depending on the award type

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
@@ -69,7 +69,7 @@ public class WriteFinalDecisionMidEventValidationHandler extends IssueDocumentHa
                 &&  sscsCaseData.getPipWriteFinalDecisionMobilityActivitiesQuestion() != null
                 &&  sscsCaseData.getPipWriteFinalDecisionDailyLivingActivitiesQuestion().isEmpty()
                 &&  sscsCaseData.getPipWriteFinalDecisionMobilityActivitiesQuestion().isEmpty()) {
-            preSubmitCallbackResponse.addWarning("At least one activity must be selected unless there is no award");
+            preSubmitCallbackResponse.addError("At least one activity must be selected unless there is no award");
         }
 
         if (AwardType.NO_AWARD.getKey().equals(sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion())

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandler.java
@@ -1,5 +1,8 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import java.time.LocalDate;
 import java.util.Objects;
 import java.util.Set;
@@ -20,7 +23,7 @@ import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 @Slf4j
 public class WriteFinalDecisionMidEventValidationHandler extends IssueDocumentHandler implements PreSubmitCallbackHandler<SscsCaseData> {
 
-    private Validator validator;
+    private final Validator validator;
 
     @Autowired
     WriteFinalDecisionMidEventValidationHandler(Validator validator) {
@@ -60,6 +63,15 @@ public class WriteFinalDecisionMidEventValidationHandler extends IssueDocumentHa
     }
 
     private void validateAwardTypes(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if ((!equalsIgnoreCase(AwardType.NO_AWARD.getKey(), sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion())
+                || !equalsIgnoreCase(AwardType.NO_AWARD.getKey(), sscsCaseData.getPipWriteFinalDecisionMobilityQuestion()))
+                &&  sscsCaseData.getPipWriteFinalDecisionDailyLivingActivitiesQuestion() != null
+                &&  sscsCaseData.getPipWriteFinalDecisionMobilityActivitiesQuestion() != null
+                &&  sscsCaseData.getPipWriteFinalDecisionDailyLivingActivitiesQuestion().isEmpty()
+                &&  sscsCaseData.getPipWriteFinalDecisionMobilityActivitiesQuestion().isEmpty()) {
+            preSubmitCallbackResponse.addWarning("At least one activity must be selected unless there is no award");
+        }
+
         if (AwardType.NO_AWARD.getKey().equals(sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion())
             && "higher".equals(sscsCaseData.getPipWriteFinalDecisionComparedToDwpDailyLivingQuestion())) {
             preSubmitCallbackResponse.addError("Daily living decision of No Award cannot be higher than DWP decision");
@@ -87,7 +99,7 @@ public class WriteFinalDecisionMidEventValidationHandler extends IssueDocumentHa
     }
 
     private boolean isDecisionNoticeDatesInvalid(SscsCaseData sscsCaseData) {
-        if (sscsCaseData.getWriteFinalDecisionStartDate() != null && sscsCaseData.getWriteFinalDecisionEndDate() != null) {
+        if (isNotBlank(sscsCaseData.getWriteFinalDecisionStartDate()) && isNotBlank(sscsCaseData.getWriteFinalDecisionEndDate())) {
             LocalDate decisionNoticeStartDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionStartDate());
             LocalDate decisionNoticeEndDate = LocalDate.parse(sscsCaseData.getWriteFinalDecisionEndDate());
             return !decisionNoticeStartDate.isBefore(decisionNoticeEndDate);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.when;
@@ -387,6 +388,48 @@ public class WriteFinalDecisionMidEventValidationHandlerTest {
         assertEquals(1, response.getErrors().size());
         String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("At least one of Mobility or Daily Living must be considered", error);
+    }
+
+    @Test
+    @Parameters({
+        "STANDARD_RATE, STANDARD_RATE",
+        "ENHANCED_RATE, ENHANCED_RATE",
+        "NOT_CONSIDERED, STANDARD_RATE",
+        "STANDARD_RATE, NO_AWARD",
+        "NO_AWARD, ENHANCED_RATE"
+    })
+    public void shouldDisplayActivitiesWarningWhenAnAnAwardIsGivenAndNoActivitiesSelected(AwardType dailyLiving, AwardType mobility) {
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(dailyLiving.key);
+        sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(mobility.key);
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(emptyList());
+        sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(emptyList());
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(1, response.getWarnings().size());
+        String error = response.getWarnings().stream().findFirst().orElse("");
+        assertEquals("At least one activity must be selected unless there is no award", error);
+    }
+
+    @Test
+    public void shouldNotDisplayActivitiesWarningWhenNoAwardsAreGivenAndNoActivitiesAreSelected() {
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(AwardType.NO_AWARD.key);
+        sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(AwardType.NO_AWARD.key);
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(emptyList());
+        sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(emptyList());
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(0, response.getWarnings().size());
+    }
+
+    @Test
+    public void shouldNotDisplayActivitiesWarningWhenActivitiesAreNotYetSelected() {
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(AwardType.STANDARD_RATE.key);
+        sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(AwardType.STANDARD_RATE.key);
+        sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(null);
+        sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(null);
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(0, response.getWarnings().size());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionMidEventValidationHandlerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.MID_EVENT;
 
-import java.io.IOException;
 import java.time.LocalDate;
 import javax.validation.Validation;
 import junitparams.JUnitParamsRunner;
@@ -45,7 +44,7 @@ public class WriteFinalDecisionMidEventValidationHandlerTest {
     private SscsCaseData sscsCaseData;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         openMocks(this);
         handler = new WriteFinalDecisionMidEventValidationHandler(Validation.buildDefaultValidatorFactory().getValidator());
 
@@ -68,7 +67,6 @@ public class WriteFinalDecisionMidEventValidationHandlerTest {
                     .identity(Identity.builder().build())
                     .build())
                 .build()).build();
-
 
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
     }
@@ -398,20 +396,20 @@ public class WriteFinalDecisionMidEventValidationHandlerTest {
         "STANDARD_RATE, NO_AWARD",
         "NO_AWARD, ENHANCED_RATE"
     })
-    public void shouldDisplayActivitiesWarningWhenAnAnAwardIsGivenAndNoActivitiesSelected(AwardType dailyLiving, AwardType mobility) {
+    public void shouldDisplayActivitiesErrorWhenAnAnAwardIsGivenAndNoActivitiesSelected(AwardType dailyLiving, AwardType mobility) {
         sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(dailyLiving.key);
         sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(mobility.key);
         sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(emptyList());
         sscsCaseData.setPipWriteFinalDecisionMobilityActivitiesQuestion(emptyList());
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(1, response.getWarnings().size());
-        String error = response.getWarnings().stream().findFirst().orElse("");
+        assertEquals(0, response.getWarnings().size());
+        assertEquals(1, response.getErrors().size());
+        String error = response.getErrors().stream().findFirst().orElse("");
         assertEquals("At least one activity must be selected unless there is no award", error);
     }
 
     @Test
-    public void shouldNotDisplayActivitiesWarningWhenNoAwardsAreGivenAndNoActivitiesAreSelected() {
+    public void shouldNotDisplayActivitiesErrorWhenNoAwardsAreGivenAndNoActivitiesAreSelected() {
         sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(AwardType.NO_AWARD.key);
         sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(AwardType.NO_AWARD.key);
         sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(emptyList());
@@ -422,7 +420,7 @@ public class WriteFinalDecisionMidEventValidationHandlerTest {
     }
 
     @Test
-    public void shouldNotDisplayActivitiesWarningWhenActivitiesAreNotYetSelected() {
+    public void shouldNotDisplayActivitiesErrorWhenActivitiesAreNotYetSelected() {
         sscsCaseData.setPipWriteFinalDecisionDailyLivingQuestion(AwardType.STANDARD_RATE.key);
         sscsCaseData.setPipWriteFinalDecisionMobilityQuestion(AwardType.STANDARD_RATE.key);
         sscsCaseData.setPipWriteFinalDecisionDailyLivingActivitiesQuestion(null);


### PR DESCRIPTION
[SSCS - 8112](https://tools.hmcts.net/jira/browse/SSCS-8112) - Activities are Optional depending on the award type


If no award is selected on both daily living & mobility the judge should not have to select activities on the Select activities - Write final decision page.
 

Activities should be optional
If it is not "No award" then user should be presented with an error message (At least one activity must be selected unless there is no award)