### PR TITLE
Sscs 8210 sscs 8218 action further evidence validation revised

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
@@ -1,9 +1,20 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence;
 
 import static java.util.Objects.requireNonNull;
-import static org.apache.commons.lang3.StringUtils.*;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.*;
-import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.*;
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.APPELLANT_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.CONFIDENTIALITY_REQUEST;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DWP_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.JOINT_PARTY_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.OTHER_DOCUMENT;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.REINSTATEMENT_REQUEST;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.REPRESENTATIVE_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.ISSUE_FURTHER_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.OTHER_DOCUMENT_MANUAL;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.SEND_TO_INTERLOC_REVIEW_BY_JUDGE;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,8 +24,25 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.sscs.ccd.callback.*;
-import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
+import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
+import uk.gov.hmcts.reform.sscs.ccd.callback.ScannedDocumentType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DatedRequestOutcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Representative;
+import uk.gov.hmcts.reform.sscs.ccd.domain.RequestOutcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.ScannedDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentTranslationStatus;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.service.BundleAdditionFilenameBuilder;
@@ -60,13 +88,11 @@ public class ActionFurtherEvidenceAboutToSubmitHandler implements PreSubmitCallb
 
         preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 
-        if ((sscsCaseData.getConfidentialityRequestOutcomeAppellant() != null
-                && RequestOutcome.GRANTED.equals(sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome()))
-                || (sscsCaseData.getConfidentialityRequestOutcomeJointParty() != null
-                && RequestOutcome.GRANTED.equals(sscsCaseData.getConfidentialityRequestOutcomeJointParty().getRequestOutcome()))) {
-            if (!callback.isIgnoreWarnings()) {
-                preSubmitCallbackResponse.addWarning("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.");
-            }
+        if (!callback.isIgnoreWarnings() && ((sscsCaseData.getConfidentialityRequestOutcomeAppellant() != null
+            && RequestOutcome.GRANTED.equals(sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome()))
+            || (sscsCaseData.getConfidentialityRequestOutcomeJointParty() != null
+            && RequestOutcome.GRANTED.equals(sscsCaseData.getConfidentialityRequestOutcomeJointParty().getRequestOutcome())))) {
+            preSubmitCallbackResponse.addWarning("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.");
         }
 
         if (isIssueFurtherEvidenceToAllParties(callback.getCaseDetails().getCaseData().getFurtherEvidenceAction())) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
@@ -173,11 +173,14 @@ public class ActionFurtherEvidenceAboutToSubmitHandler implements PreSubmitCallb
             for (ScannedDocument scannedDocument : sscsCaseData.getScannedDocuments()) {
                 if (scannedDocument != null && scannedDocument.getValue() != null) {
 
-                    if (ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue().equals(scannedDocument.getValue().getType())) {
-                        setConfidentialCaseFields(sscsCaseData);
-                    }
-
                     checkWarningsAndErrors(sscsCaseData, scannedDocument, sscsCaseData.getCcdCaseId(), ignoreWarnings);
+
+
+                    if (ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue().equals(scannedDocument.getValue().getType())) {
+                        if (preSubmitCallbackResponse.getErrors().size() == 0) {
+                            setConfidentialCaseFields(sscsCaseData);
+                        }
+                    }
 
                     List<SscsDocument> documents = new ArrayList<>();
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
@@ -28,7 +28,6 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,19 +65,26 @@ import uk.gov.hmcts.reform.sscs.service.FooterService;
 @RunWith(JUnitParamsRunner.class)
 public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
 
-    private static final String USER_AUTHORISATION = "Bearer token";
-    private final BundleAdditionFilenameBuilder bundleAdditionFilenameBuilder = new BundleAdditionFilenameBuilder();
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
+
+    private static final String USER_AUTHORISATION = "Bearer token";
+
     private ActionFurtherEvidenceAboutToSubmitHandler actionFurtherEvidenceAboutToSubmitHandler;
+
     @Mock
     private Callback<SscsCaseData> callback;
+
     @Mock
     private CaseDetails<SscsCaseData> caseDetails;
+
     @Mock
     private FooterService footerService;
+
     private SscsCaseData sscsCaseData;
+
     private List<ScannedDocument> scannedDocumentList = new ArrayList<>();
+    private BundleAdditionFilenameBuilder bundleAdditionFilenameBuilder = new BundleAdditionFilenameBuilder();
 
     @Before
     public void setUp() {
@@ -87,39 +93,39 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         when(callback.getEvent()).thenReturn(EventType.ACTION_FURTHER_EVIDENCE);
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder()
-                        .fileName("bla.pdf")
-                        .subtype("sscs1")
-                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                        .scannedDate("2019-06-13T00:00:00.000")
-                        .controlNumber("123")
-                        .build()).build();
+            ScannedDocumentDetails.builder()
+                .fileName("bla.pdf")
+                .subtype("sscs1")
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .scannedDate("2019-06-13T00:00:00.000")
+                .controlNumber("123")
+                .build()).build();
 
         ScannedDocument scannedDocument2 = ScannedDocument.builder()
-                .value(ScannedDocumentDetails.builder()
-                        .fileName("bla2.pdf")
-                        .subtype("sscs2")
-                        .url(DocumentLink.builder().documentUrl("www.test2.com").build())
-                        .scannedDate("2019-06-12T00:00:00.000")
-                        .controlNumber("124")
-                        .build())
-                .build();
+            .value(ScannedDocumentDetails.builder()
+                .fileName("bla2.pdf")
+                .subtype("sscs2")
+                .url(DocumentLink.builder().documentUrl("www.test2.com").build())
+                .scannedDate("2019-06-12T00:00:00.000")
+                .controlNumber("124")
+                .build())
+            .build();
 
         scannedDocumentList.add(scannedDocument);
         scannedDocumentList.add(scannedDocument2);
         DynamicList furtherEvidenceActionList = buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
-                "Other document type - action manually");
+            "Other document type - action manually");
 
         DynamicListItem value = new DynamicListItem("appellant", "Appellant (or Appointee)");
         DynamicList originalSender = new DynamicList(value, Collections.singletonList(value));
 
         sscsCaseData = SscsCaseData.builder()
-                .ccdCaseId("1234")
-                .scannedDocuments(scannedDocumentList)
-                .furtherEvidenceAction(furtherEvidenceActionList)
-                .originalSender(originalSender)
-                .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
-                .build();
+            .ccdCaseId("1234")
+            .scannedDocuments(scannedDocumentList)
+            .furtherEvidenceAction(furtherEvidenceActionList)
+            .originalSender(originalSender)
+            .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
+            .build();
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
@@ -138,73 +144,46 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
     }
 
     @Test
-    @Parameters(method = "generateWrappedFurtherEvidenceActionListScenarios")
-    public void givenACaseWithScannedDocuments_shouldMoveToSscsDocuments(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome,
-                                                                         boolean ignoreWarnings,
-                                                                         boolean expectConfidentialityWarning,
-                                                                         @Nullable DynamicList furtherEvidenceActionList,
-                                                                         @Nullable DynamicList originalSender,
-                                                                         @Nullable String evidenceHandle,
-                                                                         DocumentType expectedDocumentType) {
+    @Parameters(method = "generateFurtherEvidenceActionListScenarios")
+    public void givenACaseWithScannedDocuments_shouldMoveToSscsDocuments(@Nullable DynamicList furtherEvidenceActionList,
+        @Nullable DynamicList originalSender,
+        @Nullable String evidenceHandle,
+        DocumentType expectedDocumentType) {
         sscsCaseData.setFurtherEvidenceAction(furtherEvidenceActionList);
         sscsCaseData.setOriginalSender(originalSender);
         sscsCaseData.setEvidenceHandled(evidenceHandle);
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
 
         PreSubmitCallbackResponse<SscsCaseData> response = null;
         try {
             response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-            if (ignoreWarnings) {
-                assertEquals(0, response.getWarnings().size());
-            } else {
-                Iterator<String> iterator = response.getWarnings().iterator();
-                if (expectConfidentialityWarning) {
-                    String warning1 = iterator.next();
-                    assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
-                }
-                String warning2 = iterator.next();
-                assertEquals("Document type is empty, are you happy to proceed?", warning2);
-            }
-
         } catch (IllegalStateException e) {
             assertTrue(furtherEvidenceActionList == null || originalSender == null);
         }
         if (null != furtherEvidenceActionList && null != originalSender) {
             assertHappyPaths(expectedDocumentType, response);
         }
-
     }
 
     @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenACaseWithScannedDocumentOfTypeCoversheet_shouldNotMoveToSscsDocumentsAndWarningShouldBeReturned(
-            DatedRequestOutcome appellantConfidentialityRequestOutcome,
-            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
+    @Parameters({"true", "false"})
+    public void givenACaseWithScannedDocumentOfTypeCoversheet_shouldNotMoveToSscsDocumentsAndWarningShouldBeReturned(boolean ignoreWarnings) {
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder()
-                        .type("coversheet")
-                        .fileName("bla.pdf")
-                        .subtype("sscs1")
-                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                        .scannedDate("2019-06-12T00:00:00.000")
-                        .controlNumber("123")
-                        .build()).build();
+            ScannedDocumentDetails.builder()
+                .type("coversheet")
+                .fileName("bla.pdf")
+                .subtype("sscs1")
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .scannedDate("2019-06-12T00:00:00.000")
+                .controlNumber("123")
+                .build()).build();
         scannedDocumentList = new ArrayList<>();
         scannedDocumentList.add(scannedDocument);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setFurtherEvidenceAction(buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
-                "\"Appellant (or Appointee)"));
+            "\"Appellant (or Appointee)"));
         sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
-                "Appellant (or Appointee)"));
+            "Appellant (or Appointee)"));
         sscsCaseData.setEvidenceHandled("No");
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
@@ -216,49 +195,37 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         if (ignoreWarnings) {
             assertEquals(0, response.getWarnings().size());
         } else {
-            assertEquals(expectConfidentialityWarning ? 2 : 1, response.getWarnings().size());
-            Iterator<String> iterator = response.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                String warning1 = iterator.next();
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
-            }
-            String warning2 = iterator.next();
-            assertEquals("Coversheet will be ignored, are you happy to proceed?", warning2);
-
+            String warning = response.getWarnings().stream().findFirst().orElse("");
+            assertEquals("Coversheet will be ignored, are you happy to proceed?", warning);
         }
     }
 
     @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenACaseWithAnEmptyScannedDocumentType_shouldMoveToSscsDocumentsAndWarningShouldBeReturned(
-            DatedRequestOutcome appellantConfidentialityRequestOutcome,
-            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
+    @Parameters({"true", "false"})
+    public void givenACaseWithAnEmptyScannedDocumentType_shouldMoveToSscsDocumentsAndWarningShouldBeReturned(boolean ignoreWarnings) {
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder()
-                        .type(null)
-                        .fileName("bla.pdf")
-                        .subtype("sscs1")
-                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                        .scannedDate("2019-06-12T00:00:00.000")
-                        .controlNumber("123")
-                        .build()).build();
+            ScannedDocumentDetails.builder()
+                .type(null)
+                .fileName("bla.pdf")
+                .subtype("sscs1")
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .scannedDate("2019-06-12T00:00:00.000")
+                .controlNumber("123")
+                .build()).build();
         scannedDocumentList = new ArrayList<>();
         scannedDocumentList.add(scannedDocument);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setFurtherEvidenceAction(
-                buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
-                        "\"Appellant (or Appointee)"));
+            buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
+                "\"Appellant (or Appointee)"));
         sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
