### PR TITLE
CVE-2020-15824 suppression

### DIFF
--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -21,7 +21,7 @@
         <cve>CVE-2016-5394</cve>
         <cve>CVE-2016-6798</cve>
     </suppress>
-    <suppress until="2020-11-30">
+    <suppress until="2021-01-31">
         <notes><![CDATA[
          file name: kotlin-stdlib-common-1.4.0.jar
         ]]></notes>


### PR DESCRIPTION

### JIRA link (if applicable) ###


### Change description ###

CVE-2020-15824 Supressing CVE-2020-15824 until 31 Jan due to suspected false positive

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
