### PR TITLE
SSCS-8794 - SSCS1 Pdf letter for welsh date appeal submitted

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/SscsPdfService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/SscsPdfService.java
@@ -91,7 +91,7 @@ public class SscsPdfService {
                 }
                 placeholders.put("welsh_exclude_dates", welshExcludesDates);
             }
-            placeholders.put("welshCurtrentDate", LocalDateToWelshStringConverter.convert(LocalDate.now()));
+            placeholders.put("welshCurrentDate", LocalDateToWelshStringConverter.convert(sscsCaseData.getCaseCreated()));
             String benefitType;
             benefitType = welshBenefitTypeTranslator.translate(sscsCaseData);
             placeholders.put("welshBenefitType", benefitType);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsPdfServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/SscsPdfServiceTest.java
@@ -57,6 +57,7 @@ public class SscsPdfServiceTest {
         given(welshBenefitTranslator.translate(caseData)).willReturn("Taliad Annibyniaeth Personol (PIP)");
         caseData.setLanguagePreferenceWelsh("Yes");
         caseData.getAppeal().getAppellant().getIdentity().setDob("2000-12-31");
+        caseData.setCaseCreated("2020-12-31");
         service.generatePdf(caseData, 1L, "appellantEvidence", "fileName");
 
         ArgumentCaptor<Map> argumentCaptor = ArgumentCaptor.forClass(Map.class);
@@ -71,6 +72,7 @@ public class SscsPdfServiceTest {
         assertEquals("31 Rhagfyr 2000",argumentCaptor.getValue().get("appellant_appointee_identity_dob"));
         assertEquals("31 Rhagfyr 2000",argumentCaptor.getValue().get("appellant_identity_dob"));
         assertEquals("29 Mehefin 2018",argumentCaptor.getValue().get("date_of_decision"));
+        assertEquals("31 Rhagfyr 2020",argumentCaptor.getValue().get("welshCurrentDate"));
         assertEquals("Taliad Annibyniaeth Personol (PIP)",argumentCaptor.getValue().get("welshBenefitType"));
         assertEquals("nac ydw",argumentCaptor.getValue().get("welshEvidencePresent"));
         assertEquals("ydw",argumentCaptor.getValue().get("welshWantsToAttend"));


### PR DESCRIPTION
SSCS-8794 - Welsh cases - "Date appeal submitted" field is not populated with date value in generated SSCS1 Pdf letter

The appeal date submitted now appears in the SSCS1 Pdf

<img width="302" alt="Screenshot 2021-03-19 at 13 57 31" src="https://user-images.githubusercontent.com/369407/111791445-1bb46080-88bb-11eb-975f-dd3fb051c47a.png">
