### PR TITLE
SSCS-8426 Misc bug fixes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandler.java
@@ -52,7 +52,12 @@ public class EsaWriteFinalDecisionMidEventValidationHandler extends WriteFinalDe
 
     @Override
     protected void validateAwardTypes(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
-        // No-op for ESA
+        if ("Yes".equalsIgnoreCase(sscsCaseData.getSscsEsaCaseData().getEsaWriteFinalDecisionSchedule3ActivitiesApply())) {
+            if (sscsCaseData.getSscsEsaCaseData().getEsaWriteFinalDecisionSchedule3ActivitiesQuestion() == null
+                || sscsCaseData.getSscsEsaCaseData().getEsaWriteFinalDecisionSchedule3ActivitiesQuestion().isEmpty()) {
+                preSubmitCallbackResponse.addError("Please select the Schedule 3 Activities that apply, or indicate that none apply");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionPreviewDecisionService.java
@@ -122,6 +122,12 @@ public class EsaWriteFinalDecisionPreviewDecisionService extends WriteFinalDecis
             allSchedule2Descriptors.addAll(mentalAssessmentDescriptors);
         }
 
+        // Don't add descriptors to the template if the total points in schedule 2 are zero
+        int totalPoints = allSchedule2Descriptors.stream().mapToInt(d -> d.getActivityAnswerPoints()).sum();
+        if (totalPoints == 0) {
+            allSchedule2Descriptors.clear();
+        }
+
         if (allSchedule2Descriptors.isEmpty()) {
             if (caseData.getSscsEsaCaseData().isWcaAppeal()) {
                 if (caseData.isSupportGroupOnlyAppeal()) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionMidEventValidationHandlerTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.MID_EVENT;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import javax.validation.Validator;
@@ -74,6 +75,47 @@ public class EsaWriteFinalDecisionMidEventValidationHandlerTest extends WriteFin
         assertEquals("Yes", sscsCaseData.getSscsEsaCaseData().getEsaWriteFinalDecisionSchedule3ActivitiesApply());
 
         assertTrue(response.getErrors().isEmpty());
+    }
+
+    @Test
+    public void givenSchedule3ActivitiesApplyFlagSetToYes_WhenActivitiesSpecified_thenDoNoDisplayError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(Arrays.asList("schedule3MobilisingUnaided"));
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(0, response.getErrors().size());
+    }
+
+    @Test
+    public void givenSchedule3ActivitiesApplyFlagSetToYes_WhenNullActivities_thenDisplayError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(null);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getErrors().size());
+        assertEquals("Please select the Schedule 3 Activities that apply, or indicate that none apply", response.getErrors().iterator().next());
+    }
+
+    @Test
+    public void givenSchedule3ActivitiesApplyFlagSetToYes_WhenEmptyActivities_thenDisplayError() {
+
+        when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
+
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply("Yes");
+        sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(new ArrayList<>());
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(MID_EVENT, callback, USER_AUTHORISATION);
+
+        assertEquals(1, response.getErrors().size());
+        assertEquals("Please select the Schedule 3 Activities that apply, or indicate that none apply", response.getErrors().iterator().next());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario1Test.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/scenarios/EsaScenario1Test.java
@@ -72,7 +72,7 @@ public class EsaScenario1Test {
                 .attendedHearing(true)
                 .presentingOfficerAttended(true)
                 .dateOfDecision("2020-09-20")
-                .esaNumberOfPoints(9)
+                .esaNumberOfPoints(0)
                 .pageNumber("A1")
                 .appellantName("Felix Sydney")
                 .reasonsForDecision(Arrays.asList("My first reasons", "My second reasons"))
@@ -87,7 +87,7 @@ public class EsaScenario1Test {
             + "\n"
             + "Felix Sydney does not have limited capability for work and cannot be treated as having limited capability for work.\n"
             + "\n"
-            + "In applying the work capability assessment 9 points were scored from the activities and descriptors in Schedule 2 of the ESA Regulations 2008. This is insufficient to meet the threshold for the test. Regulation 29 of the Employment and Support Allowance (ESA) Regulations 2008 did not apply.\n"
+            + "In applying the work capability assessment 0 points were scored from the activities and descriptors in Schedule 2 of the ESA Regulations 2008. This is insufficient to meet the threshold for the test. Regulation 29 of the Employment and Support Allowance (ESA) Regulations 2008 did not apply.\n"
             + "\n"
             + "My first reasons\n"
             + "\n"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-8426

### Change description ###

* Ensuring that we don't add Schedule2 descriptors to the template if no points were scored
* Ensuring that the validation mid event callback checks whether schedule3 activities are submitted if the flag to indicate they apply has been checked

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