-                "Appellant (or Appointee)"));
+            "Appellant (or Appointee)"));
         sscsCaseData.setEvidenceHandled("No");
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
 
         when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
         PreSubmitCallbackResponse<SscsCaseData> response =
-                actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+            actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertEquals(response.getData().getSscsDocument().size(), 1);
         assertEquals("Yes", response.getData().getEvidenceHandled());
@@ -266,18 +233,13 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         if (ignoreWarnings) {
             assertEquals(0, response.getWarnings().size());
         } else {
-            Iterator<String> iterator = response.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                String warning1 = iterator.next();
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
-            }
-            String warning2 = iterator.next();
-            assertEquals("Document type is empty, are you happy to proceed?", warning2);
+            String warning = response.getWarnings().stream().findFirst().orElse("");
+            assertEquals("Document type is empty, are you happy to proceed?", warning);
         }
     }
 
     private void assertHappyPaths(DocumentType expectedDocumentType,
-                                  PreSubmitCallbackResponse<SscsCaseData> response) {
+        PreSubmitCallbackResponse<SscsCaseData> response) {
 
         SscsDocumentDetails sscsDocumentDetail = response.getData().getSscsDocument().get(1).getValue();
         assertEquals((expectedDocumentType.getLabel() != null ? expectedDocumentType.getLabel() : expectedDocumentType.getValue()) + " received on 13-06-2019", sscsDocumentDetail.getDocumentFileName());
@@ -290,9 +252,537 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals("Yes", response.getData().getEvidenceHandled());
     }
 
+    private Object[] generateFurtherEvidenceActionListScenarios() {
+        DynamicList furtherEvidenceActionListOtherDocuments =
+            buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
+                "Other document type - action manually");
+
+        DynamicList furtherEvidenceActionListInterloc =
+            buildFurtherEvidenceActionItemListForGivenOption("informationReceivedForInterlocJudge",
+                "Information received for interlocutory review");
+
+        DynamicList furtherEvidenceActionListIssueParties =
+            buildFurtherEvidenceActionItemListForGivenOption("issueFurtherEvidence",
+                "Issue further evidence to all parties");
+
+        DynamicList appellantOriginalSender = buildOriginalSenderItemListForGivenOption("appellant",
+            "Appellant (or Appointee)");
+        DynamicList representativeOriginalSender = buildOriginalSenderItemListForGivenOption("representative",
+            "Representative");
+        DynamicList dwpOriginalSender = buildOriginalSenderItemListForGivenOption("dwp",
+            "Dwp");
+        DynamicList jointPartyOriginalSender = buildOriginalSenderItemListForGivenOption("jointParty",
+            "Joint Party");
+
+        return new Object[]{
+            //other options scenarios
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, null, OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "No", OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "Yes", OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "No", OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, null, OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "Yes", OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, "No", OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, null, OTHER_DOCUMENT},
+            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, "Yes", OTHER_DOCUMENT},
+            //issue parties scenarios
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, null, APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "No", APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "Yes", APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, null, REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, "No", DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, "Yes", DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, null, DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, "No", JOINT_PARTY_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, "Yes", JOINT_PARTY_EVIDENCE},
+            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, null, JOINT_PARTY_EVIDENCE},
+            //interloc scenarios
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, null, APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "No", APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "Yes", APPELLANT_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, null, REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, null, DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "No", DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "Yes", DWP_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, null, JOINT_PARTY_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, "No", JOINT_PARTY_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, "Yes", JOINT_PARTY_EVIDENCE},
+            //edge cases scenarios
+            new Object[]{null, representativeOriginalSender, "", null}, //edge case: furtherEvidenceActionOption is null
+            new Object[]{furtherEvidenceActionListIssueParties, null, null, null} //edge case: originalSender is null
+        };
+    }
+
+    private DynamicList buildOriginalSenderItemListForGivenOption(String code, String label) {
+        DynamicListItem value = new DynamicListItem(code, label);
+        return new DynamicList(value, Collections.singletonList(value));
+    }
+
+    private DynamicList buildFurtherEvidenceActionItemListForGivenOption(String code, String label) {
+        DynamicListItem selectedOption = new DynamicListItem(code, label);
+        return new DynamicList(selectedOption,
+            Collections.singletonList(selectedOption));
+    }
+
+    @Test
+    public void givenACaseWithScannedDocumentsAndSscsCaseDocuments_thenAppendNewDocumentsToSscsDocumentsList() {
+        List<SscsDocument> sscsDocuments = new ArrayList<>();
+        SscsDocument doc = SscsDocument.builder()
+            .value(SscsDocumentDetails.builder()
+                .documentType("appellantEvidence")
+                .documentFileName("exist.pdf")
+                .build())
+            .build();
+        sscsDocuments.add(doc);
+
+        sscsCaseData.setScannedDocuments(scannedDocumentList);
+        sscsCaseData.setSscsDocument(sscsDocuments);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("Other document received on 12-06-2019", response.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("2019-06-12", response.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
+        assertEquals("Other document received on 13-06-2019", response.getData().getSscsDocument().get(1).getValue().getDocumentFileName());
+        assertEquals("2019-06-13", response.getData().getSscsDocument().get(1).getValue().getDocumentDateAdded());
+        assertEquals("exist.pdf", response.getData().getSscsDocument().get(2).getValue().getDocumentFileName());
+        assertNull(response.getData().getScannedDocuments());
+    }
+
+    @Test
+    public void givenAWelshCaseWithScannedDocuments_thenSetTranslationStatusToRequired() {
+        List<SscsDocument> sscsDocuments = new ArrayList<>();
+        SscsDocument doc = SscsDocument.builder()
+            .value(SscsDocumentDetails.builder()
+                .documentType("appellantEvidence")
+                .documentFileName("exist.pdf")
+                .build())
+            .build();
+        sscsDocuments.add(doc);
+
+        sscsCaseData.setScannedDocuments(scannedDocumentList);
+        sscsCaseData.setSscsDocument(sscsDocuments);
+        sscsCaseData.setLanguagePreferenceWelsh("Yes");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("Other document received on 12-06-2019", response.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
+        assertEquals("2019-06-12", response.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
+        assertEquals(SscsDocumentTranslationStatus.TRANSLATION_REQUIRED, response.getData().getSscsDocument().get(0).getValue().getDocumentTranslationStatus());
+
+        assertEquals("Other document received on 13-06-2019", response.getData().getSscsDocument().get(1).getValue().getDocumentFileName());
+        assertEquals("2019-06-13", response.getData().getSscsDocument().get(1).getValue().getDocumentDateAdded());
+        assertEquals(SscsDocumentTranslationStatus.TRANSLATION_REQUIRED, response.getData().getSscsDocument().get(1).getValue().getDocumentTranslationStatus());
+
+        assertEquals("exist.pdf", response.getData().getSscsDocument().get(2).getValue().getDocumentFileName());
+        assertNull(response.getData().getSscsDocument().get(2).getValue().getDocumentTranslationStatus());
+        assertNull(response.getData().getScannedDocuments());
+        assertEquals("Yes", response.getData().getTranslationWorkOutstanding());
+    }
+
+    @Test
+    public void givenACaseWithScannedDocumentWithEmptyValues_thenHandleTheDocument() {
+        List<ScannedDocument> docs = new ArrayList<>();
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder()
+                .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                .build()).build();
+
+        docs.add(scannedDocument);
+
+        sscsCaseData.setScannedDocuments(docs);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("www.test.com", response.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+    }
+
+    @Test
+    public void givenACaseWithNoScannedDocuments_thenAddAnErrorToResponse() {
+        sscsCaseData.setScannedDocuments(null);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getErrors().size());
+
+        for (String error : response.getErrors()) {
+            assertEquals("No further evidence to process", error);
+        }
+    }
+
+    private Callback<SscsCaseData> buildCallback(String dynamicListItemCode) {
+        DynamicList dynamicList = new DynamicList(new DynamicListItem(dynamicListItemCode, "label"),
+            Collections.singletonList(new DynamicListItem(dynamicListItemCode, "label")));
+        SscsCaseData sscsCaseData = SscsCaseData.builder()
+            .originalSender(dynamicList)
+            .furtherEvidenceAction(dynamicList)
+            .scannedDocuments(Collections.singletonList(ScannedDocument.builder().build()))
+            .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
+            .build();
+        CaseDetails<SscsCaseData> caseDetails = new CaseDetails<>(123L, "sscs",
+            State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now());
+        return new Callback<>(caseDetails, Optional.empty(), EventType.ACTION_FURTHER_EVIDENCE, false);
+    }
+
+    @Test
+    public void givenIssueFurtherEvidence_shouldUpdateDwpFurtherEvidenceStates() {
+        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode());
+
+        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals("furtherEvidenceReceived", updated.getData().getDwpFurtherEvidenceStates());
+    }
+
+    @Test
+    @Parameters(method = "generateIssueFurtherEvidenceAddressEmptyScenarios")
+    public void givenIssueFurtherEvidenceAndEmptyAppellantAddress_shouldReturnAnErrorToUser(Appeal appeal, String... parties) {
+        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode());
+
+        callback.getCaseDetails().getCaseData().setAppeal(appeal);
+        PreSubmitCallbackResponse<SscsCaseData> result = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        for (String party : parties) {
+            String expectedError = "Address details are missing for the " + party + ", please validate or process manually";
+            assertTrue(result.getErrors().contains(expectedError));
+        }
+    }
+
+    private Object[] generateIssueFurtherEvidenceAddressEmptyScenarios() {
+
+        return new Object[]{
+            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().build()).build()).build(), "Appellant"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("Line1").build()).build()).build(), "Appellant"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().postcode("TS1 2BA").build()).build()).build(), "Appellant"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().address(null).build()).build(), "Appellant"},
+            new Object[]{Appeal.builder().appellant(null).build(), "Appellant"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").build()).build(), "Appointee"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().build()).build()).build(), "Appointee"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().address(Address.builder().build()).build()).build()).build(), "Appointee"},
+            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().address(null).build()).build()).build(), "Appointee"},
+            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(Address.builder().build()).build()).appellant(Appellant.builder().address(Address.builder().line1("The road").build()).build()).build(), "Representative"},
+            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(null).build()).appellant(Appellant.builder().address(Address.builder().line1("The road").build()).build()).build(), "Representative"},
+            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(Address.builder().build()).build()).appellant(Appellant.builder().address(null).build()).build(), "Appellant", "Representative"},
+        };
+    }
+
+    @Test
+    public void givenOtherDocument_shouldNotUpdateDwpFurtherEvidenceStates() {
+        Callback<SscsCaseData> callback = buildCallback(OTHER_DOCUMENT_MANUAL.getCode());
+
+        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertNull(updated.getData().getDwpFurtherEvidenceStates());
+    }
+
+    @Test
+    public void givenNullFurtherEvidenceAction_shouldNotUpdateDwpFurtherEvidenceStates() {
+        Callback<SscsCaseData> callback = buildCallback(null);
+
+        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertNull(updated.getData().getDwpFurtherEvidenceStates());
+    }
+
+    @Test
+    public void givenADocumentWithNoUrl_thenAddAnErrorToResponse() {
+        List<ScannedDocument> docs = new ArrayList<>();
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("Testing.jpg").build()).build();
+
+        docs.add(scannedDocument);
+
+        sscsCaseData.setScannedDocuments(docs);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getErrors().size());
+
+        for (String error : response.getErrors()) {
+            assertEquals("No document URL so could not process", error);
+        }
+    }
+
+    @Test
+    @Parameters({"null", " ", "    "})
+    public void givenADocumentWithNoDocFileName_thenAddAnErrorToResponse(@Nullable String filename) {
+        List<ScannedDocument> docs = new ArrayList<>();
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName(filename).url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+
+        docs.add(scannedDocument);
+
+        sscsCaseData.setScannedDocuments(docs);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getErrors().size());
+
+        for (String error : response.getErrors()) {
+            assertEquals("No document file name so could not process", error);
+        }
+    }
+
+    @Test
+    @Parameters({"null", "DORMANT_APPEAL_STATE", "VOID_STATE"})
+    public void shouldReviewByJudgeAndUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable State previousState) {
+
+        actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
+
+        List<ScannedDocument> docs = new ArrayList<>();
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
+        sscsCaseData.setPreviousState(previousState);
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData.getPreviousState());
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
+        assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
+        assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
+    }
+
+    @Test
+    @Parameters({"VALID_APPEAL", "READY_TO_LIST"})
+    public void shouldReviewByJudgeButNotUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable State previousState) {
+
+        actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
+
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
+        sscsCaseData.setPreviousState(previousState);
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(previousState, sscsCaseData.getPreviousState());
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
+        assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
+        assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
+    }
+
+    @Test
+    public void shouldNotUpdateInterlocReviewStateWhenActionManuallyAndHasNoReinstatementRequestDocument() {
+        sscsCaseData.setPreviousState(null);
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertNull(sscsCaseData.getPreviousState());
+        assertNull(sscsCaseData.getReinstatementOutcome());
+        assertNull(sscsCaseData.getReinstatementRegistered());
+        assertNull(sscsCaseData.getInterlocReviewState());
+    }
+
+    @Test
+    public void shouldNotUpdateInterlocReviewStateWhenNotActionManuallyAndHasReinstatementRequestDocument() {
+        sscsCaseData.setPreviousState(null);
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertNull(sscsCaseData.getPreviousState());
+        assertNull(sscsCaseData.getReinstatementOutcome());
+        assertNull(sscsCaseData.getReinstatementRegistered());
+        assertNull(sscsCaseData.getInterlocReviewState());
+    }
+
+    @Test
+    @Parameters({"SEND_TO_INTERLOC_REVIEW_BY_JUDGE", "INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"})
+    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(0, response.getWarnings().size());
+
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeJointParty());
+        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeAppellant().getDate());
+    }
+
+    @Test
+    @Parameters({"SEND_TO_INTERLOC_REVIEW_BY_JUDGE", "INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"})
+    public void givenConfidentialRequestWhenJointPartyExistsAndAlreadyHasConfidentialityFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFieldsAndDisplayWarning(FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(createDatedRequestOutcome(RequestOutcome.GRANTED));
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(1, response.getWarnings().size());
+
+        assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome());
+        assertEquals(createDatedRequestOutcome(RequestOutcome.GRANTED), sscsCaseData.getConfidentialityRequestOutcomeJointParty());
+        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeAppellant().getDate());
+    }
+
+    @Test
+    @Parameters({"SEND_TO_INTERLOC_REVIEW_BY_JUDGE", "INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"})
+    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderAppellant_thenShowError(FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(1, response.getErrors().size());
+        assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", response.getErrors().iterator().next());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeAppellant());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeJointParty());
+    }
+
+    @Test
+    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields() {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeJointParty().getRequestOutcome());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeAppellant());
+        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeJointParty().getDate());
+    }
+
+    @Test
+    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields() {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(1, response.getErrors().size());
+        assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", response.getErrors().iterator().next());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeJointParty());
+        assertNull(sscsCaseData.getConfidentialityRequestOutcomeAppellant());
+    }
+
+
+    @Test
+    public void givenConfidentialRequestFromRep_thenShowAnError() {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(OriginalSenderItemList.REPRESENTATIVE.getCode(), OriginalSenderItemList.REPRESENTATIVE.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(1, response.getErrors().size());
+        for (String error : response.getErrors()) {
+            assertEquals("Original sender must be appellant or joint party for a confidential document", error);
+        }
+    }
+
+    @Test
+    public void givenConfidentialRequestWithInvalidFurtherEvidenceAction_thenShowAnError() {
+
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(ISSUE_FURTHER_EVIDENCE.code, ISSUE_FURTHER_EVIDENCE.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(1, response.getErrors().size());
+        for (String error : response.getErrors()) {
+            assertEquals("Further evidence action must be 'Send to Interloc - Review by Judge' or 'Information received for Interloc - send to Judge' for a confidential document", error);
+        }
+    }
+
     private DatedRequestOutcome createDatedRequestOutcome(RequestOutcome requestOutcome) {
         return DatedRequestOutcome.builder().date(LocalDate.now().minusDays(1))
-                .requestOutcome(requestOutcome).build();
+            .requestOutcome(requestOutcome).build();
+    }
+
+    private Object[][] generateWrappedFurtherEvidenceActionListScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateFurtherEvidenceActionListScenarios());
+    }
+
+    private Object[][] wrapWithConfidentialityAndWarningCombinationScenarios(Object[] scenarios) {
+
+        Object[][] results = new Object[scenarios.length * confidentialityAndWarningRequestStateCombinations().length][];
+        int index = 0;
+        for (Object scenario : scenarios) {
+            for (Object[] confidentialityRequestStateCombination : confidentialityAndWarningRequestStateCombinations()) {
+                results[index++] = wrapScenario((Object[])scenario, confidentialityRequestStateCombination);
+            }
+        }
+        return results;
+    }
+
+    private Object[] wrapScenario(Object[] scenario, Object[] confidentialityRequestStateCombination) {
+        Object[] result = new Object[scenario.length + confidentialityRequestStateCombination.length];
+        for (int i = 0; i < confidentialityRequestStateCombination.length; i++) {
+            result[i] = confidentialityRequestStateCombination[i];
+        }
+        for (int i = 0; i < scenario.length; i++) {
+            result[confidentialityRequestStateCombination.length + i] = scenario[i];
+        }
+        return result;
     }
 
     protected Object[][] confidentialityAndWarningRequestStateCombinations() {
@@ -332,860 +822,45 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         };
     }
 
