### PR TITLE
SSCS-7578 Misc fixes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandler.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.domain.SscsEsaCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.domain.YesNo;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.writefinaldecision.WriteFinalDecisionMidEventValidationHandlerBase;
 import uk.gov.hmcts.reform.sscs.service.DecisionNoticeService;
@@ -49,28 +48,7 @@ public class EsaWriteFinalDecisionMidEventValidationHandler extends WriteFinalDe
 
     @Override
     protected void validateAwardTypes(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
-        SscsEsaCaseData esaCaseData = sscsCaseData.getSscsEsaCaseData();
-        if (esaCaseData.getEsaWriteFinalDecisionPhysicalDisabilitiesQuestion() != null
-            || esaCaseData.getEsaWriteFinalDecisionMentalAssessmentQuestion() != null) {
-
-            if ((esaCaseData.getEsaWriteFinalDecisionPhysicalDisabilitiesQuestion() == null
-                || esaCaseData.getEsaWriteFinalDecisionPhysicalDisabilitiesQuestion().isEmpty())
-                && (esaCaseData.getEsaWriteFinalDecisionMentalAssessmentQuestion() == null
-                || esaCaseData.getEsaWriteFinalDecisionMentalAssessmentQuestion().isEmpty())
-                && "yes".equalsIgnoreCase(sscsCaseData.getWriteFinalDecisionIsDescriptorFlow())
-                && bothDailyLivingAndMobilityQuestionsAnswered(sscsCaseData)) {
-                if (isNoAwardOrNotConsideredForDailyLiving(sscsCaseData)
-                    && isNoAwardOrNotConsideredForMobility(sscsCaseData)) {
-                    if (sscsCaseData.getWriteFinalDecisionEndDateType() != null && !"na".equals(sscsCaseData.getWriteFinalDecisionEndDateType())) {
-                        preSubmitCallbackResponse.addError("End date is not applicable for this decision - please specify 'N/A - No Award'.");
-                    }
-                } else {
-                    if ("na".equals(sscsCaseData.getWriteFinalDecisionEndDateType())) {
-                        preSubmitCallbackResponse.addError("An end date must be provided or set to Indefinite for this decision.");
-                    }
-                }
-            }
-        }
+        // No-op for ESA
     }
 
     @Override
@@ -80,22 +58,5 @@ public class EsaWriteFinalDecisionMidEventValidationHandler extends WriteFinalDe
             return;
         }
         sscsCaseData.setShowFinalDecisionNoticeSummaryOfOutcomePage(YesNo.NO);
