### PR TITLE
Ignore git properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ bin/
 
 # VS Code
 .vscode/
+
+# Auto-generated file at compile time, used to display git version on health endpoint
+/src/main/resources/uk/gov/hmcts/reform/sscs/git.properties


### PR DESCRIPTION
Ignore git.properties file

The git.properties file will get auto generated when we compile the tribunal-api
It adds extra information to display git version on health endpoint