-    private Object[][] generateWrappedFurtherEvidenceActionListScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateFurtherEvidenceActionListScenarios());
-    }
-
-    private Object[][] wrapWithConfidentialityAndWarningCombinationScenarios(Object[][] scenarios) {
-
-        Object[][] results = new Object[scenarios.length * confidentialityAndWarningRequestStateCombinations().length][];
-        int index = 0;
-        for (Object[] scenario : scenarios) {
-            for (Object[] confidentialityRequestStateCombination : confidentialityAndWarningRequestStateCombinations()) {
-                results[index++] = wrapScenario(scenario, confidentialityRequestStateCombination);
-            }
-        }
-        return results;
-    }
-
-    private Object[] wrapScenario(Object[] scenario, Object[] confidentialityRequestStateCombination) {
-        Object[] result = new Object[scenario.length + confidentialityRequestStateCombination.length];
-        for (int i = 0; i < confidentialityRequestStateCombination.length; i++) {
-            result[i] = confidentialityRequestStateCombination[i];
-        }
-        for (int i = 0; i < scenario.length; i++) {
-            result[confidentialityRequestStateCombination.length + i] = scenario[i];
-        }
-        return result;
-    }
-
-    private Object[][] generateFurtherEvidenceActionListScenarios() {
-        DynamicList furtherEvidenceActionListOtherDocuments =
-                buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
-                        "Other document type - action manually");
-
-        DynamicList furtherEvidenceActionListInterloc =
-                buildFurtherEvidenceActionItemListForGivenOption("informationReceivedForInterlocJudge",
-                        "Information received for interlocutory review");
-
-        DynamicList furtherEvidenceActionListIssueParties =
-                buildFurtherEvidenceActionItemListForGivenOption("issueFurtherEvidence",
-                        "Issue further evidence to all parties");
-
-        DynamicList appellantOriginalSender = buildOriginalSenderItemListForGivenOption("appellant",
-                "Appellant (or Appointee)");
-        DynamicList representativeOriginalSender = buildOriginalSenderItemListForGivenOption("representative",
-                "Representative");
-        DynamicList dwpOriginalSender = buildOriginalSenderItemListForGivenOption("dwp",
-                "Dwp");
-        DynamicList jointPartyOriginalSender = buildOriginalSenderItemListForGivenOption("jointParty",
-                "Joint Party");
-
-        return new Object[][]{
-            //other options scenarios
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, null, OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "No", OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "Yes", OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "No", OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, null, OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, representativeOriginalSender, "Yes", OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, "No", OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, null, OTHER_DOCUMENT},
-            new Object[]{furtherEvidenceActionListOtherDocuments, dwpOriginalSender, "Yes", OTHER_DOCUMENT},
-            //issue parties scenarios
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, null, APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "No", APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, appellantOriginalSender, "Yes", APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, representativeOriginalSender, null, REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, "No", DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, "Yes", DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, dwpOriginalSender, null, DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, "No", JOINT_PARTY_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, "Yes", JOINT_PARTY_EVIDENCE},
-            new Object[]{furtherEvidenceActionListIssueParties, jointPartyOriginalSender, null, JOINT_PARTY_EVIDENCE},
-            //interloc scenarios
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, null, APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "No", APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "Yes", APPELLANT_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, null, REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE}, new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, null, DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "No", DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "Yes", DWP_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, null, JOINT_PARTY_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, "No", JOINT_PARTY_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, jointPartyOriginalSender, "Yes", JOINT_PARTY_EVIDENCE},
-            //edge cases scenarios
-            new Object[]{null, representativeOriginalSender, "", null}, //edge case: furtherEvidenceActionOption is null
-            new Object[]{furtherEvidenceActionListIssueParties, null, null, null} //edge case: originalSender is null
-        };
-    }
-
-    private DynamicList buildOriginalSenderItemListForGivenOption(String code, String label) {
-        DynamicListItem value = new DynamicListItem(code, label);
-        return new DynamicList(value, Collections.singletonList(value));
-    }
-
-    private DynamicList buildFurtherEvidenceActionItemListForGivenOption(String code, String label) {
-        DynamicListItem selectedOption = new DynamicListItem(code, label);
-        return new DynamicList(selectedOption,
-                Collections.singletonList(selectedOption));
-    }
-
     @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenACaseWithScannedDocumentsAndSscsCaseDocuments_thenAppendNewDocumentsToSscsDocumentsList(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                             @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome,
-                                                                                                             boolean ignoreWarnings,
-                                                                                                             boolean expectConfidentialityWarning) {
-        List<SscsDocument> sscsDocuments = new ArrayList<>();
-        SscsDocument doc = SscsDocument.builder()
-                .value(SscsDocumentDetails.builder()
-                        .documentType("appellantEvidence")
-                        .documentFileName("exist.pdf")
-                        .build())
-                .build();
-        sscsDocuments.add(doc);
+    @Parameters(method = "generateWrappedFurtherEvidenceActionListScenarios")
+    public void givenACaseWithScannedDocuments_shouldMoveToSscsDocumentsAndDisplayAppropriatesConfidentialityWarning(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+        @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome,
+        boolean ignoreWarnings,
+        boolean expectConfidentialityWarning,
+        @Nullable DynamicList furtherEvidenceActionList,
+        @Nullable DynamicList originalSender,
+        @Nullable String evidenceHandle,
+        DocumentType expectedDocumentType) {
+        sscsCaseData.setFurtherEvidenceAction(furtherEvidenceActionList);
+        sscsCaseData.setOriginalSender(originalSender);
+        sscsCaseData.setEvidenceHandled(evidenceHandle);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.setScannedDocuments(scannedDocumentList);
-        sscsCaseData.setSscsDocument(sscsDocuments);
+        PreSubmitCallbackResponse<SscsCaseData> response = null;
+        try {
+            response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals("Other document received on 12-06-2019", response.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
-        assertEquals("2019-06-12", response.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
-        assertEquals("Other document received on 13-06-2019", response.getData().getSscsDocument().get(1).getValue().getDocumentFileName());
-        assertEquals("2019-06-13", response.getData().getSscsDocument().get(1).getValue().getDocumentDateAdded());
-        assertEquals("exist.pdf", response.getData().getSscsDocument().get(2).getValue().getDocumentFileName());
-        assertNull(response.getData().getScannedDocuments());
-
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            if (!ignoreWarnings && anyDocumentTypeBlank) {
-                assertEquals(1, response.getWarnings().size());
-            } else {
+            if (ignoreWarnings) {
                 assertEquals(0, response.getWarnings().size());
-            }
-        } else {
-            assertEquals(2, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenAWelshCaseWithScannedDocuments_thenSetTranslationStatusToRequired(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                       @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                       boolean expectConfidentialityWarning) {
-        List<SscsDocument> sscsDocuments = new ArrayList<>();
-        SscsDocument doc = SscsDocument.builder()
-                .value(SscsDocumentDetails.builder()
-                        .documentType("appellantEvidence")
-                        .documentFileName("exist.pdf")
-                        .build())
-                .build();
-        sscsDocuments.add(doc);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.setScannedDocuments(scannedDocumentList);
-        sscsCaseData.setSscsDocument(sscsDocuments);
-        sscsCaseData.setLanguagePreferenceWelsh("Yes");
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals("Other document received on 12-06-2019", response.getData().getSscsDocument().get(0).getValue().getDocumentFileName());
-        assertEquals("2019-06-12", response.getData().getSscsDocument().get(0).getValue().getDocumentDateAdded());
-        assertEquals(SscsDocumentTranslationStatus.TRANSLATION_REQUIRED, response.getData().getSscsDocument().get(0).getValue().getDocumentTranslationStatus());
-
-        assertEquals("Other document received on 13-06-2019", response.getData().getSscsDocument().get(1).getValue().getDocumentFileName());
-        assertEquals("2019-06-13", response.getData().getSscsDocument().get(1).getValue().getDocumentDateAdded());
-        assertEquals(SscsDocumentTranslationStatus.TRANSLATION_REQUIRED, response.getData().getSscsDocument().get(1).getValue().getDocumentTranslationStatus());
-
-        assertEquals("exist.pdf", response.getData().getSscsDocument().get(2).getValue().getDocumentFileName());
-        assertNull(response.getData().getSscsDocument().get(2).getValue().getDocumentTranslationStatus());
-        assertNull(response.getData().getScannedDocuments());
-        assertEquals("Yes", response.getData().getTranslationWorkOutstanding());
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            if (!ignoreWarnings && anyDocumentTypeBlank) {
-                assertEquals(1, response.getWarnings().size());
             } else {
-                assertTrue(response.getWarnings().isEmpty());
+                Iterator<String> iterator = response.getWarnings().iterator();
+                if (expectConfidentialityWarning) {
+                    String warning1 = iterator.next();
+                    assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
+                }
+                String warning2 = iterator.next();
+                assertEquals("Document type is empty, are you happy to proceed?", warning2);
             }
-        } else {
-            assertEquals(2, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+
+        } catch (IllegalStateException e) {
+            assertTrue(furtherEvidenceActionList == null || originalSender == null);
         }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenACaseWithScannedDocumentWithEmptyValues_thenHandleTheDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                   @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                   boolean expectConfidentialityWarning) {
-        List<ScannedDocument> docs = new ArrayList<>();
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder()
-                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                        .build()).build();
-
-        docs.add(scannedDocument);
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        sscsCaseData.setScannedDocuments(docs);
-
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals("www.test.com", response.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
-
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
-            Iterator<String> iterator = response.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-            if (anyDocumentTypeBlank) {
-                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
-            }
-        } else {
-            assertEquals(0, response.getWarnings().size());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenACaseWithNoScannedDocuments_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                          @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                          boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setScannedDocuments(null);
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals(1, response.getErrors().size());
-
-        for (String error : response.getErrors()) {
-            assertEquals("No further evidence to process", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    private Callback<SscsCaseData> buildCallback(String dynamicListItemCode, boolean isIgnoreWarnings) {
-        DynamicList dynamicList = new DynamicList(new DynamicListItem(dynamicListItemCode, "label"),
-                Collections.singletonList(new DynamicListItem(dynamicListItemCode, "label")));
-        SscsCaseData sscsCaseData = SscsCaseData.builder()
-                .originalSender(dynamicList)
-                .furtherEvidenceAction(dynamicList)
-                .scannedDocuments(Collections.singletonList(ScannedDocument.builder().build()))
-                .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
-                .build();
-        CaseDetails<SscsCaseData> caseDetails = new CaseDetails<>(123L, "sscs",
-                State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now());
-        return new Callback<>(caseDetails, Optional.empty(), EventType.ACTION_FURTHER_EVIDENCE, isIgnoreWarnings);
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenIssueFurtherEvidence_shouldUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                               @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                               boolean expectConfidentialityWarning) {
-        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode(), ignoreWarnings);
-
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals("furtherEvidenceReceived", updated.getData().getDwpFurtherEvidenceStates());
-
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
-            Iterator<String> iterator = updated.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-        } else {
-            assertEquals(0, updated.getWarnings().size());
-        }
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedIssueFurtherEvidenceAddressEmptyScenarios")
-    public void givenIssueFurtherEvidenceAndEmptyAppellantAddress_shouldReturnAnErrorToUser(DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning, Appeal appeal, String... parties) {
-        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode(), ignoreWarnings);
-
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        callback.getCaseDetails().getCaseData().setAppeal(appeal);
-
-        PreSubmitCallbackResponse<SscsCaseData> result = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        for (String party : parties) {
-            String expectedError = "Address details are missing for the " + party + ", please validate or process manually";
-            assertTrue(result.getErrors().contains(expectedError));
-        }
-
-        if (!ignoreWarnings && expectConfidentialityWarning) {
-            assertEquals(1, result.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", result.getWarnings().iterator().next());
-        } else {
-            assertEquals(0, result.getWarnings().size());
-        }
-    }
-
-    private Object[][] generateWrappedIssueFurtherEvidenceAddressEmptyScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateIssueFurtherEvidenceAddressEmptyScenarios());
-    }
-
-    private Object[][] generateIssueFurtherEvidenceAddressEmptyScenarios() {
-
-        return new Object[][]{
-            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().build()).build()).build(), "Appellant"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("Line1").build()).build()).build(), "Appellant"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().postcode("TS1 2BA").build()).build()).build(), "Appellant"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().address(null).build()).build(), "Appellant"},
-            new Object[]{Appeal.builder().appellant(null).build(), "Appellant"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").build()).build(), "Appointee"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().build()).build()).build(), "Appointee"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().address(Address.builder().build()).build()).build()).build(), "Appointee"},
-            new Object[]{Appeal.builder().appellant(Appellant.builder().isAppointee("Yes").appointee(Appointee.builder().address(null).build()).build()).build(), "Appointee"},
-            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(Address.builder().build()).build()).appellant(Appellant.builder().address(Address.builder().line1("The road").build()).build()).build(), "Representative"},
-            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(null).build()).appellant(Appellant.builder().address(Address.builder().line1("The road").build()).build()).build(), "Representative"},
-            new Object[]{Appeal.builder().rep(Representative.builder().hasRepresentative("Yes").address(Address.builder().build()).build()).appellant(Appellant.builder().address(null).build()).build(), "Appellant", "Representative"},
-        };
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenOtherDocument_shouldNotUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                           @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                           boolean expectConfidentialityWarning) {
-        Callback<SscsCaseData> callback = buildCallback(OTHER_DOCUMENT_MANUAL.getCode(), ignoreWarnings);
-
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertNull(updated.getData().getDwpFurtherEvidenceStates());
-
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
-            Iterator<String> iterator = updated.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-        } else {
-            assertEquals(0, updated.getWarnings().size());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenNullFurtherEvidenceAction_shouldNotUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                       @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                       boolean expectConfidentialityWarning) {
-        Callback<SscsCaseData> callback = buildCallback(null, ignoreWarnings);
-
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertNull(updated.getData().getDwpFurtherEvidenceStates());
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
-            Iterator<String> iterator = updated.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-        } else {
-            assertEquals(0, updated.getWarnings().size());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenADocumentWithNoUrl_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                 @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                 boolean expectConfidentialityWarning) {
-        List<ScannedDocument> docs = new ArrayList<>();
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("Testing.jpg").build()).build();
-
-        docs.add(scannedDocument);
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        sscsCaseData.setScannedDocuments(docs);
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals(1, response.getErrors().size());
-
-        for (String error : response.getErrors()) {
-            assertEquals("No document URL so could not process", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            if (!ignoreWarnings && anyDocumentTypeBlank) {
-                assertEquals(1, response.getWarnings().size());
-            } else {
-                assertTrue(response.getWarnings().isEmpty());
-            }
-        } else {
-            assertEquals(2, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    private Object[][] generateFileNameScenarios() {
-        return new Object[][]{new Object[]{null}, new Object[]{" "}, new Object[]{"    "}};
-    }
-
-    private Object[][] generateWrappedFileNameScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateFileNameScenarios());
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedFileNameScenarios")
-    public void givenADocumentWithNoDocFileName_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                         boolean expectConfidentialityWarning, @Nullable String filename) {
-        List<ScannedDocument> docs = new ArrayList<>();
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName(filename).url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-
-        docs.add(scannedDocument);
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        sscsCaseData.setScannedDocuments(docs);
-
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-
-        assertEquals(1, response.getErrors().size());
-
-        for (String error : response.getErrors()) {
-            assertEquals("No document file name so could not process", error);
-        }
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
-            Iterator<String> iterator = response.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-            if (anyDocumentTypeBlank) {
-                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
-            }
-        } else {
-            assertEquals(0, response.getWarnings().size());
-        }
-    }
-
-    private Object[][] generateUpdatePreviousStateScenarios() {
-        return new Object[][]{
-            new Object[]{null},
-            new Object[]{"DORMANT_APPEAL_STATE"},
-            new Object[]{"VOID_STATE"}
-        };
-    }
-
-    private Object[][] generateWrappedUpdatePreviousStateScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateUpdatePreviousStateScenarios());
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedUpdatePreviousStateScenarios")
-    public void shouldReviewByJudgeAndUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                              @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                              boolean expectConfidentialityWarning, @Nullable State previousState) {
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
-
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
-        sscsCaseData.setPreviousState(previousState);
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-        List<ScannedDocument> docs = new ArrayList<>();
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData.getPreviousState());
-        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
-        assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
-        assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    private Object[][] generateNotUpdatePreviousStateScenarios() {
-        return new Object[][]{
-            new Object[]{"VALID_APPEAL"},
-            new Object[]{"READY_TO_LIST"}
-        };
-    }
-
-    private Object[][] generateWrappedNotUpdatePreviousStateScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateNotUpdatePreviousStateScenarios());
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedNotUpdatePreviousStateScenarios")
-    public void shouldReviewByJudgeButNotUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                                 @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning, @Nullable State previousState) {
-
-        actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
-        sscsCaseData.setPreviousState(previousState);
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(previousState, sscsCaseData.getPreviousState());
-        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
-        assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
-        assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void shouldNotUpdateInterlocReviewStateWhenActionManuallyAndHasNoReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                         boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.setPreviousState(null);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
-
-        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
-
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertNull(sscsCaseData.getPreviousState());
-        assertNull(sscsCaseData.getReinstatementOutcome());
-        assertNull(sscsCaseData.getReinstatementRegistered());
-        assertNull(sscsCaseData.getInterlocReviewState());
-
-        if (!ignoreWarnings) {
-            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
-            Iterator<String> iterator = response.getWarnings().iterator();
-            if (expectConfidentialityWarning) {
-                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
-            }
-            if (anyDocumentTypeBlank) {
-                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
-            }
-        } else {
-            assertEquals(0, response.getWarnings().size());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void shouldNotUpdateInterlocReviewStateWhenNotActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                          @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                          boolean expectConfidentialityWarning) {
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.setPreviousState(null);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertNull(sscsCaseData.getPreviousState());
-        assertNull(sscsCaseData.getReinstatementOutcome());
-        assertNull(sscsCaseData.getReinstatementRegistered());
-        assertNull(sscsCaseData.getInterlocReviewState());
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    private Object[][] generateSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios() {
-        return new Object[][]{
-            new Object[]{"SEND_TO_INTERLOC_REVIEW_BY_JUDGE"},
-            new Object[]{"INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"}
-        };
-    }
-
-    private Object[][] generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios() {
-        return wrapWithConfidentialityAndWarningCombinationScenarios(generateSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios());
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios")
-    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                                                   @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                                                   boolean expectConfidentialityWarning, FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(1, response.getErrors().size());
-        for (String error : response.getErrors()) {
-            assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios")
-    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                                             @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                                             boolean expectConfidentialityWarning, FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
-        sscsCaseData.setJointParty("Yes");
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome());
-        assertEquals(jointPartyConfidentialityRequestOutcome, sscsCaseData.getConfidentialityRequestOutcomeJointParty());
-        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeAppellant().getDate());
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                                                    @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                                                                    boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(1, response.getErrors().size());
-        for (String error : response.getErrors()) {
-            assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                                                              @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
-        sscsCaseData.setJointParty("Yes");
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeJointParty().getRequestOutcome());
-        assertEquals(appellantConfidentialityRequestOutcome, sscsCaseData.getConfidentialityRequestOutcomeAppellant());
-        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeJointParty().getDate());
-
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenConfidentialRequestFromRep_thenShowAnError(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(OriginalSenderItemList.REPRESENTATIVE.getCode(), OriginalSenderItemList.REPRESENTATIVE.getLabel()));
-        sscsCaseData.setJointParty("Yes");
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(1, response.getErrors().size());
-        for (String error : response.getErrors()) {
-            assertEquals("Original sender must be appellant or joint party for a confidential document", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
-        }
-    }
-
-    @Test
-    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
-    public void givenConfidentialRequestWithInvalidFurtherEvidenceAction_thenShowAnError(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
-                                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
-                                                                                         boolean expectConfidentialityWarning) {
-
-        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
-
-        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
-        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
-        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(ISSUE_FURTHER_EVIDENCE.code, ISSUE_FURTHER_EVIDENCE.label));
-        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
-        sscsCaseData.setJointParty("Yes");
-
-        ScannedDocument scannedDocument = ScannedDocument.builder().value(
-                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
-                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
-        List<ScannedDocument> docs = new ArrayList<>();
-        docs.add(scannedDocument);
-        sscsCaseData.setScannedDocuments(docs);
-        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(1, response.getErrors().size());
-        for (String error : response.getErrors()) {
-            assertEquals("Further evidence action must be 'Send to Interloc - Review by Judge' or 'Information received for Interloc - send to Judge' for a confidential document", error);
-        }
-        if (ignoreWarnings || !expectConfidentialityWarning) {
-            assertTrue(response.getWarnings().isEmpty());
-        } else {
-            assertEquals(1, response.getWarnings().size());
-            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        if (null != furtherEvidenceActionList && null != originalSender) {
+            assertHappyPaths(expectedDocumentType, response);
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
@@ -1,10 +1,19 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
-import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.*;
-import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.*;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.APPELLANT_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.DWP_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.JOINT_PARTY_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.OTHER_DOCUMENT;
+import static uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType.REPRESENTATIVE_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.ISSUE_FURTHER_EVIDENCE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.OTHER_DOCUMENT_MANUAL;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.FurtherEvidenceActionDynamicListItems.SEND_TO_INTERLOC_REVIEW_BY_JUDGE;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.OriginalSenderItemList.APPELLANT;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.furtherevidence.actionfurtherevidence.OriginalSenderItemList.JOINT_PARTY;
 
@@ -12,12 +21,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +40,25 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.callback.ScannedDocumentType;
-import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Address;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appeal;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appellant;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Appointee;
+import uk.gov.hmcts.reform.sscs.ccd.domain.CaseDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DatedRequestOutcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicList;
+import uk.gov.hmcts.reform.sscs.ccd.domain.DynamicListItem;
+import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Representative;
+import uk.gov.hmcts.reform.sscs.ccd.domain.RequestOutcome;
+import uk.gov.hmcts.reform.sscs.ccd.domain.ScannedDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.ScannedDocumentDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocument;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentDetails;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsDocumentTranslationStatus;
+import uk.gov.hmcts.reform.sscs.ccd.domain.State;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState;
 import uk.gov.hmcts.reform.sscs.service.BundleAdditionFilenameBuilder;
 import uk.gov.hmcts.reform.sscs.service.FooterService;
@@ -37,26 +66,19 @@ import uk.gov.hmcts.reform.sscs.service.FooterService;
 @RunWith(JUnitParamsRunner.class)
 public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
 
+    private static final String USER_AUTHORISATION = "Bearer token";
+    private final BundleAdditionFilenameBuilder bundleAdditionFilenameBuilder = new BundleAdditionFilenameBuilder();
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
-
-    private static final String USER_AUTHORISATION = "Bearer token";
-
     private ActionFurtherEvidenceAboutToSubmitHandler actionFurtherEvidenceAboutToSubmitHandler;
-
     @Mock
     private Callback<SscsCaseData> callback;
-
     @Mock
     private CaseDetails<SscsCaseData> caseDetails;
-
     @Mock
     private FooterService footerService;
-
     private SscsCaseData sscsCaseData;
-
     private List<ScannedDocument> scannedDocumentList = new ArrayList<>();
-    private BundleAdditionFilenameBuilder bundleAdditionFilenameBuilder = new BundleAdditionFilenameBuilder();
 
     @Before
     public void setUp() {
@@ -65,39 +87,39 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         when(callback.getEvent()).thenReturn(EventType.ACTION_FURTHER_EVIDENCE);
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder()
-                .fileName("bla.pdf")
-                .subtype("sscs1")
-                .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                .scannedDate("2019-06-13T00:00:00.000")
-                .controlNumber("123")
-                .build()).build();
+                ScannedDocumentDetails.builder()
+                        .fileName("bla.pdf")
+                        .subtype("sscs1")
+                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                        .scannedDate("2019-06-13T00:00:00.000")
+                        .controlNumber("123")
+                        .build()).build();
 
         ScannedDocument scannedDocument2 = ScannedDocument.builder()
-            .value(ScannedDocumentDetails.builder()
-                .fileName("bla2.pdf")
-                .subtype("sscs2")
-                .url(DocumentLink.builder().documentUrl("www.test2.com").build())
-                .scannedDate("2019-06-12T00:00:00.000")
-                .controlNumber("124")
-                .build())
-            .build();
+                .value(ScannedDocumentDetails.builder()
+                        .fileName("bla2.pdf")
+                        .subtype("sscs2")
+                        .url(DocumentLink.builder().documentUrl("www.test2.com").build())
+                        .scannedDate("2019-06-12T00:00:00.000")
+                        .controlNumber("124")
+                        .build())
+                .build();
 
         scannedDocumentList.add(scannedDocument);
         scannedDocumentList.add(scannedDocument2);
         DynamicList furtherEvidenceActionList = buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
-            "Other document type - action manually");
+                "Other document type - action manually");
 
         DynamicListItem value = new DynamicListItem("appellant", "Appellant (or Appointee)");
         DynamicList originalSender = new DynamicList(value, Collections.singletonList(value));
 
         sscsCaseData = SscsCaseData.builder()
-            .ccdCaseId("1234")
-            .scannedDocuments(scannedDocumentList)
-            .furtherEvidenceAction(furtherEvidenceActionList)
-            .originalSender(originalSender)
-            .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
-            .build();
+                .ccdCaseId("1234")
+                .scannedDocuments(scannedDocumentList)
+                .furtherEvidenceAction(furtherEvidenceActionList)
+                .originalSender(originalSender)
+                .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
+                .build();
 
         when(callback.getCaseDetails()).thenReturn(caseDetails);
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
@@ -116,46 +138,73 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
     }
 
     @Test
