### PR TITLE
SSCS-8425 Changes to support regulation 29 and schedule 2 sections not populated for support group only

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaAllowedOrRefusedCondition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaAllowedOrRefusedCondition.java
@@ -42,6 +42,7 @@ import uk.gov.hmcts.reform.sscs.utility.StringUtils;
  */
 public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOrRefusedCondition> {
 
+    // Scenario 1
     REFUSED_NON_SUPPORT_GROUP_ONLY(
         isAllowedOrRefused(REFUSED),
         isWcaAppeal(TRUE, false),
@@ -52,15 +53,17 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
         isRegulation29(FALSE),
         isSchedule3ActivitiesAnswer(StringListPredicate.UNSPECIFIED),
         isRegulation35(UNSPECIFIED)),
+    // Scenario 2
     REFUSED_SUPPORT_GROUP_ONLY_LOW_POINTS(
         isAllowedOrRefused(REFUSED),
         isWcaAppeal(TRUE, false),
         isSupportGroupOnly(YesNoPredicate.TRUE),
         isPoints(POINTS_LESS_THAN_FIFTEEN),
         isAnySchedule3(),
-        isRegulation29(TRUE),
+        isRegulation29(UNSPECIFIED),
         isSchedule3ActivitiesAnswer(EMPTY),
         isRegulation35(FALSE)),
+    // Scenario 2
     REFUSED_SUPPORT_GROUP_ONLY_HIGH_POINTS(
         isAllowedOrRefused(REFUSED),
         isWcaAppeal(TRUE, false),
@@ -70,12 +73,14 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
         isRegulation29(UNSPECIFIED),
         isSchedule3ActivitiesAnswer(EMPTY),
         isRegulation35(FALSE)),
+    // Scenario 5 and Scenario 6
     ALLOWED_NON_SUPPORT_GROUP_ONLY_HIGH_POINTS(
         isAllowedOrRefused(ALLOWED),
         isWcaAppeal(TRUE, false),
         isSupportGroupOnly(YesNoPredicate.FALSE),
         isPoints(POINTS_GREATER_OR_EQUAL_TO_FIFTEEN),
         isAnySchedule3()),
+    // Scenario 7 and Scenario 8
     ALLOWED_NON_SUPPORT_GROUP_ONLY_LOW_POINTS(
         isAllowedOrRefused(ALLOWED),
         isWcaAppeal(TRUE, false),
@@ -84,20 +89,22 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
         isAnySchedule3(),
         isRegulation29(YesNoPredicate.TRUE)
     ),
+    // Scenario 4
     ALLOWED_SUPPORT_GROUP_ONLY_SCHEDULE_3_SELECTED(
         isAllowedOrRefused(ALLOWED),
         isWcaAppeal(TRUE, false),
         isSupportGroupOnly(TRUE),
         isAnyPoints(),
         isSchedule3(NOT_EMPTY),
-        isRegulation29(TRUE.or(UNSPECIFIED))),
+        isRegulation29(UNSPECIFIED)),
+    // SCENARIO_3
     ALLOWED_SUPPORT_GROUP_ONLY_SCHEDULE_3_NOT_SELECTED(
         isAllowedOrRefused(ALLOWED),
         isWcaAppeal(TRUE, false),
         isSupportGroupOnly(TRUE),
         isAnyPoints(),
         isSchedule3(EMPTY),
-        isRegulation29(TRUE.or(UNSPECIFIED)),
+        isRegulation29(UNSPECIFIED),
         isRegulation35(YesNoPredicate.TRUE)),
     ALLOWED_SUPPORT_GROUP_ONLY_SCHEDULE_3_UNSPECIFIED(
         isAllowedOrRefused(ALLOWED),
@@ -105,8 +112,9 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
         isSupportGroupOnly(TRUE),
         isAnyPoints(),
         isSchedule3(StringListPredicate.UNSPECIFIED),
-        isRegulation29(TRUE.or(UNSPECIFIED)),
+        isRegulation29(UNSPECIFIED),
         isRegulation35(TRUE)),
+    // Scenario 10
     NON_WCA_APPEAL_ALLOWED(
             isAllowedOrRefused(ALLOWED),
             isWcaAppeal(FALSE, true),
@@ -114,6 +122,7 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
             isAnyPoints(),
             isAnySchedule3(),
             isDwpReassessTheAward(TRUE)),
