### PR TITLE
CVE-2020-17527 fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,8 +229,8 @@ dependencyManagement {
             entry 'kotlin-stdlib-jdk7'
             entry 'kotlin-reflect'
         }
-	// CVE-2020-13934, CVE-2020-13935
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.39') {
+	// CVE-2020-13934, CVE-2020-13935, CVE-2020-17527, CVE-2020-17527
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.40') {
           entry 'tomcat-embed-core'
           entry 'tomcat-embed-el'
           entry 'tomcat-embed-websocket'
@@ -275,10 +275,10 @@ dependencies {
 
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
 
-    // Added to fix CVE-2020-13934, CVE-2020-13935
-    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.39'
-    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.39'
-    compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.39'
+    // Added to fix CVE-2020-13934, CVE-2020-13935, CVE-2020-17527
+    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.40'
+    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
+    compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.40'
 
     // Safe to remove once Spring update their dependencies - see CVE-2019-14439 and add 'com.fasterxml.jackson.core' configurations.all above
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.3'
@@ -314,10 +314,10 @@ dependencies {
     testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '2.21.0'
     testCompile group: 'io.github.artsok', name: 'rerunner-jupiter', version: '2.1.6'
 
-    // Added to fix CVE-2020-13934, CVE-2020-13935
-    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.39'
-    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.39'
-    testCompile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.39'
+    // Added to fix CVE-2020-13934, CVE-2020-13935, CVE-2020-17527
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.40'
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
+    testCompile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.40'
 
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'
 


### PR DESCRIPTION

### JIRA link (if applicable) ###


### Change description ###

Fix for CVE-2020-17527-fix -  upgrade tomcat to 9.0.40

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