-    @Parameters(method = "generateFurtherEvidenceActionListScenarios")
-    public void givenACaseWithScannedDocuments_shouldMoveToSscsDocuments(@Nullable DynamicList furtherEvidenceActionList,
+    @Parameters(method = "generateWrappedFurtherEvidenceActionListScenarios")
+    public void givenACaseWithScannedDocuments_shouldMoveToSscsDocuments(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome,
+                                                                         boolean ignoreWarnings,
+                                                                         boolean expectConfidentialityWarning,
+                                                                         @Nullable DynamicList furtherEvidenceActionList,
                                                                          @Nullable DynamicList originalSender,
                                                                          @Nullable String evidenceHandle,
                                                                          DocumentType expectedDocumentType) {
         sscsCaseData.setFurtherEvidenceAction(furtherEvidenceActionList);
         sscsCaseData.setOriginalSender(originalSender);
         sscsCaseData.setEvidenceHandled(evidenceHandle);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
 
         PreSubmitCallbackResponse<SscsCaseData> response = null;
         try {
             response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+            if (ignoreWarnings) {
+                assertEquals(0, response.getWarnings().size());
+            } else {
+                Iterator<String> iterator = response.getWarnings().iterator();
+                if (expectConfidentialityWarning) {
+                    String warning1 = iterator.next();
+                    assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
+                }
+                String warning2 = iterator.next();
+                assertEquals("Document type is empty, are you happy to proceed?", warning2);
+            }
+
         } catch (IllegalStateException e) {
             assertTrue(furtherEvidenceActionList == null || originalSender == null);
         }
         if (null != furtherEvidenceActionList && null != originalSender) {
             assertHappyPaths(expectedDocumentType, response);
         }
+
     }
 
     @Test
-    @Parameters({"true", "false"})
-    public void givenACaseWithScannedDocumentOfTypeCoversheet_shouldNotMoveToSscsDocumentsAndWarningShouldBeReturned(boolean ignoreWarnings) {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenACaseWithScannedDocumentOfTypeCoversheet_shouldNotMoveToSscsDocumentsAndWarningShouldBeReturned(
+            DatedRequestOutcome appellantConfidentialityRequestOutcome,
+            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder()
-                .type("coversheet")
-                .fileName("bla.pdf")
-                .subtype("sscs1")
-                .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                .scannedDate("2019-06-12T00:00:00.000")
-                .controlNumber("123")
-                .build()).build();
+                ScannedDocumentDetails.builder()
+                        .type("coversheet")
+                        .fileName("bla.pdf")
+                        .subtype("sscs1")
+                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                        .scannedDate("2019-06-12T00:00:00.000")
+                        .controlNumber("123")
+                        .build()).build();
         scannedDocumentList = new ArrayList<>();
         scannedDocumentList.add(scannedDocument);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setFurtherEvidenceAction(buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
-            "\"Appellant (or Appointee)"));
+                "\"Appellant (or Appointee)"));
         sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