+    // Scenario 10
     NON_WCA_APPEAL_REFUSED(
             isAllowedOrRefused(REFUSED),
             isWcaAppeal(FALSE, true),
@@ -272,7 +281,7 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
             }
         }
         throw new IllegalStateException(
-            "No points condition found for " + caseData.getDoesRegulation29Apply() + ":" + caseData.getSchedule3Selections() + ":" + caseData.getRegulation35Selection());
+            "No allowed/refused condition found for " + caseData.getDoesRegulation29Apply() + ":" + caseData.getSchedule3Selections() + ":" + caseData.getRegulation35Selection());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesCondition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesCondition.java
@@ -59,13 +59,13 @@ public enum EsaPointsRegulationsAndSchedule3ActivitiesCondition implements Point
     // SCENARIO_3
     LOW_POINTS_SCHEDULE2_AND_REG_29_SKIPPED_REGULATION_35_DOES_APPLY_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
         Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(TRUE),  isRegulation35(TRUE)), Optional.of(AwardType.HIGHER_RATE), false, isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY), isRegulation29(UNSPECIFIED)),
-    // SCENARIO_4, SCENARIO_6
+    // SCENARIO_6
     HIGH_POINTS_REGULATION_35_UNSPECIFIED(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
         isWcaAppeal(TRUE), isRegulation35(UNSPECIFIED), Optional.of(AwardType.HIGHER_RATE), true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY)),
-    // SCENARIO_2  SCENARIO_5
+    // SCENARIO_5
     HIGH_POINTS_REGULATION_35_DOES_NOT_APPLY(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
         isWcaAppeal(TRUE),isRegulation35(FALSE), Optional.of(AwardType.LOWER_RATE),  true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
-    // SCENARIO_3. SCENARIO_5
+    // SCENARIO_5
     HIGH_POINTS_REGULATION_35_DOES_APPLY(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
         isWcaAppeal(TRUE), isRegulation35(TRUE), Optional.of(AwardType.HIGHER_RATE),  true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
     // SCENARIO 10

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesCondition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesCondition.java
@@ -35,33 +35,53 @@ import uk.gov.hmcts.reform.sscs.utility.StringUtils;
  */
 public enum EsaPointsRegulationsAndSchedule3ActivitiesCondition implements PointsCondition<EsaPointsRegulationsAndSchedule3ActivitiesCondition> {
 
+    // Used for the scenario where case points start high but are lowered and regulation 29 question is skipped
     LOW_POINTS_REGULATION_29_UNSPECIFIED(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-        isWcaAppeal(TRUE), isRegulation29(UNSPECIFIED, false), Optional.empty(), isRegulation29(SPECIFIED)),
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(FALSE), isRegulation29(UNSPECIFIED, false)), Optional.empty(), true, isRegulation29(SPECIFIED)),
+    // Scenario 1
     LOW_POINTS_REGULATION_29_DOES_NOT_APPLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-        isWcaAppeal(TRUE), isRegulation29(FALSE), Optional.of(AwardType.NO_AWARD), isRegulation35(UNSPECIFIED), isSchedule3ActivitiesAnswer(StringListPredicate.UNSPECIFIED)),
