### PR TITLE
SSCS-8317 - Add functional tests for MYA

### DIFF
--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/CitizenLoginTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/CitizenLoginTest.java
@@ -49,4 +49,15 @@ public class CitizenLoginTest extends BaseFunctionTest {
         assertThat(onlineHearingForTya.length(), is(1));
         assertThat(onlineHearingForTya.getJSONObject(0).get("case_id"), is(expectedCaseId));
     }
+
+    @Test
+    public void logUserWithCase_returnsNoContent() throws IOException {
+        String userEmail = createRandomEmail();
+        idamTestApiRequests.createUser(userEmail);
+        CreatedCcdCase ccdCase = createCcdCase(userEmail);
+        sscsMyaBackendRequests.assignCaseToUser(ccdCase.getAppellantTya(), userEmail, "TN32 6PL");
+
+        Long caseId = Long.valueOf(ccdCase.getCaseId());
+        sscsMyaBackendRequests.logUserWithCase(caseId);
+    }
 }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/EvidenceUploadTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/EvidenceUploadTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.sscs.functional.mya;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,5 +47,15 @@ public class EvidenceUploadTest extends BaseFunctionTest {
 
         String coversheet = sscsMyaBackendRequests.getCoversheet(createdCcdCase.getCaseId());
         assertThat(coversheet, is("evidence_cover_sheet.pdf"));
+    }
+
+    @Test
+    public void shouldDeleteUploadEvidenceForAnAppeal() throws IOException {
+        CreatedCcdCase createdCcdCase = createCase();
+        sscsMyaBackendRequests.uploadHearingEvidence(createdCcdCase.getCaseId(), "evidence.png");
+        SscsCaseDetails caseDetails = getCaseDetails(createdCcdCase.getCaseId());
+        JSONArray draftHearingEvidence = sscsMyaBackendRequests.getDraftHearingEvidence(createdCcdCase.getCaseId());
+        assertThat(draftHearingEvidence.length(), is(1));
+        sscsMyaBackendRequests.deleteUploadEvidence(caseDetails.getId(), draftHearingEvidence.getJSONObject(0).getString("id"));
     }
 }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/SscsMyaBackendRequests.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/SscsMyaBackendRequests.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.sscs.functional.mya;
 
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.apache.http.client.methods.RequestBuilder.*;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -64,6 +66,13 @@ public class SscsMyaBackendRequests {
         return new JSONObject(responseBody);
     }
 
+    public void logUserWithCase(Long caseId) throws IOException {
+        StringEntity entity = new StringEntity(EMPTY, APPLICATION_JSON);
+
+        HttpResponse response = putRequest("/api/citizen/cases/" + caseId + "/log", entity);
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
+    }
+
     public CreatedCcdCase createOralCase(String emailAddress) throws IOException {
         HttpResponse createCaseResponse = client.execute(post(baseUrl + "/api/case?hearingType=oral&email=" + emailAddress)
                 .setHeader("Content-Length", "0")
@@ -92,6 +101,11 @@ public class SscsMyaBackendRequests {
 
         HttpResponse response = putRequest("/api/continuous-online-hearings/" + hearingId + "/evidence", data);
         assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+    }
+
+    public void deleteUploadEvidence(Long caseId, String evidenceId) throws IOException {
+        HttpResponse response = client.execute(addHeaders(delete(baseUrl + "/api/continuous-online-hearings/" + caseId + "/evidence/" + evidenceId)).build());
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.NO_CONTENT.value()));
     }
 
     public void submitHearingEvidence(String hearingId, String description) throws IOException {
@@ -130,6 +144,20 @@ public class SscsMyaBackendRequests {
         assertThat(getCoverSheetResponse.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
         Header fileNameHeader = getCoverSheetResponse.getFirstHeader("Content-Disposition");
         return ContentDisposition.parse(fileNameHeader.getValue()).getFilename();
+    }
+
+
+    public String updateSubscription(String appellantTya, String userEmail) throws IOException {
+        HttpResponse response = postRequest(format("/appeals/%s/subscriptions/%s", appellantTya, appellantTya),
+                new StringEntity(format("{ \"subscription\" : {\"email\" : \"%s\"}}", userEmail), APPLICATION_JSON));
+
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
+        return EntityUtils.toString(response.getEntity());
+    }
+
+    public void unsubscribeSubscription(String appellantTya, String userEmail) throws IOException {
+        HttpResponse response = client.execute(addHeaders(delete(format("%s/appeals/%s/subscriptions/%s", baseUrl, appellantTya, appellantTya))).build());
+        assertThat(response.getStatusLine().getStatusCode(), is(HttpStatus.OK.value()));
     }
 
     private RequestBuilder addHeaders(RequestBuilder requestBuilder) {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/SubscriptionTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/mya/SubscriptionTest.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscs.functional.mya;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
+
+public class SubscriptionTest extends BaseFunctionTest {
+    private static final String YES = "yes";
+    private static final String NO = "no";
+
+    @Test
+    public void shouldUpdateSubscription() throws IOException {
+        String newUserEmail = createRandomEmail();
+        CreatedCcdCase ccdCase = createCcdCase(createRandomEmail());
+        String appellantTya = ccdCase.getAppellantTya();
+        String benefitType = sscsMyaBackendRequests.updateSubscription(appellantTya, newUserEmail);
+        assertThat(benefitType, is("{\"benefitType\":\"pip\"}"));
+        SscsCaseDetails updatedCase = getCaseDetails(ccdCase.getCaseId());
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getTya(), is(appellantTya));
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getEmail(), is(newUserEmail));
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getSubscribeEmail(), is(YES));
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getSubscribeSms(), is(NO));
+    }
+
+    @Test
+    public void shouldUnsubscribeSubscription() throws IOException {
+        String userEmail = createRandomEmail();
+        CreatedCcdCase ccdCase = createCcdCase(userEmail);
+        String appellantTya = ccdCase.getAppellantTya();
+        sscsMyaBackendRequests.unsubscribeSubscription(appellantTya, userEmail);
+        SscsCaseDetails updatedCase = getCaseDetails(ccdCase.getCaseId());
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getTya(), is(appellantTya));
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getSubscribeEmail(), is(NO));
+        assertThat(updatedCase.getData().getSubscriptions().getAppellantSubscription().getSubscribeSms(), is(NO));
+    }
+}


### PR DESCRIPTION
SSCS-8317 - Add functional tests for MYA

- PUT: /api/citizen/cases/{caseId}/log 
- DELETE: /api/continuous-online-hearings/{identifier}/evidence/{evidenceId}
- POST: /appeals/{appealNumber}/subscriptions/{subscriptionId} 
- DELETE: /appeals/{id}/subscriptions/{subscriptionId}