-            "Appellant (or Appointee)"));
+                "Appellant (or Appointee)"));
         sscsCaseData.setEvidenceHandled("No");
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
@@ -167,37 +216,49 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         if (ignoreWarnings) {
             assertEquals(0, response.getWarnings().size());
         } else {
-            String warning = response.getWarnings().stream().findFirst().orElse("");
-            assertEquals("Coversheet will be ignored, are you happy to proceed?", warning);
+            assertEquals(expectConfidentialityWarning ? 2 : 1, response.getWarnings().size());
+            Iterator<String> iterator = response.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                String warning1 = iterator.next();
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
+            }
+            String warning2 = iterator.next();
+            assertEquals("Coversheet will be ignored, are you happy to proceed?", warning2);
+
         }
     }
 
     @Test
-    @Parameters({"true", "false"})
-    public void givenACaseWithAnEmptyScannedDocumentType_shouldMoveToSscsDocumentsAndWarningShouldBeReturned(boolean ignoreWarnings) {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenACaseWithAnEmptyScannedDocumentType_shouldMoveToSscsDocumentsAndWarningShouldBeReturned(
+            DatedRequestOutcome appellantConfidentialityRequestOutcome,
+            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder()
-                .type(null)
-                .fileName("bla.pdf")
-                .subtype("sscs1")
-                .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                .scannedDate("2019-06-12T00:00:00.000")
-                .controlNumber("123")
-                .build()).build();
+                ScannedDocumentDetails.builder()
+                        .type(null)
+                        .fileName("bla.pdf")
+                        .subtype("sscs1")
+                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                        .scannedDate("2019-06-12T00:00:00.000")
+                        .controlNumber("123")
+                        .build()).build();
         scannedDocumentList = new ArrayList<>();
         scannedDocumentList.add(scannedDocument);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setFurtherEvidenceAction(
-            buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
-                "\"Appellant (or Appointee)"));
+                buildFurtherEvidenceActionItemListForGivenOption(APPELLANT_EVIDENCE.getValue(),
+                        "\"Appellant (or Appointee)"));
         sscsCaseData.setOriginalSender(buildOriginalSenderItemListForGivenOption("appellant",
-            "Appellant (or Appointee)"));
+                "Appellant (or Appointee)"));
         sscsCaseData.setEvidenceHandled("No");
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
 
         when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
         PreSubmitCallbackResponse<SscsCaseData> response =