-    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_UNSPECIFIED(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-        Arrays.asList(isWcaAppeal(TRUE), isRegulation29(TRUE), isRegulation35(UNSPECIFIED)), Optional.of(AwardType.HIGHER_RATE),  isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY)),
-    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_DOES_NOT_APPLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-        Arrays.asList(isWcaAppeal(TRUE), isRegulation29(TRUE), isRegulation35(FALSE)), Optional.of(AwardType.LOWER_RATE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
-    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_DOES_APPLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-        Arrays.asList(isWcaAppeal(TRUE), isRegulation29(TRUE), isRegulation35(TRUE)), Optional.of(AwardType.HIGHER_RATE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(FALSE), isRegulation29(FALSE)), Optional.of(AwardType.NO_AWARD), true, isRegulation35(UNSPECIFIED), isSchedule3ActivitiesAnswer(StringListPredicate.UNSPECIFIED)),
+    // SCENARIO_9
+    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_UNSPECIFIED_NON_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(FALSE), isRegulation29(TRUE), isRegulation35(UNSPECIFIED)), Optional.of(AwardType.HIGHER_RATE),  true, isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY)),
+    // SCENARIO_7
+    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_DOES_NOT_APPLY_NON_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(FALSE), isRegulation29(TRUE), isRegulation35(FALSE)), Optional.of(AwardType.LOWER_RATE), true, isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+    // SCENARIO_8
+    LOW_POINTS_REGULATION_29_DOES_APPLY_REGULATION_35_DOES_APPLY_NON_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(FALSE), isRegulation29(TRUE), isRegulation35(TRUE)), Optional.of(AwardType.HIGHER_RATE), true, isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+    // SCENARIO_4
+    LOW_POINTS_SCHEDULE2_AND_REG_29_SKIPPED_REGULATION_35_UNSPECIFIED_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(TRUE), isRegulation35(UNSPECIFIED)), Optional.of(AwardType.HIGHER_RATE),  false, isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY), isRegulation29(UNSPECIFIED)),
+    // SCENARIO_2
+    LOW_POINTS_SCHEDULE2_AND_REG_29_SKIPPED_REGULATION_35_DOES_NOT_APPLY_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(TRUE), isRegulation35(FALSE)), Optional.of(AwardType.LOWER_RATE), false, isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY), isRegulation29(UNSPECIFIED)),
+    // SCENARIO_3
+    LOW_POINTS_SCHEDULE2_AND_REG_29_SKIPPED_REGULATION_35_DOES_APPLY_SUPPORT_GROUP_ONLY(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
+        Arrays.asList(isWcaAppeal(TRUE), isSupportGroupOnly(TRUE),  isRegulation35(TRUE)), Optional.of(AwardType.HIGHER_RATE), false, isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY), isRegulation29(UNSPECIFIED)),
+    // SCENARIO_4, SCENARIO_6
     HIGH_POINTS_REGULATION_35_UNSPECIFIED(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
-        isWcaAppeal(TRUE), isRegulation35(UNSPECIFIED), Optional.of(AwardType.HIGHER_RATE), isRegulation29(UNSPECIFIED), isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY)),
+        isWcaAppeal(TRUE), isRegulation35(UNSPECIFIED), Optional.of(AwardType.HIGHER_RATE), true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.NOT_EMPTY)),
+    // SCENARIO_2  SCENARIO_5
     HIGH_POINTS_REGULATION_35_DOES_NOT_APPLY(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
-        isWcaAppeal(TRUE),isRegulation35(FALSE), Optional.of(AwardType.LOWER_RATE),  isRegulation29(UNSPECIFIED), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+        isWcaAppeal(TRUE),isRegulation35(FALSE), Optional.of(AwardType.LOWER_RATE),  true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+    // SCENARIO_3. SCENARIO_5
     HIGH_POINTS_REGULATION_35_DOES_APPLY(EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN,
-        isWcaAppeal(TRUE), isRegulation35(TRUE), Optional.of(AwardType.HIGHER_RATE),  isRegulation29(UNSPECIFIED), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+        isWcaAppeal(TRUE), isRegulation35(TRUE), Optional.of(AwardType.HIGHER_RATE),  true, isRegulation29(UNSPECIFIED), isSupportGroupOnly(FALSE), isSchedule3ActivitiesAnswer(StringListPredicate.EMPTY)),
+    // SCENARIO 10
     NON_WCA_APPEAL(EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN,
-            Arrays.asList(isWcaAppeal(FALSE)), Optional.empty(), isDwpReassessTheAward(TRUE));
+            Arrays.asList(isWcaAppeal(FALSE)), Optional.empty(), false, isDwpReassessTheAward(TRUE));
     List<YesNoFieldCondition> primaryConditions;
     List<FieldCondition> validationConditions;
 
     EsaPointsCondition pointsCondition;
     Optional<AwardType> awardType;
