### PR TITLE
Sscs 8466 non wca lwca existing points bugfix2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,8 +229,8 @@ dependencyManagement {
             entry 'kotlin-stdlib-jdk7'
             entry 'kotlin-reflect'
         }
-	// CVE-2020-13934, CVE-2020-13935
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.39') {
+	// CVE-2020-13934, CVE-2020-13935, CVE-2020-17527
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.40') {
           entry 'tomcat-embed-core'
           entry 'tomcat-embed-el'
           entry 'tomcat-embed-websocket'
@@ -275,10 +275,10 @@ dependencies {
 
     compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '3.1.2'
 
-    // Added to fix CVE-2020-13934, CVE-2020-13935
-    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.39'
-    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.39'
-    compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.39'
+    // Added to fix CVE-2020-13934, CVE-2020-13935, CVE-2020-17527
+    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.40'
+    compile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
+    compile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.40'
 
     // Safe to remove once Spring update their dependencies - see CVE-2019-14439 and add 'com.fasterxml.jackson.core' configurations.all above
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.11.3'
@@ -314,10 +314,10 @@ dependencies {
     testCompile group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '2.21.0'
     testCompile group: 'io.github.artsok', name: 'rerunner-jupiter', version: '2.1.6'
 
-    // Added to fix CVE-2020-13934, CVE-2020-13935
-    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.39'
-    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.39'
-    testCompile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.39'
+    // Added to fix CVE-2020-13934, CVE-2020-13935, CVE-2020-17527
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.40'
+    testCompile group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.40'
+    testCompile group: 'org.apache.tomcat', name: 'tomcat-annotations-api', version: '9.0.40'
 
     testCompile 'pl.pragmatists:JUnitParams:1.1.1'
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
@@ -204,6 +204,70 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
     }
 
     @Test
+    public void callToMidEventPreviewFinalDecisionCallback_willPreviewTheDocumentForEsaNonWCA_WhenPreviousQuestionsAnsweredAndOver15Points() throws Exception {
+        setup();
+        setJsonAndReplace("callback/writeFinalDecisionDescriptorESANonWCA.json", "START_DATE_PLACEHOLDER", "2018-10-10");
+
+        String documentUrl = "document.url";
+        when(generateFile.assemble(any())).thenReturn(documentUrl);
+
+        when(userDetails.getFullName()).thenReturn("Judge Full Name");
+
+        when(idamClient.getUserDetails("Bearer userToken")).thenReturn(userDetails);
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdMidEventPreviewFinalDecision"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertEquals(documentUrl, result.getData().getWriteFinalDecisionPreviewDocument().getDocumentUrl());
+
+        ArgumentCaptor<GenerateFileParams> capture = ArgumentCaptor.forClass(GenerateFileParams.class);
+        verify(generateFile).assemble(capture.capture());
+        final NoticeIssuedTemplateBody parentPayload = (NoticeIssuedTemplateBody) capture.getValue().getFormPayload();
+        final WriteFinalDecisionTemplateBody payload = parentPayload.getWriteFinalDecisionTemplateBody();
+
+        assertEquals("An Test", parentPayload.getAppellantFullName());
+        assertEquals("12345656789", parentPayload.getCaseId());
+        assertEquals("JT 12 34 56 D", parentPayload.getNino());
+        assertEquals("DRAFT DECISION NOTICE", parentPayload.getNoticeType());
+        assertEquals("Judge Full Name", parentPayload.getUserName());
+        assertEquals(LocalDate.parse("2017-07-17"), payload.getHeldOn());
+        assertEquals("Chester Magistrate's Court", payload.getHeldAt());
+        assertEquals("Judge Full Name, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
+        assertEquals(true, payload.isAllowed());
+        assertEquals(true, payload.isSetAside());
+        assertEquals("2018-09-01", payload.getDateOfDecision());
+        assertEquals("An Test",payload.getAppellantName());
+        assertEquals("2018-10-10",payload.getStartDate());
+        assertEquals("2018-11-10",payload.getEndDate());
+        assertEquals(false, payload.isIndefinite());
+        assertEquals(false, payload.isEsaIsEntited());
+        assertNull(payload.getEsaAwardRate());
+        Assert.assertNull(payload.getEsaSchedule2Descriptors());
+        Assert.assertNull(payload.getEsaNumberOfPoints());
+        assertNotNull(payload.getReasonsForDecision());
+        assertEquals(1, payload.getReasonsForDecision().size());
+        Assert.assertEquals("My reasons for decision", payload.getReasonsForDecision().get(0));
+        assertEquals("Something else.", payload.getAnythingElse());
+        assertNotNull(parentPayload.getWriteFinalDecisionTemplateContent());
+        assertNotNull(parentPayload.getWriteFinalDecisionTemplateContent());
+        assertEquals("The appeal is allowed.\n"
+            + "\n"
+            + "The decision made by the Secretary of State on 01/09/2018 is set aside.\n"
+            + "\n"
+            + "This is my summary.\n"
+            + "\n"
+            + "My reasons for decision\n"
+            + "\n"
+            + "Something else.\n"
+            + "\n"
+            + "This has been an oral (face to face) hearing. An Test attended the hearing today and the Tribunal considered the appeal bundle to page A1. A Presenting Officer attended on behalf of the Respondent.\n"
+            + "\n", parentPayload.getWriteFinalDecisionTemplateContent().toString());
+    }
+
+    @Test
     public void callToMidEventPreviewFinalDecisionCallback_willPreviewTheDocumentForUc() throws Exception {
         setup();
         setJsonAndReplace("callback/writeFinalDecisionDescriptorUC.json", "START_DATE_PLACEHOLDER", "2018-10-10");
@@ -271,6 +335,69 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
             + "\n"
             + "\n"
             + "An Test does not have limited capability for work-related activity because no descriptor from Schedule 7 of the UC Regulations 2013 applied. Schedule 9, paragraph 4 did not apply.\n"
+            + "\n"
+            + "My reasons for decision\n"
+            + "\n"
+            + "Something else.\n"
+            + "\n"
+            + "This has been an oral (face to face) hearing. An Test attended the hearing today and the Tribunal considered the appeal bundle to page A1. A Presenting Officer attended on behalf of the Respondent.\n"
+            + "\n", parentPayload.getWriteFinalDecisionTemplateContent().toString());
+    }
+
+    @Test
+    public void callToMidEventPreviewFinalDecisionCallback_willPreviewTheDocumentForUc_WhenNonLcwa_WhenQuestionsPreviouslyAnsweredAndOver15Points() throws Exception {
+        setup();
+        setJsonAndReplace("callback/writeFinalDecisionDescriptorUCNonLcwa.json", "START_DATE_PLACEHOLDER", "2018-10-10");
+
+        String documentUrl = "document.url";
+        when(generateFile.assemble(any())).thenReturn(documentUrl);
+
+        when(userDetails.getFullName()).thenReturn("Judge Full Name");
+
+        when(idamClient.getUserDetails("Bearer userToken")).thenReturn(userDetails);
+
+        MockHttpServletResponse response = getResponse(getRequestWithAuthHeader(json, "/ccdMidEventPreviewFinalDecision"));
+        assertHttpStatus(response, HttpStatus.OK);
+        PreSubmitCallbackResponse<SscsCaseData> result = deserialize(response.getContentAsString());
+
+        assertEquals(Collections.EMPTY_SET, result.getErrors());
+
+        assertEquals(documentUrl, result.getData().getWriteFinalDecisionPreviewDocument().getDocumentUrl());
+
+        ArgumentCaptor<GenerateFileParams> capture = ArgumentCaptor.forClass(GenerateFileParams.class);
+        verify(generateFile).assemble(capture.capture());
+        final NoticeIssuedTemplateBody parentPayload = (NoticeIssuedTemplateBody) capture.getValue().getFormPayload();
+        final WriteFinalDecisionTemplateBody payload = parentPayload.getWriteFinalDecisionTemplateBody();
+
+        assertEquals("An Test", parentPayload.getAppellantFullName());
+        assertEquals("12345656789", parentPayload.getCaseId());
+        assertEquals("JT 12 34 56 D", parentPayload.getNino());
+        assertEquals("DRAFT DECISION NOTICE", parentPayload.getNoticeType());
+        assertEquals("Judge Full Name", parentPayload.getUserName());
+        assertEquals(LocalDate.parse("2017-07-17"), payload.getHeldOn());
+        assertEquals("Chester Magistrate's Court", payload.getHeldAt());
+        assertEquals("Judge Full Name, Panel Member 1 and Panel Member 2", payload.getHeldBefore());
+        assertEquals(true, payload.isAllowed());
+        assertEquals(true, payload.isSetAside());
+        assertEquals("2018-09-01", payload.getDateOfDecision());
+        assertEquals("An Test",payload.getAppellantName());
+        assertEquals("2018-10-10",payload.getStartDate());
+        assertEquals("2018-11-10",payload.getEndDate());
+        assertEquals(false, payload.isIndefinite());
+        assertEquals(false, payload.isUcIsEntited());
+        assertNull(payload.getUcAwardRate());
+        Assert.assertNull(payload.getUcSchedule6Descriptors());
+        Assert.assertNull(payload.getUcNumberOfPoints());
+        assertNotNull(payload.getReasonsForDecision());
+        assertEquals(1, payload.getReasonsForDecision().size());
+        Assert.assertEquals("My reasons for decision", payload.getReasonsForDecision().get(0));
+        assertEquals("Something else.", payload.getAnythingElse());
+        assertNotNull(parentPayload.getWriteFinalDecisionTemplateContent());
+        assertEquals("The appeal is allowed.\n"
+            + "\n"
+            + "The decision made by the Secretary of State on 01/09/2018 is set aside.\n"
+            + "\n"
+            + "This is my summary.\n"
             + "\n"
             + "My reasons for decision\n"
             + "\n"

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/callback/WriteFinalDecisionIt.java
@@ -204,7 +204,7 @@ public class WriteFinalDecisionIt extends AbstractEventIt {
     }
 
     @Test
-    public void callToMidEventPreviewFinalDecisionCallback_willPreviewTheDocumentForEsaNonWCA_WhenPreviousQuestionsAnsweredAndOver15Points() throws Exception {
+    public void callToMidEventPreviewFinalDecisionCallback_willPreviewTheDocumentForEsaNonWca_WhenPreviousQuestionsAnsweredAndOver15Points() throws Exception {
         setup();
         setJsonAndReplace("callback/writeFinalDecisionDescriptorESANonWCA.json", "START_DATE_PLACEHOLDER", "2018-10-10");
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/EsaDecisionNoticeOutcomeService.java
@@ -72,6 +72,8 @@ public class EsaDecisionNoticeOutcomeService extends DecisionNoticeOutcomeServic
                 esaCaseData.setDoesRegulation29Apply(null);
                 sscsCaseData.setSupportGroupOnlyAppeal(null);
                 sscsCaseData.setDwpReassessTheAward(null);
+                sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionPhysicalDisabilitiesQuestion(null);
+                sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionMentalAssessmentQuestion(null);
                 sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesApply(null);
                 sscsCaseData.getSscsEsaCaseData().setEsaWriteFinalDecisionSchedule3ActivitiesQuestion(null);
             }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/UcDecisionNoticeOutcomeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/UcDecisionNoticeOutcomeService.java
@@ -72,6 +72,8 @@ public class UcDecisionNoticeOutcomeService extends DecisionNoticeOutcomeService
                 ucCaseData.setDoesSchedule8Paragraph4Apply(null);
                 sscsCaseData.setSupportGroupOnlyAppeal(null);
                 sscsCaseData.setDwpReassessTheAward(null);
+                sscsCaseData.getSscsUcCaseData().setUcWriteFinalDecisionPhysicalDisabilitiesQuestion(null);
+                sscsCaseData.getSscsUcCaseData().setUcWriteFinalDecisionMentalAssessmentQuestion(null);
                 sscsCaseData.getSscsUcCaseData().setUcWriteFinalDecisionSchedule7ActivitiesApply(null);
                 sscsCaseData.getSscsUcCaseData().setUcWriteFinalDecisionSchedule7ActivitiesQuestion(null);
             }

--- a/src/test/resources/callback/writeFinalDecisionDescriptorESANonWCA.json
+++ b/src/test/resources/callback/writeFinalDecisionDescriptorESANonWCA.json
@@ -1,0 +1,1472 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "wcaAppeal" : "No",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "supportGroupOnlyAppeal" : "No",
+      "writeFinalDecisionDetailsOfDecision" : "This is my summary.",
+      "writeFinalDecisionAllowedOrRefused" : "allowed",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "esaWriteFinalDecisionPhysicalDisabilitiesQuestion" : ["mobilisingUnaided", "standingAndSitting"],
+      "esaWriteFinalDecisionMobilisingUnaidedQuestion" : "mobilisingUnaided1a",
+      "esaWriteFinalDecisionStandingAndSittingQuestion" : "standingAndSitting2b",
+      "esaWriteFinalDecisionSchedule3ActivitiesApply" : "No",
+      "doesRegulation35Apply" : "No",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "writeFinalDecisionPresentingOfficerAttendedQuestion": "Yes",
+      "writeFinalDecisionAppellantAttendedQuestion": "Yes",
+      "writeFinalDecisionPageSectionReference": "A1",
+      "writeFinalDecisionTypeOfHearing": "faceToFace",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "wcaAppeal" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "wcaAppeal" : "Yes",
+      "supportGroupOnlyAppeal" : "No",
+      "writeFinalDecisionAllowedOrRefused" : "allowed",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "esaWriteFinalDecisionPhysicalDisabilitiesQuestion" : ["mobilisingUnaided"],
+      "esaWriteFinalDecisionMobilisingUnaidedQuestion" : "mobilisingUnaided1a",
+      "esaWriteFinalDecisionSchedule3ActivitiesApply" : "No",
+      "doesRegulation35Apply" : "No",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "ESA",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "writeFinalDecision"
+}

--- a/src/test/resources/callback/writeFinalDecisionDescriptorUCNonLcwa.json
+++ b/src/test/resources/callback/writeFinalDecisionDescriptorUCNonLcwa.json
@@ -1,0 +1,1472 @@
+{
+  "case_details": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "dormantAppealState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "lcwaAppeal" : "No",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "supportGroupOnlyAppeal" : "No",
+      "writeFinalDecisionDetailsOfDecision" : "This is my summary.",
+      "writeFinalDecisionAllowedOrRefused" : "allowed",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "ucWriteFinalDecisionPhysicalDisabilitiesQuestion" : ["mobilisingUnaided", "standingAndSitting"],
+      "ucWriteFinalDecisionMobilisingUnaidedQuestion" : "mobilisingUnaided1a",
+      "ucWriteFinalDecisionStandingAndSittingQuestion" : "standingAndSitting2b",
+      "ucWriteFinalDecisionSchedule7ActivitiesApply" : "No",
+      "doesSchedule9Paragraph4Apply" : "No",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "writeFinalDecisionPresentingOfficerAttendedQuestion": "Yes",
+      "writeFinalDecisionAppellantAttendedQuestion": "Yes",
+      "writeFinalDecisionPageSectionReference": "A1",
+      "writeFinalDecisionTypeOfHearing": "faceToFace",
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "UC",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "case_details_before": {
+    "id": 12345656789,
+    "jurisdiction": "SSCS",
+    "state": "interlocutoryReviewState",
+    "case_type_id": "Benefit",
+    "created_date": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "last_modified": [
+      2018,
+      10,
+      23,
+      15,
+      4,
+      48,
+      187000000
+    ],
+    "security_classification": "PUBLIC",
+    "case_data": {
+      "wcaAppeal" : "Yes",
+      "writeFinalDecisionGenerateNotice": "Yes",
+      "wcaAppeal" : "Yes",
+      "supportGroupOnlyAppeal" : "No",
+      "writeFinalDecisionAllowedOrRefused" : "allowed",
+      "writeFinalDecisionDisabilityQualifiedPanelMemberName": "Panel Member 1",
+      "writeFinalDecisionMedicallyQualifiedPanelMemberName": "Panel Member 2",
+      "ucWriteFinalDecisionPhysicalDisabilitiesQuestion" : ["mobilisingUnaided"],
+      "ucWriteFinalDecisionMobilisingUnaidedQuestion" : "mobilisingUnaided1a",
+      "ucWriteFinalDecisionSchedule7ActivitiesApply" : "No",
+      "doesSchedule9Paragraph4Apply" : "No",
+      "writeFinalDecisionDateOfDecision" : "2018-09-01",
+      "writeFinalDecisionStartDate": "START_DATE_PLACEHOLDER",
+      "writeFinalDecisionEndDate": "2018-11-10",
+      "writeFinalDecisionReasons" : [{"id" : null, "value" : "My reasons for decision"}],
+      "writeFinalDecisionAnythingElse" : "Something else.",
+      "writeFinalDecisionPreviewDocument": {
+        "document_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c",
+        "document_binary_url": "http://dm-store:5005/documents/7539160a-b124-4539-b7c1-f3dcfbcea94c/binary",
+        "document_filename": "decisionIssued.pdf"
+      },
+      "dwpTimeExtension": [
+      ],
+      "generatedNino": "JT 12 34 56 D",
+      "hearings": [
+        {
+          "value": {
+            "venue": {
+              "name": "Chester Magistrate's Court",
+              "address": {
+                "line1": "Chester Magistrate's Court",
+                "line2": "Grosvenor Street",
+                "town": "Chester",
+                "postcode": "CH1 2XA"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/Chester+Magistrate%27s+Court+Grosvenor+Street+Chester+Cheshire+CH1+2XA/@53.187454,-2.893632"
+            },
+            "hearingDate": "2017-07-17",
+            "time": "23:00"
+          }
+        },
+        {
+          "value": {
+            "venue": {
+              "name": "Prudential House",
+              "address": {
+                "line1": "36 Dale Street",
+                "line2": "",
+                "town": "Liverpool",
+                "postcode": "L2 5UZ"
+              },
+              "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+            },
+            "hearingDate": "2017-07-12",
+            "time": "23:00",
+            "eventDate": "2017-06-24T18:11:34.013"
+          }
+        }
+      ],
+      "subscriptions": {
+        "appellantSubscription": {
+          "wantSmsNotifications": "Yes",
+          "tya": "NpmhpYaFLa",
+          "email": "sscstest+notify@greencroftconsulting.com",
+          "mobile": "07398785050",
+          "subscribeEmail": "Yes",
+          "subscribeSms": "Yes",
+          "reason": ""
+        },
+        "representativeSubscription": {
+          "email": "",
+          "mobile": "",
+          "subscribeEmail": "No",
+          "subscribeSms": "No",
+          "tya": ""
+        }
+      },
+      "sscsDocument": [
+        {
+          "value": {
+            "documentType": "appellantEvidence",
+            "documentFileName": "11111.pdf",
+            "documentDateAdded": "2018-10-10",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.bbc.com",
+              "document_binary_url": "http://www.bbc.com/binary",
+              "document_filename": "myfile1.jpg"
+            }
+          }
+        },
+        {
+          "value": {
+            "documentType": "representativeEvidence",
+            "documentFileName": "22222.pdf",
+            "documentDateAdded": "2018-10-11",
+            "evidenceIssued": "Yes",
+            "documentLink": {
+              "document_url": "http://www.itv.com",
+              "document_binary_url": "http://www.itv.com/binary",
+              "document_filename": "myfile2.jpg"
+            }
+          }
+        }
+      ],
+      "reissueFurtherEvidenceDocument": {},
+      "resendToAppellant": "NO",
+      "resendToRepresentative": "NO",
+      "resendToDwp": "NO",
+      "evidence": {
+        "documents": [
+        ]
+      },
+      "caseReference": "SC022/14/12423",
+      "generatedSurname": "Test",
+      "regionalProcessingCenter": {
+        "faxNumber": "0126 434 7983",
+        "address4": "PO Box 14620",
+        "phoneNumber": "0300 123 1142",
+        "name": "BIRMINGHAM",
+        "address1": "HM Courts & Tribunals Service",
+        "address2": "Social Security & Child Support Appeals",
+        "address3": "Administrative Support Centre",
+        "postcode": "B16 6FR",
+        "city": "BIRMINGHAM"
+      },
+      "appeal": {
+        "mrnDetails": {},
+        "appellant": {
+          "name": {
+            "title": "Miss",
+            "firstName": "AN",
+            "lastName": "Test"
+          },
+          "address": {
+            "line1": "2 Drake Close",
+            "line2": "Hutton",
+            "town": "Brentwood",
+            "county": "Essex",
+            "postcode": "CM13 1AQ"
+          },
+          "contact": {
+            "email": null,
+            "phone": "01424 752419",
+            "mobile": null
+          },
+          "identity": {
+            "dob": "1900-01-01",
+            "nino": "JT 12 34 56 D"
+          },
+          "appointee": null,
+          "isAddressSameAsAppointee": null
+        },
+        "benefitType": {
+          "code": "UC",
+          "description": "Employment Support Allowance"
+        },
+        "receivedVia": "PAPER",
+        "hearingOptions": {
+          "wantsToAttend": "No",
+          "other": "No"
+        },
+        "appealReasons": {
+        },
+        "rep": {
+          "hasRepresentative": "Yes",
+          "name": {
+            "title": "Mr",
+            "firstName": "Harry",
+            "lastName": "Potter"
+          },
+          "address": {
+            "line1": "123 Hairy Lane",
+            "line2": "Off Hairy Park",
+            "town": "Town",
+            "county": "County",
+            "postcode": "TS3 3ST"
+          },
+          "contact": {
+            "email": "harry.potter@wizards.com",
+            "mobile": "07411999999"
+          },
+          "organisation": "HP Ltd"
+        },
+        "signer": null,
+        "hearingType": "paper"
+      },
+      "region": "BIRMINGHAM",
+      "generatedDOB": "1900-01-01",
+      "evidencePresent": "No",
+      "events": [
+        {
+          "value": {
+            "date": "2018-07-05T14:38:26.443",
+            "type": "appealDormant",
+            "description": "Appeal dormant"
+          },
+          "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+        },
+        {
+          "value": {
+            "date": "2018-05-09T11:16:01.867",
+            "type": "responseReceived",
+            "description": "Response received"
+          },
+          "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+        },
+        {
+          "value": {
+            "date": "2018-02-09T14:38:26.443",
+            "type": "hearingBooked",
+            "description": "Hearing booked"
+          },
+          "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+        },
+        {
+          "value": {
+            "date": "2017-10-06T09:38:25.190",
+            "type": "appealReceived",
+            "description": "Appeal received"
+          },
+          "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+        }
+      ],
+      "originalSender": {},
+      "furtherEvidenceAction": {}
+    },
+    "data_classification": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    },
+    "after_submit_callback_response": null,
+    "callback_response_status_code": null,
+    "callback_response_status": null,
+    "delete_draft_response_status_code": null,
+    "delete_draft_response_status": null,
+    "security_classifications": {
+      "dwpTimeExtension": {
+        "classification": "PUBLIC",
+        "value": [
+        ]
+      },
+      "generatedNino": "PUBLIC",
+      "hearings": [
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        },
+        {
+          "classification": "PUBLIC",
+          "value": [
+            {
+              "value": {
+                "venue": {
+                  "classification": "PUBLIC",
+                  "value": {
+                    "name": "PUBLIC",
+                    "address": {
+                      "classification": "PUBLIC",
+                      "value": {
+                        "line1": "PUBLIC",
+                        "line2": "PUBLIC",
+                        "town": "PUBLIC",
+                        "county": "PUBLIC",
+                        "postcode": "PUBLIC"
+                      }
+                    },
+                    "googleMapLink": "PUBLIC"
+                  }
+                },
+                "hearingDate": "PUBLIC",
+                "time": "PUBLIC",
+                "adjourned": "PUBLIC",
+                "eventDate": "PUBLIC",
+                "hearingId": "PUBLIC"
+              },
+              "id": "491adfdc-a8d3-430d-bd47-5ae3eac2149f"
+            }
+          ]
+        }
+      ],
+      "subscriptions": {
+        "classification": "PUBLIC",
+        "value": {
+          "appellantSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          },
+          "representativeSubscription": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantSmsNotifications": "PUBLIC",
+              "tya": "PUBLIC",
+              "email": "PUBLIC",
+              "mobile": "PUBLIC",
+              "subscribeEmail": "PUBLIC",
+              "subscribeSms": "PUBLIC",
+              "reason": "PUBLIC"
+            }
+          }
+        }
+      },
+      "evidence": {
+        "classification": "PUBLIC",
+        "value": {
+          "documents": {
+            "classification": "PUBLIC",
+            "value": [
+            ]
+          }
+        }
+      },
+      "caseReference": "PUBLIC",
+      "generatedSurname": "PUBLIC",
+      "regionalProcessingCenter": {
+        "classification": "PUBLIC",
+        "value": {
+          "faxNumber": "PUBLIC",
+          "address4": "PUBLIC",
+          "phoneNumber": "PUBLIC",
+          "name": "PUBLIC",
+          "address1": "PUBLIC",
+          "address2": "PUBLIC",
+          "address3": "PUBLIC",
+          "postcode": "PUBLIC",
+          "city": "PUBLIC"
+        }
+      },
+      "appeal": {
+        "classification": "PUBLIC",
+        "value": {
+          "mrnDetails": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "appellant": {
+            "classification": "PUBLIC",
+            "value": {
+              "name": {
+                "classification": "PUBLIC",
+                "value": {
+                  "title": "PUBLIC",
+                  "firstName": "PUBLIC",
+                  "lastName": "PUBLIC"
+                }
+              },
+              "address": {
+                "classification": "PUBLIC",
+                "value": {
+                }
+              },
+              "contact": {
+                "classification": "PUBLIC",
+                "value": {
+                  "email": "PUBLIC",
+                  "phone": "PUBLIC",
+                  "mobile": "PUBLIC"
+                }
+              },
+              "identity": {
+                "classification": "PUBLIC",
+                "value": {
+                  "dob": "PUBLIC",
+                  "nino": "PUBLIC"
+                }
+              },
+              "isAppointee": "PUBLIC"
+            }
+          },
+          "benefitType": {
+            "classification": "PUBLIC",
+            "value": {
+              "code": "PUBLIC"
+            }
+          },
+          "hearingOptions": {
+            "classification": "PUBLIC",
+            "value": {
+              "wantsToAttend": "PUBLIC",
+              "other": "PUBLIC"
+            }
+          },
+          "appealReasons": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "rep": {
+            "classification": "PUBLIC",
+            "value": {
+            }
+          },
+          "signer": "PUBLIC",
+          "hearingType": "PUBLIC"
+        }
+      },
+      "region": "PUBLIC",
+      "generatedDOB": "PUBLIC",
+      "events": {
+        "classification": "PUBLIC",
+        "value": [
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "324a9f42-b9a0-428d-ae22-24fa606a46cc"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "2b863cb1-5b99-4ac1-8b4c-f0b9c71f1fd8"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "b8c61d93-1e82-44c9-bfff-55339f829a0e"
+          },
+          {
+            "value": {
+              "date": "PUBLIC",
+              "type": "PUBLIC",
+              "description": "PUBLIC"
+            },
+            "id": "29a280db-7937-49db-ae7c-84c62581e3a2"
+          }
+        ]
+      }
+    }
+  },
+  "event_id": "writeFinalDecision"
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-8466

### Change description ###

* Fixing bug where if non wca/lcwa route is selected,  but points-questions have previously been answered before selecting the non-wca/lcwa route and the points >=15,  the DN couldn't be previewed.   This was because the points were retained despite switching the route,  and no matching wca/lwca condition was found.
* Resolved this by clearing the points-questions before preview if non-wca/lcwa route 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
