### PR TITLE
SSCS-7580 Ensure that we validate that reg35 must be set to No for Scenario 5

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaAllowedOrRefusedCondition.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaAllowedOrRefusedCondition.java
@@ -82,6 +82,7 @@ public enum EsaAllowedOrRefusedCondition implements PointsCondition<EsaAllowedOr
         isSupportGroupOnly(YesNoPredicate.NOT_TRUE, true),
         isPoints(POINTS_GREATER_OR_EQUAL_TO_FIFTEEN),
         isAnySchedule3(),
+        isRegulation35(NOT_TRUE),
         isSupportGroupOnly(YesNoPredicate.FALSE, false).get()),
     // Scenario 7 and Scenario 8
     ALLOWED_NON_SUPPORT_GROUP_ONLY_LOW_POINTS(

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesConditionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaPointsRegulationsAndSchedule3ActivitiesConditionTest.java
@@ -125,6 +125,11 @@ public class EsaPointsRegulationsAndSchedule3ActivitiesConditionTest {
         }
         if (allowed && !supportGroupOnly) {
             if (points >= 15) {
+                if (schedule3ActivitiesSelected != null && !schedule3ActivitiesSelected.booleanValue()) {
+                    if (doesRegulation35Apply.booleanValue()) {
+                        return false;
+                    }
+                }
                 return true;
             } else {
                 return doesRegulation29Apply != null && doesRegulation29Apply.booleanValue();

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/writefinaldecision/esa/EsaWriteFinalDecisionAboutToSubmitHandlerTest.java
@@ -62,7 +62,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
     @Test
     @Parameters(named = "schedule3ActivityAndRegulation35Combinations")
-    public void givenRegulation29FieldIsPopulatedWithYesAndPointsAreTooHigh_thenOnlyDisplayAnErrorIfSchedule3ActivitiesNotPopulated(Boolean schedule3Activities, Boolean regulation35) {
+    public void givenRegulation29FieldIsPopulatedWithYesAndPointsAreTooHigh_thenOnlyDisplayAnErrorIfSchedule3ActivitiesNotPopulatedOrIfNonSupportGroupAndRegulation35SetToYes(Boolean schedule3Activities, Boolean regulation35) {
 
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
         sscsCaseData.getSscsEsaCaseData().setWcaAppeal("Yes");
@@ -88,7 +88,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         if ((schedule3Activities != null && schedule3Activities.booleanValue())
-            || schedule3Activities != null && !schedule3Activities.booleanValue() && regulation35 != null) {
+            || schedule3Activities != null && !schedule3Activities.booleanValue() && regulation35 != null && !regulation35.booleanValue()) {
             Assert.assertEquals(0, response.getErrors().size());
 
         } else {
@@ -114,7 +114,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
                     if (!regulation35.booleanValue()) {
                         assertEquals("You have awarded 15 points or more, but have submitted an unexpected answer for the Regulation 29 question and have a missing answer for the Schedule 3 Activities question. Please review your previous selection.", error);
                     } else {
-                        assertEquals("You have awarded 15 points or more, but have submitted an unexpected answer for the Regulation 29 question and have a missing answer for the Schedule 3 Activities question. Please review your previous selection.", error);
+                        assertEquals("You have awarded 15 points or more, specified that the appeal is allowed and specified that Support Group Only Appeal does not apply, but have answered Yes for the Regulation 35 question. Please review your previous selection.", error);
                     }
                 }
             } else {
@@ -134,7 +134,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
     @Test
     @Parameters(named = "schedule3ActivityAndRegulation35Combinations")
-    public void givenRegulation29FieldIsPopulatedWithNoAndPointsAreTooHigh_thenOnlyDisplayAnErrorIfSchedule3ActivitiesNotPopulated(Boolean schedule3Activities, Boolean regulation35) {
+    public void givenRegulation29FieldIsPopulatedWithNoAndPointsAreTooHigh_thenOnlyDisplayAnErrorIfSchedule3ActivitiesNotPopulatedOrIfNonSupportGroupAndRegulation35SetToYes(Boolean schedule3Activities, Boolean regulation35) {
 
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
         sscsCaseData.getSscsEsaCaseData().setWcaAppeal("Yes");
@@ -161,7 +161,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         if ((schedule3Activities != null && schedule3Activities.booleanValue())
-            || schedule3Activities != null && !schedule3Activities.booleanValue() && regulation35 != null) {
+            || schedule3Activities != null && !schedule3Activities.booleanValue() && regulation35 != null && !regulation35.booleanValue()) {
             Assert.assertEquals(0, response.getErrors().size());
 
         } else {
@@ -187,7 +187,7 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
                     if (!regulation35.booleanValue()) {
                         assertEquals("You have awarded 15 points or more, but have submitted an unexpected answer for the Regulation 29 question and have a missing answer for the Schedule 3 Activities question. Please review your previous selection.", error);
                     } else {
-                        assertEquals("You have awarded 15 points or more, but have submitted an unexpected answer for the Regulation 29 question and have a missing answer for the Schedule 3 Activities question. Please review your previous selection.", error);
+                        assertEquals("You have awarded 15 points or more, specified that the appeal is allowed and specified that Support Group Only Appeal does not apply, but have answered Yes for the Regulation 35 question. Please review your previous selection.", error);
                     }
                 }
             } else {
@@ -568,10 +568,8 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
     }
 
 
-
-
     @Test
-    public void givenRegulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoActivitiesSelectedAndRegulation35SetToYes_thenDoNotDisplayAnError() {
+    public void givenRegulation29FieldIsNotPopulatedAndPointsAreCorrectForRegulation29AndNoActivitiesSelectedAndRegulation35SetToYes_thenDoDisplayAnError() {
 
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
 
@@ -592,7 +590,10 @@ public class EsaWriteFinalDecisionAboutToSubmitHandlerTest extends WriteFinalDec
 
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        Assert.assertEquals(0, response.getErrors().size());
+        Assert.assertEquals(1, response.getErrors().size());
+
+        Assert.assertEquals("You have awarded 15 points or more, specified that the appeal is allowed and specified that Support Group Only Appeal does not apply, but have answered Yes for the Regulation 35 question. Please review your previous selection.", response.getErrors().iterator().next());
+
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-7580

### Change description ###

Scenario 5 stipulates that Regulation 35 is set to no,  but if the user selected yes, the same Scenario was selected and the decision notice displayed, but with incorrect content.

This PR validates that Regulation 35 is set to Yes for Scenario 5 and displays an error message is so. 
Note :  Since creating this PR a new Scenario 12 has been added which covers the case that this validates for - making it a valid scenario but with it's own content.   We may want to merge this first,  and then add Scenario 12 later,  or alternatively wait for Scenario 12 to be implemented - in which case this PR won't be needed

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
