### PR TITLE
Change gradle repositories so that libs will be picked up from local first then maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,21 +131,21 @@ dependencyCheck {
 
 repositories {
 
+    mavenLocal()
+    mavenCentral()
     maven {
         url "https://dl.bintray.com/hmcts/hmcts-maven"
     }
 
-    maven {
-        url 'https://repo.spring.io/libs-milestone'
-    }
-
     jcenter()
-    mavenCentral()
 
     // jitpack should be last resort
     // see: https://github.com/jitpack/jitpack.io/issues/1939
     maven { url 'https://jitpack.io' }
-    mavenLocal()
+    // Requires authentication, if it gets here the library cannot be found!
+    maven {
+        url 'https://repo.spring.io/libs-milestone'
+    }
 }
 
 project.tasks['sonarqube'].dependsOn test, integration, jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -132,10 +132,10 @@ dependencyCheck {
 repositories {
 
     mavenLocal()
-    mavenCentral()
     maven {
         url "https://dl.bintray.com/hmcts/hmcts-maven"
     }
+    mavenCentral()
 
     jcenter()
 


### PR DESCRIPTION
Change gradle repositories so that libs will be picked up from local first and then maven central.
Similar to https://github.com/hmcts/sscs-pdf-email-common/pull/457
`https://repo.spring.io/libs-milestone/` now requires authentication, so presumably, will never work if libraries need to be pulled from there