+    private boolean displayPointsSatisfiedMessageOnError;
 
     EsaPointsRegulationsAndSchedule3ActivitiesCondition(EsaPointsCondition pointsCondition, YesNoFieldCondition primaryCondition1,YesNoFieldCondition primaryCondition2,
-        Optional<AwardType> awardType, FieldCondition...validationConditions) {
-        this(pointsCondition, Arrays.asList(primaryCondition1, primaryCondition2), awardType, validationConditions);
+        Optional<AwardType> awardType, boolean displayPointsSatisfiedMessageOnError, FieldCondition...validationConditions) {
+        this(pointsCondition, Arrays.asList(primaryCondition1, primaryCondition2), awardType, displayPointsSatisfiedMessageOnError, validationConditions);
+        this.displayPointsSatisfiedMessageOnError = displayPointsSatisfiedMessageOnError;
     }
 
     public Optional<AwardType> getAwardType() {
@@ -69,11 +89,12 @@ public enum EsaPointsRegulationsAndSchedule3ActivitiesCondition implements Point
     }
 
     EsaPointsRegulationsAndSchedule3ActivitiesCondition(EsaPointsCondition pointsCondition, List<YesNoFieldCondition> primaryConditions,
-        Optional<AwardType> awardType, FieldCondition...validationConditions) {
+        Optional<AwardType> awardType, boolean displayPointsSatisfiedMessageOnError, FieldCondition...validationConditions) {
         this.pointsCondition = pointsCondition;
         this.awardType = awardType;
         this.primaryConditions = primaryConditions;
         this.validationConditions = Arrays.asList(validationConditions);
+        this.displayPointsSatisfiedMessageOnError = displayPointsSatisfiedMessageOnError;
     }
 
     static YesNoFieldCondition isRegulation29(YesNoPredicate predicate) {
@@ -84,6 +105,11 @@ public enum EsaPointsRegulationsAndSchedule3ActivitiesCondition implements Point
     static YesNoFieldCondition isRegulation29(YesNoPredicate predicate, boolean displaySatisifiedMessageOnError) {
         return new YesNoFieldCondition("Regulation 29", predicate,
                 SscsCaseData::getDoesRegulation29Apply, displaySatisifiedMessageOnError);
+    }
+
+    static YesNoFieldCondition isSupportGroupOnly(Predicate<YesNo> predicate) {
+        return new YesNoFieldCondition("Support Group Only Appeal", predicate,
+            s -> s.isSupportGroupOnlyAppeal() ? YesNo.YES : YesNo.NO);
     }
 
     static YesNoFieldCondition isRegulation35(Predicate<YesNo> predicate) {
@@ -175,7 +201,9 @@ public enum EsaPointsRegulationsAndSchedule3ActivitiesCondition implements Point
                 .collect(Collectors.toList());
 
         List<String> criteriaSatisfiedMessages = new ArrayList<>();
-        criteriaSatisfiedMessages.add(pointsCondition.getIsSatisfiedMessage());
+        if (displayPointsSatisfiedMessageOnError) {
+            criteriaSatisfiedMessages.add(pointsCondition.getIsSatisfiedMessage());
+        }
         criteriaSatisfiedMessages.addAll(primaryCriteriaSatisfiedMessages);
 
         if (!validationErrorMessages.isEmpty()) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
@@ -120,8 +120,13 @@ public class EsaWriteFinalDecisionPreviewDecisionService extends WriteFinalDecis
 
         if (allSchedule2Descriptors.isEmpty()) {
             if (caseData.isWcaAppeal()) {
-                builder.esaSchedule2Descriptors(new ArrayList<>());
-                builder.esaNumberOfPoints(caseData.isWcaAppeal() ? 0 : null);
+                if (caseData.isSupportGroupOnlyAppeal()) {
+                    builder.esaSchedule2Descriptors(null);
+                    builder.esaNumberOfPoints(null);
+                } else {
+                    builder.esaSchedule2Descriptors(new ArrayList<>());
+                    builder.esaNumberOfPoints(0);
+                }
             } else {
                 builder.esaSchedule2Descriptors(null);
                 builder.esaNumberOfPoints(null);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
@@ -31,22 +31,34 @@ public class EsaDecisionNoticeOutcomeService extends DecisionNoticeOutcomeServic
 
             if (sscsCaseData.isWcaAppeal()) {
 
-                int totalPoints = questionService.getTotalPoints(sscsCaseData,
-                    EsaPointsRegulationsAndSchedule3ActivitiesCondition.getAllAnswersExtractor().apply(sscsCaseData));
-
-                if (EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN.getPointsRequirementCondition().test(totalPoints)) {
+                if (sscsCaseData.isSupportGroupOnlyAppeal()) {
                     sscsCaseData.setDoesRegulation29Apply(null);
+                    sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(null);
+                    sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMentalAssessmentQuestion(null);
                     // Ensure that we set the following fields taking into account the radio button
                     // for whether schedule 3 activities apply.   The getRegulation35Selection and
                     // getSchedule3Selections methods peform this check,  and we use these methods
                     // to set the final values of doesRegulation35Apply and esaWriteFinalDecisionSchedule3ActivitiesQuestion
                     sscsCaseData.setDoesRegulation35Apply(sscsCaseData.getRegulation35Selection());
                     sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(sscsCaseData.getSchedule3Selections());
-                } else if (EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN.getPointsRequirementCondition().test(totalPoints)) {
-                    if (YesNo.NO.equals(sscsCaseData.getDoesRegulation29Apply())) {
-                        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply(null);
-                        sscsCaseData.setDoesRegulation35Apply(null);
-                        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(null);
+                } else {
+                    int totalPoints = questionService.getTotalPoints(sscsCaseData,
+                        EsaPointsRegulationsAndSchedule3ActivitiesCondition.getAllAnswersExtractor().apply(sscsCaseData));
+
+                    if (EsaPointsCondition.POINTS_GREATER_OR_EQUAL_TO_FIFTEEN.getPointsRequirementCondition().test(totalPoints)) {
+                        sscsCaseData.setDoesRegulation29Apply(null);
+                        // Ensure that we set the following fields taking into account the radio button
+                        // for whether schedule 3 activities apply.   The getRegulation35Selection and
+                        // getSchedule3Selections methods peform this check,  and we use these methods
+                        // to set the final values of doesRegulation35Apply and esaWriteFinalDecisionSchedule3ActivitiesQuestion
+                        sscsCaseData.setDoesRegulation35Apply(sscsCaseData.getRegulation35Selection());
+                        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(sscsCaseData.getSchedule3Selections());
+                    } else if (EsaPointsCondition.POINTS_LESS_THAN_FIFTEEN.getPointsRequirementCondition().test(totalPoints)) {
+                        if (YesNo.NO.equals(sscsCaseData.getDoesRegulation29Apply())) {
+                            sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply(null);
+                            sscsCaseData.setDoesRegulation35Apply(null);
+                            sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(null);
+                        }
                     }
                 }
             } else {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesConditionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesConditionTest.java
@@ -144,27 +144,42 @@ public class EsaPointsRegulationsAndSchedule3ActivitiesConditionTest {
         return false;
     }
 
-    private boolean isValidCombinationExpected(int points, Boolean wcaAppeal, Boolean doesRegulation29Apply, Boolean schedule3ActivitiesSelected,
-        Boolean doesRegulation35Apply) {
+    private boolean isValidPointsBasedCombinationExpected(int points, Boolean wcaAppeal, Boolean doesRegulation29Apply, Boolean schedule3ActivitiesSelected,
+        Boolean doesRegulation35Apply, Boolean supportGroupOnly) {
 
+        // If it's not a wca appeal we don't do any points-based validation - always valid
         if (!wcaAppeal.booleanValue()) {
             return true;
         }
+        // For WCA appeals, if points < 15
         if (points < 15) {
             if (doesRegulation29Apply == null) {
-                return false;
-            } else {
-                if (!doesRegulation29Apply.booleanValue()) {
-                    if (schedule3ActivitiesSelected != null) {
-                        return false;
-                    } else {
-                        return true;
-                    }
-                } else {
+                if (supportGroupOnly) {
                     return isValidCombinationFromSelectSchedule3ActivitiesOnwards(schedule3ActivitiesSelected, doesRegulation35Apply);
+                } else {
+                    return false;
+                }
+            } else {
+                if (supportGroupOnly) {
+                    return false;
+                } else {
+                    if (!doesRegulation29Apply.booleanValue()) {
+                        if (schedule3ActivitiesSelected != null) {
+                            return false;
+                        } else {
+                            return true;
+                        }
+                    } else {
+                        return isValidCombinationFromSelectSchedule3ActivitiesOnwards(schedule3ActivitiesSelected, doesRegulation35Apply);
+                    }
                 }
             }
         } else {
+            // For WCA appeals, if points >= 15
+            if (supportGroupOnly != null && supportGroupOnly.booleanValue()) {
+                // If points >= 15 there must have been an error, because we skip the points pages and we should be
+                return false;
+            }
             if (doesRegulation29Apply != null) {
                 return false;
             }
@@ -203,8 +218,8 @@ public class EsaPointsRegulationsAndSchedule3ActivitiesConditionTest {
                     int conditionApplicableCount = 0;
 
                     final boolean isValidCombinationExpected =
-                        isValidCombinationExpected(points, wcaAppeal, doesRegulation29Apply, schedule3ActivitiesSelected,
-                            doesRegulation35Apply);
+                        isValidPointsBasedCombinationExpected(points, wcaAppeal, doesRegulation29Apply, schedule3ActivitiesSelected,
+                            doesRegulation35Apply, supportGroupOnly);
 
                     List<String> schedule3Activities = null;
                     String schedule3ActivitesApply = null;
@@ -253,18 +268,18 @@ public class EsaPointsRegulationsAndSchedule3ActivitiesConditionTest {
                     }
 
                     Assert.assertEquals(
-                        "Expected 1 condition to be satisfied for points:" + points + ":" + wcaAppeal + ":" + doesRegulation29Apply + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply + " but "
+                        "Expected 1 condition to be satisfied for points:" + points + ":" + wcaAppeal + ":" + doesRegulation29Apply + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply + ":" + supportGroupOnly +  " but "
                             + conditionApplicableCount + " were satisfied",
                         1, conditionApplicableCount);
 
                     if (isValidCombinationExpected) {
 
                         Assert.assertTrue("Unexpected error for:" + points + ":" + wcaAppeal + ":" + doesRegulation29Apply
-                            + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply, matchingCondition
+                            + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply + ":" + supportGroupOnly, matchingCondition
                             .getOptionalErrorMessage(questionService, caseData).isEmpty());
                     } else {
                         Assert.assertTrue("Expected an error for:" + points + ":" + wcaAppeal + ":" + doesRegulation29Apply
-                            + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply, matchingCondition
+                            + ":" + schedule3ActivitiesSelected + ":" + doesRegulation35Apply + ":" + supportGroupOnly, matchingCondition
                             .getOptionalErrorMessage(questionService, caseData).isPresent());
                     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -228,7 +228,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         String error = response.getErrors().stream().findFirst().orElse("");
 
-        assertEquals("You have awarded less than 15 points, but have a missing answer for the Regulation 29 question. Please review your previous selection.", error);
+        assertEquals("You have awarded less than 15 points and specified that Support Group Only Appeal does not apply, but have a missing answer for the Regulation 29 question. Please review your previous selection.", error);
     }
 
     @Test
@@ -453,9 +453,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
         Assert.assertEquals(1, response.getErrors().size());
 
         String error = response.getErrors().stream().findFirst().orElse("");
-        assertEquals("You have awarded less than 15 points, specified that Regulation 29 applies "
-                + "and not provided an answer to the Regulation 35 question, but have made "
-                + "no selections for the Schedule 3 Activities question. Please review your previous selection.", error);
+        assertEquals("You have awarded less than 15 points, specified that Support Group Only Appeal does not apply, specified that Regulation 29 applies and not provided an answer to the Regulation 35 question, but have made no selections for the Schedule 3 Activities question. Please review your previous selection.", error);
     }
 
     @Test
@@ -714,7 +712,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         String error = response.getErrors().iterator().next();
 
-        Assert.assertEquals("You have awarded less than 15 points, specified that the appeal is refused and specified that Support Group Only Appeal applies, but have answered No for the Regulation 29 question, have a missing answer for the Schedule 3 Activities question and a missing answer for the Regulation 35 question. Please review your previous selection.", error);
+        Assert.assertEquals("You have specified that Support Group Only Appeal applies and not provided an answer to the Regulation 35 question, but have have a missing answer for the Schedule 3 Activities question. Please review your previous selection.", error);
     }
 
     // Refused scenario 2

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionServiceTest.java
@@ -217,17 +217,9 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("lower rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
         assertNull(body.getEsaSchedule3Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(9, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("c", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("Cannot, unaided by another person, either: (i) mobilise more than 100 metres on level ground without stopping in order to avoid significant discomfort or exhaustion; or (ii) repeatedly mobilise 100 metres within a reasonable timescale because of significant discomfort or exhaustion.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(9, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(payload.getDateIssued());
@@ -241,6 +233,130 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals(6, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
     }
+
+    @Test
+    public void willSetPreviewFile_WhenRefusedSupportGroupOnlyAppealAndLowerRateAward_WhenZeroPointsNoSchedule2Selected() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setDoesRegulation29Apply(YesNo.YES);
+        sscsCaseData.setDoesRegulation35Apply(YesNo.NO);
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("refused");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = false;
+
+        boolean setAsideExpectation = false;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("lower rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule3Descriptors());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_2, templateContent.getScenario());
+
+        assertEquals(6, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenRefusedSupportGroupOnlyAppealAndLowerRateAward_WhenSchedule2AndReg29Skipped() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setDoesRegulation35Apply(YesNo.NO);
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("refused");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = false;
+
+        boolean setAsideExpectation = false;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("lower rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule3Descriptors());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_2, templateContent.getScenario());
+
+        assertEquals(6, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
 
     @Test
     public void willSetPreviewFile_WhenRefusedSupportGroupOnlyAppealAndLowerRateAward_WhenHighPoints() {
@@ -289,17 +405,9 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("lower rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
         assertNull(body.getEsaSchedule3Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(15, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("a", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("Cannot, unaided by another person, either: (i) mobilise more than 50 metres on level ground without stopping in order to avoid significant discomfort or exhaustion; or (ii) repeatedly mobilise 50 metres within a reasonable timescale because of significant discomfort or exhaustion.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(15, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(payload.getDateIssued());
@@ -810,16 +918,8 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("higher rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(15, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("a", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("Cannot, unaided by another person, either: (i) mobilise more than 50 metres on level ground without stopping in order to avoid significant discomfort or exhaustion; or (ii) repeatedly mobilise 50 metres within a reasonable timescale because of significant discomfort or exhaustion.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(15, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(body.getDwpReassessTheAward());
@@ -887,16 +987,8 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("higher rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(15, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("a", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("Cannot, unaided by another person, either: (i) mobilise more than 50 metres on level ground without stopping in order to avoid significant discomfort or exhaustion; or (ii) repeatedly mobilise 50 metres within a reasonable timescale because of significant discomfort or exhaustion.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(15, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(body.getDwpReassessTheAward());
@@ -963,16 +1055,141 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("higher rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(0, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("e", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("None of the above applies.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(0, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_3, templateContent.getScenario());
+        assertEquals(9, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenAllowedAndSupportGroupOnlyNoSchedule3_WhenZeroPointsAndNoSchedule2Selected() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation35Apply(YesNo.YES);
+        sscsCaseData.setDoesRegulation29Apply(YesNo.YES);
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        // 0 points awarded because no schedule 2 activities selected - low, which means regulation 29 must apply
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1e");
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("higher rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_3, templateContent.getScenario());
+        assertEquals(9, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenAllowedAndSupportGroupOnlyNoSchedule3_WhenSchedule2AndReg29Skipped() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("No");
+        sscsCaseData.setDoesRegulation35Apply(YesNo.YES);
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        // 0 points awarded because no schedule 2 activities selected - low, which means regulation 29 must apply
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMobilisingUnaidedQuestion("mobilisingUnaided1e");
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("higher rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(body.getDwpReassessTheAward());
@@ -1039,16 +1256,137 @@ public class EsaWriteFinalDecisionPreviewDecisionServiceTest extends WriteFinalD
 
         assertEquals("higher rate", body.getEsaAwardRate());
 
-        assertNotNull(body.getEsaSchedule2Descriptors());
-        assertEquals(1, body.getEsaSchedule2Descriptors().size());
-        assertNotNull(body.getEsaSchedule2Descriptors().get(0));
-        assertEquals(0, body.getEsaSchedule2Descriptors().get(0).getActivityAnswerPoints());
-        assertEquals("e", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerLetter());
-        assertEquals("None of the above applies.", body.getEsaSchedule2Descriptors().get(0).getActivityAnswerValue());
-        assertEquals("1. Mobilising unaided by another person with or without a walking stick, manual wheelchair or other aid if such aid is normally or could reasonably be worn or used.", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionValue());
-        assertEquals("1", body.getEsaSchedule2Descriptors().get(0).getActivityQuestionNumber());
-        assertNotNull(body.getEsaNumberOfPoints());
-        assertEquals(0, body.getEsaNumberOfPoints().intValue());
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_4, templateContent.getScenario());
+        assertEquals(9, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenAllowedAndSupportGroupOnlySchedule3_WhenZeroPointsAndNoSchedule2Selected() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList("schedule3MobilisingUnaided", "schedule3AppropriatenessOfBehaviour"));
+        sscsCaseData.setDoesRegulation29Apply(YesNo.YES);
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(Arrays.asList());
+
+        // 0 points awarded as no schedule 2 selected - low, which means regulation 29 must apply
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("higher rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
+
+        assertTrue(body.isEsaIsEntited());
+        assertNull(body.getDwpReassessTheAward());
+        assertNull(payload.getDateIssued());
+        assertEquals(LocalDate.now(), payload.getGeneratedDate());
+        assertNull(sscsCaseData.getWriteFinalDecisionEndDateType());
+
+        assertNotNull(payload.getWriteFinalDecisionTemplateContent());
+        assertTrue(payload.getWriteFinalDecisionTemplateContent() instanceof EsaTemplateContent);
+        EsaTemplateContent templateContent = (EsaTemplateContent)payload.getWriteFinalDecisionTemplateContent();
+        assertEquals(EsaScenario.SCENARIO_4, templateContent.getScenario());
+        assertEquals(9, payload.getWriteFinalDecisionTemplateContent().getComponents().size());
+    }
+
+    @Test
+    public void willSetPreviewFile_WhenAllowedAndSupportGroupOnlySchedule3_WhenSchedule2AndReg29Skipped() {
+
+        String endDate = "2018-11-10";
+        setCommonPreviewParams(sscsCaseData, endDate);
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList("schedule3MobilisingUnaided", "schedule3AppropriatenessOfBehaviour"));
+        sscsCaseData.setWcaAppeal("Yes");
+        sscsCaseData.setSupportGroupOnlyAppeal("Yes");
+        sscsCaseData.setWriteFinalDecisionAllowedOrRefused("allowed");
+
+        sscsCaseData.setWriteFinalDecisionGenerateNotice("yes");
+
+        final PreSubmitCallbackResponse<SscsCaseData> response = service.preview(callback, DocumentType.DRAFT_DECISION_NOTICE, USER_AUTHORISATION, false);
+
+        assertNotNull(response.getData().getWriteFinalDecisionPreviewDocument());
+        assertEquals(DocumentLink.builder()
+            .documentFilename(String.format("Draft Decision Notice generated on %s.pdf", LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-YYYY"))))
+            .documentBinaryUrl(URL + "/binary")
+            .documentUrl(URL)
+            .build(), response.getData().getWriteFinalDecisionPreviewDocument());
+
+        boolean appealAllowedExpectation = true;
+
+        boolean setAsideExpectation = true;
+
+        NoticeIssuedTemplateBody payload = verifyTemplateBody(NoticeIssuedTemplateBody.ENGLISH_IMAGE, "Appellant Lastname", null, "2018-10-10",
+            appealAllowedExpectation, setAsideExpectation, true, true, true, documentConfiguration.getBenefitSpecificDocuments().get("esa").get(LanguagePreference.ENGLISH).get(EventType.ISSUE_FINAL_DECISION));
+
+        assertTrue(payload.getWriteFinalDecisionTemplateBody().isWcaAppeal());
+
+        assertEquals("Judge Full Name", payload.getUserName());
+        assertEquals("DRAFT DECISION NOTICE", payload.getNoticeType());
+
+        WriteFinalDecisionTemplateBody body = payload.getWriteFinalDecisionTemplateBody();
+
+        assertNotNull(body);
+
+        // Common assertions
+        assertCommonPreviewParams(body, endDate, false);
+
+        assertEquals("higher rate", body.getEsaAwardRate());
+
+        assertNull(body.getEsaSchedule2Descriptors());
+        assertNull(body.getEsaNumberOfPoints());
 
         assertTrue(body.isEsaIsEntited());
         assertNull(body.getDwpReassessTheAward());

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario2Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario2Test.java
@@ -19,7 +19,7 @@ public class EsaScenario2Test {
                         .isAllowed(false)
                         .isSetAside(false)
                         .dateOfDecision("2020-09-20")
-                        .esaNumberOfPoints(9)
+                        .esaNumberOfPoints(null)
                         .pageNumber("A1")
                         .appellantName("Felix Sydney")
                         .regulation35Applicable(false)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario3Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario3Test.java
@@ -18,7 +18,7 @@ public class EsaScenario3Test {
                         .isAllowed(true)
                         .isSetAside(true)
                         .dateOfDecision("2020-09-20")
-                        .esaNumberOfPoints(15)
+                        .esaNumberOfPoints(null)
                         .pageNumber("A1")
                         .appellantName("Felix Sydney")
                         .regulation35Applicable(true)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario4Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario4Test.java
@@ -24,7 +24,7 @@ public class EsaScenario4Test {
                         .isAllowed(true)
                         .isSetAside(true)
                         .dateOfDecision("2020-09-20")
-                        .esaNumberOfPoints(15)
+                        .esaNumberOfPoints(null)
                         .pageNumber("A1")
                         .appellantName("Felix Sydney")
                         .supportGroupOnly(true)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-8425

### Change description ###

Supports the scenario where schedule 2 sections and regulation 29 pages are not displayed for support group only ( ccd changes to be done separately) - for these scenario the schedule 2 questions will be null and regulation 29 unset.

This applies to Scenarios 2, 3, 4

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
