### PR TITLE
SSCS-7578 Fixing NPE when no schedule 2 activities selected and adding tests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
@@ -119,8 +119,13 @@ public class EsaWriteFinalDecisionPreviewDecisionService extends WriteFinalDecis
         }
 
         if (allSchedule2Descriptors.isEmpty()) {
-            builder.esaSchedule2Descriptors(null);
-            builder.esaNumberOfPoints(null);
+            if (caseData.isWcaAppeal()) {
+                builder.esaSchedule2Descriptors(new ArrayList<>());
+                builder.esaNumberOfPoints(caseData.isWcaAppeal() ? 0 : null);
+            } else {
+                builder.esaSchedule2Descriptors(null);
+                builder.esaNumberOfPoints(null);
+            }
         } else {
             builder.esaSchedule2Descriptors(allSchedule2Descriptors);
             int numberOfPoints = allSchedule2Descriptors.stream().mapToInt(Descriptor::getActivityAnswerPoints).sum();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/WriteFinalDecisionTemplateContent.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/model/docassembly/WriteFinalDecisionTemplateContent.java
@@ -23,8 +23,11 @@ public class WriteFinalDecisionTemplateContent {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (TemplateComponent<?> component : components) {
-            sb.append(component.toString());
-            sb.append("\n\n");
+            if (!component.toString().isBlank()) {
+                sb.append(component.toString());
+                sb.append("\n\n");
+            }
+
         }
         return sb.toString();
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionServiceTest.java
@@ -108,6 +108,69 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
     }
 
     @Test
+    public void willSetPreviewFile_WhenRefusedAndNoAward_WhenZeroPointsAndNoSchedule2Apply() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setDoesRegulation29Apply(YesNo.NO);
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("refused");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = false;
+
+        boolean setAsideExpectation = false;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("no award", body.getEsaAwardRate());
+
+        assertNotNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaSchedule3Descriptors());
+        assertEquals(0, body.getEsaSchedule2Descriptors().size());
+        assertNotNull(body.getEsaNumberOfPoints());
+        assertEquals(0, body.getEsaNumberOfPoints().intValue());
+
+
+        assertFalse(body.isEsaIsEntited());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_1, templateContent.getScenario());
+
+        assertEquals(8, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
     public void willSetPreviewFile_WhenRefusedSupportGroupOnlyAppealAndLowerRateAward_WhenLowPoints() {
 
         String endDate = "2018-11-10";
@@ -1076,6 +1139,73 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
     }
 
     @Test
+    public void willSetPreviewFile_WhenAllowedNotSupportGroupOnlyNoSchedule3NoReg35_WhenZeroPointsAndNoSchedule2() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation29Apply(YesNo.YES);
+        sscsCaseData.setDoesRegulation35Apply(YesNo.NO);
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        // 0 points awarded as no schedule 2 apply - low, which means regulation 29 must apply
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("lower rate", body.getEsaAwardRate());
+
+        assertNotNull(body.getEsaSchedule2Descriptors());
+        assertEquals(0, body.getEsaSchedule2Descriptors().size());
+        assertNotNull(body.getEsaNumberOfPoints());
+        assertEquals(0, body.getEsaNumberOfPoints().intValue());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_7, templateContent.getScenario());
+        assertEquals(11, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
     public void willSetPreviewFile_WhenAllowedNotSupportGroupOnlyNoSchedule3WithReg35_WhenLowPoints() {
 
         String endDate = "2018-11-10";
@@ -1134,6 +1264,74 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
         assertEquals("None of the above applies.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
         assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
         assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
+        assertNotNull(body.getEsaNumberOfPoints());
+        assertEquals(0, body.getEsaNumberOfPoints().intValue());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_8, templateContent.getScenario());
+        assertEquals(10, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenAllowedNotSupportGroupOnlyNoSchedule3WithReg35_WhenZeroPointsAndNoSchedule2() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation29Apply(YesNo.YES);
+        sscsCaseData.setDoesRegulation35Apply(YesNo.YES);
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        // 0 points awarded as no schedule 2- low, which means regulation 29 must apply
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("higher rate", body.getEsaAwardRate());
+
+        assertNotNull(body.getEsaSchedule2Descriptors());
+        assertEquals(0, body.getEsaSchedule2Descriptors().size());
         assertNotNull(body.getEsaNumberOfPoints());
         assertEquals(0, body.getEsaNumberOfPoints().intValue());
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario1Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario1Test.java
@@ -56,4 +56,45 @@ public class EsaScenario1Test {
         Assert.assertEquals(expectedContent, content.toString());
 
     }
+
+    @Test
+    public void testScenario1NoSchedule2() {
+
+        List<Descriptor> schedule2Descriptors =
+            Arrays.asList();
+
+        WriteFinalDecisionTemplateBody body =
+            WriteFinalDecisionTemplateBody.builder()
+                .dateOfDecision("2020-09-20")
+                .esaNumberOfPoints(9)
+                .pageNumber("A1")
+                .appellantName("Felix Sydney")
+                .reasonsForDecision(Arrays.asList("My first reasons", "My second reasons"))
+                .anythingElse("Something else")
+                .esaSchedule2Descriptors(schedule2Descriptors).build();
+
+        EsaTemplateContent content = EsaScenario.SCENARIO_1.getContent(body);
+
+        String expectedContent = "The appeal is refused.\n"
+            + "\n"
+            + "The decision made by the Secretary of State on 20/09/2020 is confirmed.\n"
+            + "\n"
+            + "Felix Sydney does not have limited capability for work and cannot be treated as having limited capability for work.\n"
+            + "\n"
+            + "In applying the work capability assessment 9 points were scored from the activities and descriptors in Schedule 2 of the ESA Regulations 2008. This is insufficient to meet the threshold for the test. Regulation 29 of the Employment and Support Allowance (ESA) Regulations 2008 did not apply.\n"
+            + "\n"
+            + "My first reasons\n"
+            + "\n"
+            + "My second reasons\n"
+            + "\n"
+            + "Something else\n"
+            + "\n"
+            + "This has been an oral (face to face) hearing. Felix Sydney attended the hearing today and the tribunal considered the appeal bundle to page A1. A Presenting Officer attended on behalf of the Respondent.\n"
+            + "\n";
+
+        Assert.assertEquals(9, content.getComponents().size());
+
+        Assert.assertEquals(expectedContent, content.toString());
+
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario7Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario7Test.java
@@ -65,4 +65,54 @@ public class EsaScenario7Test {
         Assert.assertEquals(expectedContent, content.toString());
 
     }
+
+    @Test
+    public void testScenario7WhenNoSchedule2() {
+
+        List<Descriptor> schedule2Descriptors =
+            Arrays.asList();
+
+        WriteFinalDecisionTemplateBody body =
+            WriteFinalDecisionTemplateBody.builder()
+                .isAllowed(true)
+                .isSetAside(true)
+                .dateOfDecision("2020-09-20")
+                .esaNumberOfPoints(0)
+                .pageNumber("A1")
+                .appellantName("Felix Sydney")
+                .reasonsForDecision(Arrays.asList("My first reasons", "My second reasons"))
+                .anythingElse("Something else")
+                .regulation29Applicable(true)
+                .esaSchedule2Descriptors(schedule2Descriptors).build();
+
+        EsaTemplateContent content = EsaScenario.SCENARIO_7.getContent(body);
+
+        String expectedContent = "The appeal is allowed.\n"
+            + "\n"
+            + "The decision made by the Secretary of State on 20/09/2020 is set aside.\n"
+            + "\n"
+            + "Felix Sydney is to be treated as having limited capability for work.\n"
+            + "\n"
+            + "This is because insufficient points were scored to meet the threshold for the work capability assessment, but regulation 29 of the Employment and Support Allowance (ESA) Regulations 2008 applied.\n"
+            + "\n"
+            + "In applying the work capability assessment 0 points were scored from the activities and descriptors in Schedule 2 of the ESA Regulations 2008 made up as follows:\n"
+            + "\n"
+            + "Felix Sydney does not have limited capability for work-related activity because no descriptor from Schedule 3 applied.  Regulation 35 did not apply.\n"
+            + "\n"
+            + "The tribunal applied regulation 29 because there would be a substantial risk to the mental or physical health of any person if they were found not to have limited capability for work.\n"
+            + "\n"
+            + "My first reasons\n"
+            + "\n"
+            + "My second reasons\n"
+            + "\n"
+            + "Something else\n"
+            + "\n"
+            + "This has been an oral (face to face) hearing. Felix Sydney attended the hearing today and the tribunal considered the appeal bundle to page A1. A Presenting Officer attended on behalf of the Respondent.\n"
+            + "\n";
+
+        Assert.assertEquals(12, content.getComponents().size());
+
+        Assert.assertEquals(expectedContent, content.toString());
+
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario8Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario8Test.java
@@ -63,4 +63,52 @@ public class EsaScenario8Test {
         Assert.assertEquals(expectedContent, content.toString());
 
     }
+
+    @Test
+    public void testScenario8WhenNoSchedule2Descriptors() {
+
+        List<Descriptor> schedule2Descriptors =
+            Arrays.asList();
+
+        WriteFinalDecisionTemplateBody body =
+            WriteFinalDecisionTemplateBody.builder()
+                .isAllowed(true)
+                .isSetAside(true)
+                .dateOfDecision("2020-09-20")
+                .esaNumberOfPoints(0)
+                .pageNumber("A1")
+                .appellantName("Felix Sydney")
+                .reasonsForDecision(Arrays.asList("My first reasons", "My second reasons"))
+                .anythingElse("Something else")
+                .regulation29Applicable(true)
+                .esaSchedule2Descriptors(schedule2Descriptors).build();
+
+        EsaTemplateContent content = EsaScenario.SCENARIO_8.getContent(body);
+
+        String expectedContent = "The appeal is allowed.\n"
+            + "\n"
+            + "The decision made by the Secretary of State on 20/09/2020 is set aside.\n"
+            + "\n"
+            + "Felix Sydney is to be treated as having limited capability for work and for work-related activity.\n"
+            + "\n"
+            + "This is because insufficient points were scored to meet the threshold for the work capability assessment and none of the Schedule 3 activities and descriptors were satisfied, but the tribunal applied regulations 29 and 35 of the Employment and Support Allowance Regulations (ESA) 2008.\n"
+            + "\n"
+            + "In applying the work capability assessment 0 points were scored from the activities and descriptors in Schedule 2 of the ESA Regulations 2008 made up as follows:\n"
+            + "\n"
+            + "The tribunal applied regulations 29 and 35 because there would be a substantial risk to the mental or physical health of any person if they were found not to have limited capability for work and for work-related activity.\n"
+            + "\n"
+            + "My first reasons\n"
+            + "\n"
+            + "My second reasons\n"
+            + "\n"
+            + "Something else\n"
+            + "\n"
+            + "This has been an oral (face to face) hearing. Felix Sydney attended the hearing today and the tribunal considered the appeal bundle to page A1. A Presenting Officer attended on behalf of the Respondent.\n"
+            + "\n";
+
+        Assert.assertEquals(11, content.getComponents().size());
+
+        Assert.assertEquals(expectedContent, content.toString());
+
+    }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7578


### Change description ###

* In scenarios where schedule 2 activities were involved, it is valid to select no activities.  For this case we need to ensure that document can still be previewed.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