-            actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+                actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertEquals(response.getData().getSscsDocument().size(), 1);
         assertEquals("Yes", response.getData().getEvidenceHandled());
@@ -205,8 +266,13 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         if (ignoreWarnings) {
             assertEquals(0, response.getWarnings().size());
         } else {
-            String warning = response.getWarnings().stream().findFirst().orElse("");
-            assertEquals("Document type is empty, are you happy to proceed?", warning);
+            Iterator<String> iterator = response.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                String warning1 = iterator.next();
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", warning1);
+            }
+            String warning2 = iterator.next();
+            assertEquals("Document type is empty, are you happy to proceed?", warning2);
         }
     }
 
@@ -224,29 +290,98 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals("Yes", response.getData().getEvidenceHandled());
     }
 
-    private Object[] generateFurtherEvidenceActionListScenarios() {
+    private DatedRequestOutcome createDatedRequestOutcome(RequestOutcome requestOutcome) {
+        return DatedRequestOutcome.builder().date(LocalDate.now().minusDays(1))
+                .requestOutcome(requestOutcome).build();
+    }
+
+    protected Object[][] confidentialityAndWarningRequestStateCombinations() {
+        return new Object[][]{
+            new Object[]{null, null, false, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), false, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.REFUSED), false, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.GRANTED), false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), null, false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.REFUSED), false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.GRANTED), false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), null, false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.REFUSED), false, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.GRANTED), false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), null, false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.REFUSED), false, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.GRANTED), false, true},
+            new Object[]{null, null, true, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), true, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.REFUSED), true, false},
+            new Object[]{null, createDatedRequestOutcome(RequestOutcome.GRANTED), true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), null, true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.REFUSED), true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), createDatedRequestOutcome(RequestOutcome.GRANTED), true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), null, true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.REFUSED), true, false},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.REFUSED), createDatedRequestOutcome(RequestOutcome.GRANTED), true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), null, true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.IN_PROGRESS), true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.REFUSED), true, true},
+            new Object[]{createDatedRequestOutcome(RequestOutcome.GRANTED), createDatedRequestOutcome(RequestOutcome.GRANTED), true, true},
+        };
+    }
+
+    private Object[][] generateWrappedFurtherEvidenceActionListScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateFurtherEvidenceActionListScenarios());
+    }
+
+    private Object[][] wrapWithConfidentialityAndWarningCombinationScenarios(Object[][] scenarios) {
+
+        Object[][] results = new Object[scenarios.length * confidentialityAndWarningRequestStateCombinations().length][];
+        int index = 0;
+        for (Object[] scenario : scenarios) {
+            for (Object[] confidentialityRequestStateCombination : confidentialityAndWarningRequestStateCombinations()) {
+                results[index++] = wrapScenario(scenario, confidentialityRequestStateCombination);
+            }
+        }
+        return results;
+    }
+
+    private Object[] wrapScenario(Object[] scenario, Object[] confidentialityRequestStateCombination) {
+        Object[] result = new Object[scenario.length + confidentialityRequestStateCombination.length];
+        for (int i = 0; i < confidentialityRequestStateCombination.length; i++) {
+            result[i] = confidentialityRequestStateCombination[i];
+        }
+        for (int i = 0; i < scenario.length; i++) {
+            result[confidentialityRequestStateCombination.length + i] = scenario[i];
+        }
+        return result;
+    }
+
+    private Object[][] generateFurtherEvidenceActionListScenarios() {
         DynamicList furtherEvidenceActionListOtherDocuments =
-            buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
-                "Other document type - action manually");
+                buildFurtherEvidenceActionItemListForGivenOption("otherDocumentManual",
+                        "Other document type - action manually");
 
         DynamicList furtherEvidenceActionListInterloc =
-            buildFurtherEvidenceActionItemListForGivenOption("informationReceivedForInterlocJudge",
-                "Information received for interlocutory review");
+                buildFurtherEvidenceActionItemListForGivenOption("informationReceivedForInterlocJudge",
+                        "Information received for interlocutory review");
 
         DynamicList furtherEvidenceActionListIssueParties =
-            buildFurtherEvidenceActionItemListForGivenOption("issueFurtherEvidence",
-                "Issue further evidence to all parties");
+                buildFurtherEvidenceActionItemListForGivenOption("issueFurtherEvidence",
+                        "Issue further evidence to all parties");
 
         DynamicList appellantOriginalSender = buildOriginalSenderItemListForGivenOption("appellant",
-            "Appellant (or Appointee)");
+                "Appellant (or Appointee)");
         DynamicList representativeOriginalSender = buildOriginalSenderItemListForGivenOption("representative",
-            "Representative");
+                "Representative");
         DynamicList dwpOriginalSender = buildOriginalSenderItemListForGivenOption("dwp",
-            "Dwp");
+                "Dwp");
         DynamicList jointPartyOriginalSender = buildOriginalSenderItemListForGivenOption("jointParty",
                 "Joint Party");
 
-        return new Object[]{
+        return new Object[][]{
             //other options scenarios
             new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, null, OTHER_DOCUMENT},
             new Object[]{furtherEvidenceActionListOtherDocuments, appellantOriginalSender, "No", OTHER_DOCUMENT},
@@ -275,8 +410,7 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
             new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "No", APPELLANT_EVIDENCE},
             new Object[]{furtherEvidenceActionListInterloc, appellantOriginalSender, "Yes", APPELLANT_EVIDENCE},
             new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, null, REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE},
-            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
+            new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "No", REPRESENTATIVE_EVIDENCE}, new Object[]{furtherEvidenceActionListInterloc, representativeOriginalSender, "Yes", REPRESENTATIVE_EVIDENCE},
             new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, null, DWP_EVIDENCE},
             new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "No", DWP_EVIDENCE},
             new Object[]{furtherEvidenceActionListInterloc, dwpOriginalSender, "Yes", DWP_EVIDENCE},
@@ -297,22 +431,32 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
     private DynamicList buildFurtherEvidenceActionItemListForGivenOption(String code, String label) {
         DynamicListItem selectedOption = new DynamicListItem(code, label);
         return new DynamicList(selectedOption,
-            Collections.singletonList(selectedOption));
+                Collections.singletonList(selectedOption));
     }
 
     @Test
