### PR TITLE
Upgrade org.codehaus.groovy for CVE-2020-17521

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -245,6 +245,13 @@ dependencyManagement {
             entry 'cxf-rt-transports-http'
         }
 
+        // CVE-2020-17521
+        dependencySet(group: 'org.codehaus.groovy', version: '2.5.14') {
+            entry 'groovy'
+            entry 'groovy-json'
+            entry 'groovy-xml'
+        }
+
         imports {
             mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
         }


### PR DESCRIPTION
Upgrade org.codehaus.groovy for CVE-2020-17521