-    }
-
-    private boolean isNoAwardOrNotConsideredForMobility(SscsCaseData sscsCaseData) {
-        return sscsCaseData.getPipWriteFinalDecisionMobilityQuestion() != null
-            && ("noAward".equals(sscsCaseData.getPipWriteFinalDecisionMobilityQuestion())
-            || "notConsidered".equals(sscsCaseData.getPipWriteFinalDecisionMobilityQuestion()));
-    }
-
-    private boolean isNoAwardOrNotConsideredForDailyLiving(SscsCaseData sscsCaseData) {
-        return sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion() != null
-            && ("noAward".equals(sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion())
-            || "notConsidered".equals(sscsCaseData.getPipWriteFinalDecisionDailyLivingQuestion()));
-    }
-
-    private boolean bothDailyLivingAndMobilityQuestionsAnswered(SscsCaseData caseData) {
-        return caseData.getPipWriteFinalDecisionDailyLivingQuestion() != null
-            && caseData.getPipWriteFinalDecisionMobilityQuestion() != null;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DescriptorTable.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/DescriptorTable.java
@@ -5,22 +5,18 @@ import java.util.List;
 
 public class DescriptorTable extends TemplateComponent<List<Descriptor>> {
 
-    private boolean hidePointsColumn;
+    private boolean hideAnswerColumns;
 
-    public DescriptorTable(String id, List<Descriptor> content, boolean hidePointsColumn) {
+    public DescriptorTable(String id, List<Descriptor> content, boolean hideAnswerColumns) {
         super(id, content);
-        this.hidePointsColumn = hidePointsColumn;
+        this.hideAnswerColumns = hideAnswerColumns;
     }
 
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (Descriptor descriptor : content) {
-            if (hidePointsColumn) {
+            if (hideAnswerColumns) {
                 sb.append(descriptor.getActivityQuestionValue());
-                sb.append("\t");
-                sb.append(descriptor.getActivityAnswerLetter());
-                sb.append(".");
-                sb.append(descriptor.getActivityAnswerValue());
             } else {
                 sb.append(descriptor.getActivityQuestionValue());
                 sb.append("\t");
@@ -45,8 +41,8 @@ public class DescriptorTable extends TemplateComponent<List<Descriptor>> {
         return false;
     }
 
-    @JsonProperty("is_hide_points_column")
-    public boolean isHidePointsColumn() {
-        return hidePointsColumn;
+    @JsonProperty("is_hide_answer_columns")
+    public boolean isHideAnswerColumns() {
+        return hideAnswerColumns;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
@@ -59,7 +59,7 @@ public class EsaDecisionNoticeOutcomeService extends DecisionNoticeOutcomeServic
     @Override
     public Outcome determineOutcomeWithValidation(SscsCaseData sscsCaseData) {
         Outcome outcome = determineOutcome(sscsCaseData);
-        if (sscsCaseData.isWcaAppeal()) {
+        if ("Yes".equalsIgnoreCase(sscsCaseData.getWriteFinalDecisionGenerateNotice())) {
             Optional<EsaAllowedOrRefusedCondition> passingAllowedOrRefusedCondition = EsaPointsRegulationsAndSchedule3ActivitiesCondition.getPassingAllowedOrRefusedCondition(questionService, sscsCaseData);
             if (passingAllowedOrRefusedCondition.isEmpty()) {
                 throw new IllegalStateException("No matching allowed or refused condition");

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTestBase.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/WriteFinalDecisionPreviewDecisionServiceTestBase.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import junitparams.JUnitParamsRunner;
 import junitparams.NamedParameters;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -888,22 +887,7 @@ public abstract class WriteFinalDecisionPreviewDecisionServiceTestBase {
     }
 
     @Test
-    @Ignore
-    // FIXME
-    public void givenGeneratedDateIsAlreadySetGeneratedNonDescriptorFlow_thenSetNewGeneratedDate() {
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
-        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
-        setHigherRateScenarioFields(sscsCaseData);
-        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
-        sscsCaseData.setWriteFinalDecisionGeneratedDate("2018-10-10");
-        setDescriptorFlowIndicator("no", sscsCaseData);
-
-        service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, true);
-
-        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10", true, true, true, false, true, documentConfiguration.getBenefitSpecificDocuments().get(benefitType.toLowerCase()).get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
-
-        assertEquals(LocalDate.now().toString(), payload.getGeneratedDate().toString());
-    }
+    public abstract void givenGeneratedDateIsAlreadySetGeneratedNonDescriptorFlow_thenSetNewGeneratedDate();
 
     @Test
     public void givenGeneratedDateIsAlreadySetNonGeneratedDescriptorFlow_thenDoSetNewGeneratedDate() {
@@ -923,23 +907,7 @@ public abstract class WriteFinalDecisionPreviewDecisionServiceTestBase {
     }
 
     @Test
-    @Ignore
-    // FIXME
-    public void givenGeneratedDateIsAlreadySetNonGeneratedNonDescriptorFlow_thenDoSetNewGeneratedDate() {
-        setDescriptorFlowIndicator("no", sscsCaseData);
-        setHigherRateScenarioFields(sscsCaseData);
-        sscsCaseData.setWriteFinalDecisionGenerateNotice("no");
-        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
-        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
-        sscsCaseData.setWriteFinalDecisionGeneratedDate("2018-10-10");
-
-        service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, true);
-
-        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",  true, true, true,
-            false, true, documentConfiguration.getBenefitSpecificDocuments().get(benefitType.toLowerCase()).get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
-
-        assertEquals(LocalDate.now().toString(), payload.getGeneratedDate().toString());
-    }
+    public abstract void givenGeneratedDateIsAlreadySetNonGeneratedNonDescriptorFlow_thenDoSetNewGeneratedDate();
 
     @Test
     public void givenWelsh_GeneratedDateIsAlreadySet_thenDoNotSetNewGeneratedDate() {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -219,7 +219,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
         if (regulation35 != null) {
             sscsCaseData.setDoesRegulation35Apply(regulation35.booleanValue() ? YesNo.YES : YesNo.NO);
         }
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1w");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -247,7 +247,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
         }
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -276,7 +276,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -320,7 +320,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -342,7 +342,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -369,7 +369,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -398,7 +398,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -423,7 +423,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -445,7 +445,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -472,7 +472,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -493,7 +493,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -518,7 +518,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -546,7 +546,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -573,7 +573,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -595,7 +595,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -654,7 +654,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -677,7 +677,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -705,7 +705,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -736,7 +736,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -763,7 +763,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -795,7 +795,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 0 points - low, which means regulation 29 must apply.
+        // 0 points awarded for this question - low, which means regulation 29 must be populated
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1f");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -827,7 +827,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to apply.
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -853,7 +853,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to apply.
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -884,7 +884,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
 
-        // 15 points - high, which means regulation 29 must not apply.
+        // 15 points awarded for this question - high, which means regulation 29 does not need to apply.
         sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -895,5 +895,170 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         Assert.assertEquals("You have specified that the appeal is refused and specified that Support Group Only Appeal does not apply, but have not awarded less than 15 points, a missing answer for the Regulation 29 question, submitted an unexpected answer for the Schedule 3 Activities question and submitted an unexpected answer for the Regulation 35 question. Please review your previous selection.", error);
 
+    }
+
+    // Allowed scenario 1
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoSchedule3ActivitesAndRegulation35False_WhenAllowed_thenDoNotDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation35Apply(YesNo.NO);
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(0, response.getErrors().size());
+    }
+
+    // Allowed scenario 1 - with error due to incorrect setting of refused
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoSchedule3ActivitesAndRegulation35False_WhenRefused_thenDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation35Apply(YesNo.NO);
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("refused");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(1, response.getErrors().size());
+
+        String error = response.getErrors().iterator().next();
+
+        Assert.assertEquals("You have specified that the appeal is refused and specified that Support Group Only Appeal does not apply, but have not awarded less than 15 points, a missing answer for the Regulation 29 question, submitted an unexpected answer for the Schedule 3 Activities question and submitted an unexpected answer for the Regulation 35 question. Please review your previous selection.", error);
+    }
+
+    // Allowed scenario 1 - with error due to missing regulation 35
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoSchedule3ActivitesAndRegulation35NotSpecified_WhenAllowed_thenDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(1, response.getErrors().size());
+
+        String error = response.getErrors().iterator().next();
+
+        Assert.assertEquals("You have awarded 15 points or more and not provided an answer to the Regulation 35 question, but have made no selections for the Schedule 3 Activities question. Please review your previous selection.", error);
+    }
+
+    // Allowed scenario 2
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndSchedule3ActivitesAndRegulation35NotSet_WhenAllowed_thenDoNotDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList("schedule3MobilisingUnaided"));
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(0, response.getErrors().size());
+    }
+
+    // Allowed scenario 2 - with error due to incorrectly refused
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndSchedule3ActivitesAndRegulation35NotSet_WhenRefused_thenDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList("schedule3MobilisingUnaided"));
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("refused");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(1, response.getErrors().size());
+
+        String error = response.getErrors().iterator().next();
+
+        Assert.assertEquals("You have specified that the appeal is refused and specified that Support Group Only Appeal does not apply, but have not awarded less than 15 points, a missing answer for the Regulation 29 question and submitted an unexpected answer for the Schedule 3 Activities question. Please review your previous selection.", error);
+    }
+
+    // Allowed scenario 2 - with error due to no schedule 3 answers
+    @Test
+    public void givenNonSupportGroupAllowedScenario_Regulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoSchedule3ActivitesAndRegulation35NotSet_WhenAllowed_thenDisplayAnError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList(""));
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList("mobilisingUnaided"));
+
+        // 15 points awarded for this question - high, which means regulation 29 is not applicable
+        // and does not need to be populated
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1a");
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        Assert.assertEquals(1, response.getErrors().size());
+
+        String error = response.getErrors().iterator().next();
+
+        Assert.assertEquals("You have awarded 15 points or more and not provided an answer to the Regulation 35 question, but have made no selections for the Schedule 3 Activities question. Please review your previous selection.", error);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario4Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario4Test.java
@@ -14,10 +14,7 @@ public class EsaScenario4Test {
     public void testScenario4() {
         List<Descriptor> schedule3Descriptors =
                 Arrays.asList(Descriptor.builder()
-                        .activityQuestionValue("2. Transferring from one seated position to another.")
-                        .activityAnswerValue(" Cannot move between one seated position and another "
-                                + "seated position located next to one another without receiving physical assistance from another person.")
-                        .activityAnswerLetter("2").activityAnswerPoints(9).build());
+                        .activityQuestionValue("2. Transferring from one seated position to another.").build());
 
         WriteFinalDecisionTemplateBody body =
                 WriteFinalDecisionTemplateBody.builder()
@@ -34,24 +31,24 @@ public class EsaScenario4Test {
         EsaTemplateContent content = EsaScenario.SCENARIO_4.getContent(body);
 
         String expectedContent = "The appeal is allowed.\n"
-                + "\n"
-                + "The decision made by the Secretary of State on 20/09/2020 is set aside.\n"
-                + "\n"
-                + "Felix Sydney has limited capability for work-related activity.\n"
-                + "\n"
-                + "The Secretary of State has accepted that Felix Sydney has limited capability for work. This was not an issue.\n"
-                + "\n"
-                + "The following activity and descriptor from Schedule 3 applied:\n"
-                + "\n"
-                + "2. Transferring from one seated position to another.\t2. Cannot move between one seated position and another seated position located next to one another without receiving physical assistance from another person.\n"
-                + "\n"
-                + "\n"
-                + "My first reasons\n"
-                + "\n"
-                + "My second reasons\n"
-                + "\n"
-                + "Something else\n"
-                + "\n";
+            + "\n"
+            + "The decision made by the Secretary of State on 20/09/2020 is set aside.\n"
+            + "\n"
+            + "Felix Sydney has limited capability for work-related activity.\n"
+            + "\n"
+            + "The Secretary of State has accepted that Felix Sydney has limited capability for work. This was not an issue.\n"
+            + "\n"
+            + "The following activity and descriptor from Schedule 3 applied:\n"
+            + "\n"
+            + "2. Transferring from one seated position to another.\n"
+            + "\n"
+            + "\n"
+            + "My first reasons\n"
+            + "\n"
+            + "My second reasons\n"
+            + "\n"
+            + "Something else\n"
+            + "\n";
 
         Assert.assertEquals(9, content.getComponents().size());
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario6Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario6Test.java
@@ -21,9 +21,7 @@ public class EsaScenario6Test {
 
         List<Descriptor> schedule3Descriptors =
                 Arrays.asList(Descriptor.builder()
-                        .activityQuestionValue("My schedule 3 descriptor")
-                        .activityAnswerValue("1")
-                        .activityAnswerLetter("b").activityAnswerPoints(9).build());
+                        .activityQuestionValue("My schedule 3 descriptor").build());
 
         WriteFinalDecisionTemplateBody body =
             WriteFinalDecisionTemplateBody.builder()
@@ -54,7 +52,7 @@ public class EsaScenario6Test {
             + "\n"
             + "The following activity and descriptor from Schedule 3 applied:\n"
             + "\n"
-            + "My schedule 3 descriptor\tb.1\n"
+            + "My schedule 3 descriptor\n"
             + "\n"
             + "\n"
             + "My first reasons\n"

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario9Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario9Test.java
@@ -21,9 +21,7 @@ public class EsaScenario9Test {
 
         List<Descriptor> schedule3Descriptors =
                 Arrays.asList(Descriptor.builder()
-                        .activityQuestionValue("My schedule 3 descriptor")
-                        .activityAnswerValue("1")
-                        .activityAnswerLetter("b").activityAnswerPoints(9).build());
+                        .activityQuestionValue("My schedule 3 descriptor").build());
 
         WriteFinalDecisionTemplateBody body =
             WriteFinalDecisionTemplateBody.builder()
@@ -56,7 +54,7 @@ public class EsaScenario9Test {
             + "\n"
             + "The following activity and descriptor from Schedule 3 applied:\n"
             + "\n"
-            + "My schedule 3 descriptor\tb.1\n"
+            + "My schedule 3 descriptor\n"
             + "\n"
             + "\n"
             + "My first reasons\n"

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/pip/PipWriteFinalDecisionPreviewDecisionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/pip/PipWriteFinalDecisionPreviewDecisionServiceTest.java
@@ -54,6 +54,39 @@ public class PipWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
         sscsCaseData.setPipWriteFinalDecisionComparedToDwpMobilityQuestion("higher");
     }
 
+    @Override
+    public void givenGeneratedDateIsAlreadySetGeneratedNonDescriptorFlow_thenSetNewGeneratedDate() {
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+        setHigherRateScenarioFields(sscsCaseData);
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+        sscsCaseData.setWriteFinalDecisionGeneratedDate("2018-10-10");
+        setDescriptorFlowIndicator("no", sscsCaseData);
+
+        service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, true);
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10", true, true, true, false, true, documentConfiguration.getBenefitSpecificDocuments().get(benefitType.toLowerCase()).get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertEquals(LocalDate.now().toString(), payload.getGeneratedDate().toString());
+    }
+
+    @Override
+    public void givenGeneratedDateIsAlreadySetNonGeneratedNonDescriptorFlow_thenDoSetNewGeneratedDate() {
+        setDescriptorFlowIndicator("no", sscsCaseData);
+        setHigherRateScenarioFields(sscsCaseData);
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("no");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+        sscsCaseData.setWriteFinalDecisionDateOfDecision("2018-10-10");
+        sscsCaseData.setWriteFinalDecisionGeneratedDate("2018-10-10");
+
+        service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, true);
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",  true, true, true,
+            false, true, documentConfiguration.getBenefitSpecificDocuments().get(benefitType.toLowerCase()).get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertEquals(LocalDate.now().toString(), payload.getGeneratedDate().toString());
+    }
+
     @Test
     public void willSetPreviewFileForDailyLivingMobility_whenNotGeneratingNotice() {
 


### PR DESCRIPTION

### JIRA link (if applicable) ###

./ccd compose up -d ccd-definition-store-api

### Change description ###

* Removing unnecessary award type validation for ESA.
* Changing existing descriptor logic to be schedule2 specific, and adding schedule3 descriptor logic
* Changing hidePointsColumn to hideAnswerColumns in DescriptorTable, and changing scenario tests accordingly
* Only validating now if generating notice, but validating for all other cases including non-wca appeals
* Fixing and unignoring two validation handler tests for generated date
* Merging in changes from the "approved scenario" PR including further unit tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