-    public void givenACaseWithScannedDocumentsAndSscsCaseDocuments_thenAppendNewDocumentsToSscsDocumentsList() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenACaseWithScannedDocumentsAndSscsCaseDocuments_thenAppendNewDocumentsToSscsDocumentsList(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                             @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome,
+                                                                                                             boolean ignoreWarnings,
+                                                                                                             boolean expectConfidentialityWarning) {
         List<SscsDocument> sscsDocuments = new ArrayList<>();
         SscsDocument doc = SscsDocument.builder()
-            .value(SscsDocumentDetails.builder()
-                .documentType("appellantEvidence")
-                .documentFileName("exist.pdf")
-                .build())
-            .build();
+                .value(SscsDocumentDetails.builder()
+                        .documentType("appellantEvidence")
+                        .documentFileName("exist.pdf")
+                        .build())
+                .build();
         sscsDocuments.add(doc);
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setSscsDocument(sscsDocuments);
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -322,22 +466,42 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals("2019-06-13", response.getData().getSscsDocument().get(1).getValue().getDocumentDateAdded());
         assertEquals("exist.pdf", response.getData().getSscsDocument().get(2).getValue().getDocumentFileName());
         assertNull(response.getData().getScannedDocuments());
+
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            if (!ignoreWarnings && anyDocumentTypeBlank) {
+                assertEquals(1, response.getWarnings().size());
+            } else {
+                assertEquals(0, response.getWarnings().size());
+            }
+        } else {
+            assertEquals(2, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
     @Test
-    public void givenAWelshCaseWithScannedDocuments_thenSetTranslationStatusToRequired() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenAWelshCaseWithScannedDocuments_thenSetTranslationStatusToRequired(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                       @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                       boolean expectConfidentialityWarning) {
         List<SscsDocument> sscsDocuments = new ArrayList<>();
         SscsDocument doc = SscsDocument.builder()
-            .value(SscsDocumentDetails.builder()
-                .documentType("appellantEvidence")
-                .documentFileName("exist.pdf")
-                .build())
-            .build();
+                .value(SscsDocumentDetails.builder()
+                        .documentType("appellantEvidence")
+                        .documentFileName("exist.pdf")
+                        .build())
+                .build();
         sscsDocuments.add(doc);
 
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.setScannedDocuments(scannedDocumentList);
         sscsCaseData.setSscsDocument(sscsDocuments);
         sscsCaseData.setLanguagePreferenceWelsh("Yes");
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -353,29 +517,70 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertNull(response.getData().getSscsDocument().get(2).getValue().getDocumentTranslationStatus());
         assertNull(response.getData().getScannedDocuments());
         assertEquals("Yes", response.getData().getTranslationWorkOutstanding());
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            if (!ignoreWarnings && anyDocumentTypeBlank) {
+                assertEquals(1, response.getWarnings().size());
+            } else {
+                assertTrue(response.getWarnings().isEmpty());
+            }
+        } else {
+            assertEquals(2, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
     @Test
-    public void givenACaseWithScannedDocumentWithEmptyValues_thenHandleTheDocument() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenACaseWithScannedDocumentWithEmptyValues_thenHandleTheDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                   @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                   boolean expectConfidentialityWarning) {
         List<ScannedDocument> docs = new ArrayList<>();
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder()
-                .url(DocumentLink.builder().documentUrl("www.test.com").build())
-                .build()).build();
+                ScannedDocumentDetails.builder()
+                        .url(DocumentLink.builder().documentUrl("www.test.com").build())
+                        .build()).build();
 
         docs.add(scannedDocument);
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
         sscsCaseData.setScannedDocuments(docs);
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertEquals("www.test.com", response.getData().getSscsDocument().get(0).getValue().getDocumentLink().getDocumentUrl());
+
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
+            Iterator<String> iterator = response.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+            if (anyDocumentTypeBlank) {
+                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
+            }
+        } else {
+            assertEquals(0, response.getWarnings().size());
+        }
     }
 
     @Test
-    public void givenACaseWithNoScannedDocuments_thenAddAnErrorToResponse() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenACaseWithNoScannedDocuments_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                          @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                          boolean expectConfidentialityWarning) {
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
         sscsCaseData.setScannedDocuments(null);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -384,48 +589,86 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         for (String error : response.getErrors()) {
             assertEquals("No further evidence to process", error);
         }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
-    private Callback<SscsCaseData> buildCallback(String dynamicListItemCode) {
+    private Callback<SscsCaseData> buildCallback(String dynamicListItemCode, boolean isIgnoreWarnings) {
         DynamicList dynamicList = new DynamicList(new DynamicListItem(dynamicListItemCode, "label"),
-            Collections.singletonList(new DynamicListItem(dynamicListItemCode, "label")));
+                Collections.singletonList(new DynamicListItem(dynamicListItemCode, "label")));
         SscsCaseData sscsCaseData = SscsCaseData.builder()
-            .originalSender(dynamicList)
-            .furtherEvidenceAction(dynamicList)
-            .scannedDocuments(Collections.singletonList(ScannedDocument.builder().build()))
-            .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
-            .build();
+                .originalSender(dynamicList)
+                .furtherEvidenceAction(dynamicList)
+                .scannedDocuments(Collections.singletonList(ScannedDocument.builder().build()))
+                .appeal(Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("My Road").postcode("TS1 2BA").build()).build()).build())
+                .build();
         CaseDetails<SscsCaseData> caseDetails = new CaseDetails<>(123L, "sscs",
-            State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now());
-        return new Callback<>(caseDetails, Optional.empty(), EventType.ACTION_FURTHER_EVIDENCE, false);
+                State.INTERLOCUTORY_REVIEW_STATE, sscsCaseData, LocalDateTime.now());
+        return new Callback<>(caseDetails, Optional.empty(), EventType.ACTION_FURTHER_EVIDENCE, isIgnoreWarnings);
     }
 
     @Test
-    public void givenIssueFurtherEvidence_shouldUpdateDwpFurtherEvidenceStates() {
-        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode());
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenIssueFurtherEvidence_shouldUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                               @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                               boolean expectConfidentialityWarning) {
+        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode(), ignoreWarnings);
+
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertEquals("furtherEvidenceReceived", updated.getData().getDwpFurtherEvidenceStates());
+
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
+            Iterator<String> iterator = updated.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+        } else {
+            assertEquals(0, updated.getWarnings().size());
+        }
     }
 
     @Test
-    @Parameters(method = "generateIssueFurtherEvidenceAddressEmptyScenarios")
-    public void givenIssueFurtherEvidenceAndEmptyAppellantAddress_shouldReturnAnErrorToUser(Appeal appeal, String... parties) {
-        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode());
+    @Parameters(method = "generateWrappedIssueFurtherEvidenceAddressEmptyScenarios")
+    public void givenIssueFurtherEvidenceAndEmptyAppellantAddress_shouldReturnAnErrorToUser(DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                            DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning, Appeal appeal, String... parties) {
+        Callback<SscsCaseData> callback = buildCallback(ISSUE_FURTHER_EVIDENCE.getCode(), ignoreWarnings);
+
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         callback.getCaseDetails().getCaseData().setAppeal(appeal);
+
         PreSubmitCallbackResponse<SscsCaseData> result = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         for (String party : parties) {
             String expectedError = "Address details are missing for the " + party + ", please validate or process manually";
             assertTrue(result.getErrors().contains(expectedError));
         }
+
+        if (!ignoreWarnings && expectConfidentialityWarning) {
+            assertEquals(1, result.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", result.getWarnings().iterator().next());
+        } else {
+            assertEquals(0, result.getWarnings().size());
+        }
     }
 
-    private Object[] generateIssueFurtherEvidenceAddressEmptyScenarios() {
+    private Object[][] generateWrappedIssueFurtherEvidenceAddressEmptyScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateIssueFurtherEvidenceAddressEmptyScenarios());
+    }
 
-        return new Object[]{
+    private Object[][] generateIssueFurtherEvidenceAddressEmptyScenarios() {
+
+        return new Object[][]{
             new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().build()).build()).build(), "Appellant"},
             new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().line1("Line1").build()).build()).build(), "Appellant"},
             new Object[]{Appeal.builder().appellant(Appellant.builder().address(Address.builder().postcode("TS1 2BA").build()).build()).build(), "Appellant"},
@@ -442,33 +685,73 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
     }
 
     @Test
-    public void givenOtherDocument_shouldNotUpdateDwpFurtherEvidenceStates() {
-        Callback<SscsCaseData> callback = buildCallback(OTHER_DOCUMENT_MANUAL.getCode());
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenOtherDocument_shouldNotUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                           @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                           boolean expectConfidentialityWarning) {
+        Callback<SscsCaseData> callback = buildCallback(OTHER_DOCUMENT_MANUAL.getCode(), ignoreWarnings);
+
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertNull(updated.getData().getDwpFurtherEvidenceStates());
+
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
+            Iterator<String> iterator = updated.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+        } else {
+            assertEquals(0, updated.getWarnings().size());
+        }
     }
 
     @Test
-    public void givenNullFurtherEvidenceAction_shouldNotUpdateDwpFurtherEvidenceStates() {
-        Callback<SscsCaseData> callback = buildCallback(null);
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenNullFurtherEvidenceAction_shouldNotUpdateDwpFurtherEvidenceStates(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                       @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                       boolean expectConfidentialityWarning) {
+        Callback<SscsCaseData> callback = buildCallback(null, ignoreWarnings);
+
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        callback.getCaseDetails().getCaseData().setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         PreSubmitCallbackResponse<SscsCaseData> updated = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertNull(updated.getData().getDwpFurtherEvidenceStates());
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning ? 1 : 0, updated.getWarnings().size());
+            Iterator<String> iterator = updated.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+        } else {
+            assertEquals(0, updated.getWarnings().size());
+        }
     }
 
     @Test
-    public void givenADocumentWithNoUrl_thenAddAnErrorToResponse() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenADocumentWithNoUrl_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                 @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                 boolean expectConfidentialityWarning) {
         List<ScannedDocument> docs = new ArrayList<>();
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder().fileName("Testing.jpg").build()).build();
+                ScannedDocumentDetails.builder().fileName("Testing.jpg").build()).build();
 
         docs.add(scannedDocument);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
 
         sscsCaseData.setScannedDocuments(docs);
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -477,19 +760,46 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         for (String error : response.getErrors()) {
             assertEquals("No document URL so could not process", error);
         }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            if (!ignoreWarnings && anyDocumentTypeBlank) {
+                assertEquals(1, response.getWarnings().size());
+            } else {
+                assertTrue(response.getWarnings().isEmpty());
+            }
+        } else {
+            assertEquals(2, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
+    }
+
+    private Object[][] generateFileNameScenarios() {
+        return new Object[][]{new Object[]{null}, new Object[]{" "}, new Object[]{"    "}};
+    }
+
+    private Object[][] generateWrappedFileNameScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateFileNameScenarios());
     }
 
     @Test
-    @Parameters({"null", " ", "    "})
-    public void givenADocumentWithNoDocFileName_thenAddAnErrorToResponse(@Nullable String filename) {
+    @Parameters(method = "generateWrappedFileNameScenarios")
+    public void givenADocumentWithNoDocFileName_thenAddAnErrorToResponse(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                         boolean expectConfidentialityWarning, @Nullable String filename) {
         List<ScannedDocument> docs = new ArrayList<>();
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder().fileName(filename).url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+                ScannedDocumentDetails.builder().fileName(filename).url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
 
         docs.add(scannedDocument);
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
         sscsCaseData.setScannedDocuments(docs);
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
 
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -498,21 +808,51 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         for (String error : response.getErrors()) {
             assertEquals("No document file name so could not process", error);
         }
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
+            Iterator<String> iterator = response.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+            if (anyDocumentTypeBlank) {
+                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
+            }
+        } else {
+            assertEquals(0, response.getWarnings().size());
+        }
+    }
+
+    private Object[][] generateUpdatePreviousStateScenarios() {
+        return new Object[][]{
+            new Object[]{null},
+            new Object[]{"DORMANT_APPEAL_STATE"},
+            new Object[]{"VOID_STATE"}
+        };
+    }
+
+    private Object[][] generateWrappedUpdatePreviousStateScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateUpdatePreviousStateScenarios());
     }
 
     @Test
-    @Parameters({"null", "DORMANT_APPEAL_STATE", "VOID_STATE"})
-    public void shouldReviewByJudgeAndUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable State previousState) {
+    @Parameters(method = "generateWrappedUpdatePreviousStateScenarios")
+    public void shouldReviewByJudgeAndUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                              @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                              boolean expectConfidentialityWarning, @Nullable State previousState) {
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
         actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
 
-        List<ScannedDocument> docs = new ArrayList<>();
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
         sscsCaseData.setPreviousState(previousState);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
+        List<ScannedDocument> docs = new ArrayList<>();
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
         docs.add(scannedDocument);
         sscsCaseData.setScannedDocuments(docs);
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -521,21 +861,43 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
         assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
         assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
+    }
+
+    private Object[][] generateNotUpdatePreviousStateScenarios() {
+        return new Object[][]{
+            new Object[]{"VALID_APPEAL"},
+            new Object[]{"READY_TO_LIST"}
+        };
+    }
+
+    private Object[][] generateWrappedNotUpdatePreviousStateScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateNotUpdatePreviousStateScenarios());
     }
 
     @Test
-    @Parameters({"VALID_APPEAL", "READY_TO_LIST"})
-    public void shouldReviewByJudgeButNotUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable State previousState) {
+    @Parameters(method = "generateWrappedNotUpdatePreviousStateScenarios")
+    public void shouldReviewByJudgeButNotUpdatePreviousStateWhenActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                                 @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning, @Nullable State previousState) {
 
         actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder);
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
         sscsCaseData.setPreviousState(previousState);
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
         List<ScannedDocument> docs = new ArrayList<>();
         docs.add(scannedDocument);
         sscsCaseData.setScannedDocuments(docs);
@@ -545,27 +907,65 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getReinstatementOutcome());
         assertEquals(LocalDate.now(), sscsCaseData.getReinstatementRegistered());
         assertEquals(InterlocReviewState.REVIEW_BY_JUDGE.getId(), sscsCaseData.getInterlocReviewState());
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
     @Test
-    public void shouldNotUpdateInterlocReviewStateWhenActionManuallyAndHasNoReinstatementRequestDocument() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void shouldNotUpdateInterlocReviewStateWhenActionManuallyAndHasNoReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                         boolean expectConfidentialityWarning) {
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.setPreviousState(null);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(OTHER_DOCUMENT_MANUAL.code, OTHER_DOCUMENT_MANUAL.label));
+
+        boolean anyDocumentTypeBlank = scannedDocumentList.stream().anyMatch(d -> StringUtils.isBlank(d.getValue().getType()));
+
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
         assertEquals(0, response.getErrors().size());
         assertNull(sscsCaseData.getPreviousState());
         assertNull(sscsCaseData.getReinstatementOutcome());
         assertNull(sscsCaseData.getReinstatementRegistered());
         assertNull(sscsCaseData.getInterlocReviewState());
+
+        if (!ignoreWarnings) {
+            assertEquals(expectConfidentialityWarning && anyDocumentTypeBlank ? 2 : (expectConfidentialityWarning ? 1 : (anyDocumentTypeBlank ? 1 : 0)), response.getWarnings().size());
+            Iterator<String> iterator = response.getWarnings().iterator();
+            if (expectConfidentialityWarning) {
+                assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", iterator.next());
+            }
+            if (anyDocumentTypeBlank) {
+                assertEquals("Document type is empty, are you happy to proceed?", iterator.next());
+            }
+        } else {
+            assertEquals(0, response.getWarnings().size());
+        }
     }
 
     @Test
-    public void shouldNotUpdateInterlocReviewStateWhenNotActionManuallyAndHasReinstatementRequestDocument() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void shouldNotUpdateInterlocReviewStateWhenNotActionManuallyAndHasReinstatementRequestDocument(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                          @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                          boolean expectConfidentialityWarning) {
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.setPreviousState(null);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
-            ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
-                .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.REINSTATEMENT_REQUEST.getValue())
+                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
         List<ScannedDocument> docs = new ArrayList<>();
         docs.add(scannedDocument);
         sscsCaseData.setScannedDocuments(docs);
@@ -575,12 +975,34 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertNull(sscsCaseData.getReinstatementOutcome());
         assertNull(sscsCaseData.getReinstatementRegistered());
         assertNull(sscsCaseData.getInterlocReviewState());
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
+    }
+
+    private Object[][] generateSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios() {
+        return new Object[][]{
+            new Object[]{"SEND_TO_INTERLOC_REVIEW_BY_JUDGE"},
+            new Object[]{"INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"}
+        };
+    }
+
+    private Object[][] generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios() {
+        return wrapWithConfidentialityAndWarningCombinationScenarios(generateSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios());
     }
 
     @Test
-    @Parameters({"SEND_TO_INTERLOC_REVIEW_BY_JUDGE", "INFORMATION_RECEIVED_FOR_INTERLOC_JUDGE"})
-    public void givenConfidentialRequestFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+    @Parameters(method = "generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios")
+    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                                                   @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                                                   boolean expectConfidentialityWarning, FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
         sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
 
@@ -591,15 +1013,60 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         docs.add(scannedDocument);
         sscsCaseData.setScannedDocuments(docs);
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
-        assertEquals(0, response.getErrors().size());
-        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome());
-        assertNull(sscsCaseData.getConfidentialityRequestOutcomeJointParty());
-        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeAppellant().getDate());
+        assertEquals(1, response.getErrors().size());
+        for (String error : response.getErrors()) {
+            assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", error);
+        }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
     @Test
-    public void givenConfidentialRequestFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields() {
+    @Parameters(method = "generateWrappedSendToInterlocReviewByJudgeOrInformationReceivedForInterlocJudgeScenarios")
+    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderAppellant_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                                             @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                                             boolean expectConfidentialityWarning, FurtherEvidenceActionDynamicListItems furtherEvidenceActionDynamicListItem) {
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
 
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(furtherEvidenceActionDynamicListItem.code, furtherEvidenceActionDynamicListItem.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(0, response.getErrors().size());
+        assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeAppellant().getRequestOutcome());
+        assertEquals(jointPartyConfidentialityRequestOutcome, sscsCaseData.getConfidentialityRequestOutcomeJointParty());
+        assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeAppellant().getDate());
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
+    }
+
+    @Test
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenConfidentialRequestWhenJointPartyDoesNotExistFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                                                    @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                                                                    boolean expectConfidentialityWarning) {
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
         sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
 
@@ -610,19 +1077,65 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         docs.add(scannedDocument);
         sscsCaseData.setScannedDocuments(docs);
         PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertEquals(1, response.getErrors().size());
+        for (String error : response.getErrors()) {
+            assertEquals("Document type \"Confidentiality Request\" is invalid as there is no joint party on the case", error);
+        }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
+    }
+
+    @Test
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenConfidentialRequestWhenJointPartyExistsFromOriginalSenderJointParty_thenUpdateCaseWithConfidentialFields(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                                                              @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings, boolean expectConfidentialityWarning) {
+
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
+        sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
+        sscsCaseData.getOriginalSender().setValue(new DynamicListItem(JOINT_PARTY.getCode(), JOINT_PARTY.getLabel()));
+        sscsCaseData.setJointParty("Yes");
+
+        ScannedDocument scannedDocument = ScannedDocument.builder().value(
+                ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
+                        .url(DocumentLink.builder().documentUrl("test.com").build()).build()).build();
+        List<ScannedDocument> docs = new ArrayList<>();
+        docs.add(scannedDocument);
+        sscsCaseData.setScannedDocuments(docs);
+        PreSubmitCallbackResponse<SscsCaseData> response = actionFurtherEvidenceAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
         assertEquals(0, response.getErrors().size());
         assertEquals(RequestOutcome.IN_PROGRESS, sscsCaseData.getConfidentialityRequestOutcomeJointParty().getRequestOutcome());
-        assertNull(sscsCaseData.getConfidentialityRequestOutcomeAppellant());
+        assertEquals(appellantConfidentialityRequestOutcome, sscsCaseData.getConfidentialityRequestOutcomeAppellant());
         assertEquals(LocalDate.now(), sscsCaseData.getConfidentialityRequestOutcomeJointParty().getDate());
+
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
 
-
     @Test
-    public void givenConfidentialRequestFromRep_thenShowAnError() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenConfidentialRequestFromRep_thenShowAnError(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                boolean expectConfidentialityWarning) {
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(SEND_TO_INTERLOC_REVIEW_BY_JUDGE.code, SEND_TO_INTERLOC_REVIEW_BY_JUDGE.label));
         sscsCaseData.getOriginalSender().setValue(new DynamicListItem(OriginalSenderItemList.REPRESENTATIVE.getCode(), OriginalSenderItemList.REPRESENTATIVE.getLabel()));
+        sscsCaseData.setJointParty("Yes");
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
                 ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
@@ -635,13 +1148,27 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         for (String error : response.getErrors()) {
             assertEquals("Original sender must be appellant or joint party for a confidential document", error);
         }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
+        }
     }
 
     @Test
-    public void givenConfidentialRequestWithInvalidFurtherEvidenceAction_thenShowAnError() {
+    @Parameters(method = "confidentialityAndWarningRequestStateCombinations")
+    public void givenConfidentialRequestWithInvalidFurtherEvidenceAction_thenShowAnError(@Nullable DatedRequestOutcome appellantConfidentialityRequestOutcome,
+                                                                                         @Nullable DatedRequestOutcome jointPartyConfidentialityRequestOutcome, boolean ignoreWarnings,
+                                                                                         boolean expectConfidentialityWarning) {
 
+        when(callback.isIgnoreWarnings()).thenReturn(ignoreWarnings);
+
+        sscsCaseData.setConfidentialityRequestOutcomeAppellant(appellantConfidentialityRequestOutcome);
+        sscsCaseData.setConfidentialityRequestOutcomeJointParty(jointPartyConfidentialityRequestOutcome);
         sscsCaseData.getFurtherEvidenceAction().setValue(new DynamicListItem(ISSUE_FURTHER_EVIDENCE.code, ISSUE_FURTHER_EVIDENCE.label));
         sscsCaseData.getOriginalSender().setValue(new DynamicListItem(APPELLANT.getCode(), APPELLANT.getLabel()));
+        sscsCaseData.setJointParty("Yes");
 
         ScannedDocument scannedDocument = ScannedDocument.builder().value(
                 ScannedDocumentDetails.builder().fileName("filename.pdf").type(ScannedDocumentType.CONFIDENTIALITY_REQUEST.getValue())
@@ -653,6 +1180,12 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
         assertEquals(1, response.getErrors().size());
         for (String error : response.getErrors()) {
             assertEquals("Further evidence action must be 'Send to Interloc - Review by Judge' or 'Information received for Interloc - send to Judge' for a confidential document", error);
+        }
+        if (ignoreWarnings || !expectConfidentialityWarning) {
+            assertTrue(response.getWarnings().isEmpty());
+        } else {
+            assertEquals(1, response.getWarnings().size());
+            assertEquals("This case is progressing via GAPS. Please ensure any documents are emailed to the Regional Processing Centre to be attached to the paper file.", response.getWarnings().iterator().next());
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-8218
https://tools.hmcts.net/jira/browse/SSCS-8210


### Change description ###

Adding validation to the action further evidence event so that:

* A warning message is displayed if either appellant or joint party have confidentiality granted.
* Confidentiality requests made when there is no joint party on the case cannot proceed and an error will be displayed.  


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
