### PR TITLE
SSCS-9294 - Enable Pact tests on path to live

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,4 +1,6 @@
 #!groovy
+import uk.gov.hmcts.contino.AppPipelineDsl
+
 properties([
         [$class: 'GithubProjectProperty', projectUrlStr: 'https://github.com/hmcts/tribunals-case-api'],
         pipelineTriggers([[$class: 'GitHubPushTrigger']])

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -51,12 +51,12 @@ withPipeline(type, product, component) {
     enableSlackNotifications('#sscs-tech')
     enableAksStagingDeployment()
     disableLegacyDeployment()
-}
 
-onPR() {
-    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
-}
+    onPR() {
+        enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    }
 
-onMaster() {
-    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    onMaster() {
+        enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    }
 }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -28,6 +28,9 @@ def secrets = [
     ]
 ]
 
+// Vars for Kubernetes
+env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
+
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [ $class: 'AzureKeyVaultSecret',
     secretType: 'Secret',
@@ -48,3 +51,10 @@ withPipeline(type, product, component) {
     disableLegacyDeployment()
 }
 
+onPR() {
+    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+}
+
+onMaster() {
+    enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+}

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -30,9 +30,6 @@ def secrets = [
     ]
 ]
 
-// Vars for Kubernetes
-env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
-
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   [ $class: 'AzureKeyVaultSecret',
     secretType: 'Secret',
@@ -41,6 +38,9 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
     envVariable: envVar
   ]
 }
+
+// Vars for Kubernetes
+env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
 
 withPipeline(type, product, component) {
     after('akschartsinstall'){

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -52,10 +52,6 @@ withPipeline(type, product, component) {
     enableAksStagingDeployment()
     disableLegacyDeployment()
 
-    onPR() {
-        enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
-    }
-
     onMaster() {
         enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -52,6 +52,10 @@ withPipeline(type, product, component) {
     enableAksStagingDeployment()
     disableLegacyDeployment()
 
+    onPR() {
+        enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
+    }
+
     onMaster() {
         enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     }

--- a/build.gradle
+++ b/build.gradle
@@ -397,7 +397,7 @@ project.ext {
 pact {
     publish {
         pactDirectory = 'target/pacts'
-        pactBrokerUrl = System.getenv("PACT_BROKER_FULL_URL") ?: 'http://dm-store-aat.service.core-compute-aat.internal'
+        pactBrokerUrl = System.getenv("PACT_BROKER_FULL_URL") ?: 'http://localhost:80'
         tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
         version = project.pactVersion
     }

--- a/build.gradle
+++ b/build.gradle
@@ -396,12 +396,28 @@ project.ext {
 
 pact {
     publish {
-        pactDirectory = 'target/pacts'
+        pactDirectory = 'pacts'
         pactBrokerUrl = System.getenv("PACT_BROKER_FULL_URL") ?: 'http://localhost:80'
         tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
         version = project.pactVersion
     }
 }
+
+task contractTest(type: Test) {
+    description = "Runs the consumer Pact tests"
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.contractTest.output.classesDirs
+    classpath = sourceSets.contractTest.runtimeClasspath
+}
+
+task runAndPublishConsumerPactTests(type: Test) {
+    logger.lifecycle("Runs pact Tests")
+    testClassesDirs = sourceSets.contractTest.output.classesDirs
+    classpath = sourceSets.contractTest.runtimeClasspath
+}
+
+runAndPublishConsumerPactTests.dependsOn contractTest
+runAndPublishConsumerPactTests.finalizedBy pactPublish
 
 static def getCheckedOutGitCommitHash() {
     'git rev-parse --verify --short HEAD'.execute().text.trim()
@@ -443,13 +459,6 @@ task smoke(type: Test) {
     setClasspath(sourceSets.e2e.runtimeClasspath)
     include "uk/gov/hmcts/reform/sscs/smoke/**"
     exclude "uk/gov/hmcts/reform/sscs/functional/**"
-}
-
-task contract(type: Test, description: 'Runs the pact contract tests.', group: 'Verification') {
-    description = "Runs the consumer Pact tests"
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.contractTest.output.classesDirs
-    classpath = sourceSets.contractTest.runtimeClasspath
 }
 
 run {

--- a/build.gradle
+++ b/build.gradle
@@ -396,8 +396,8 @@ project.ext {
 
 pact {
     publish {
-        pactDirectory = 'pacts'
-        pactBrokerUrl = System.getenv("PACT_BROKER_FULL_URL") ?: 'http://localhost:80'
+        pactDirectory = 'target/pacts'
+        pactBrokerUrl = System.getenv("PACT_BROKER_FULL_URL") ?: 'http://dm-store-aat.service.core-compute-aat.internal'
         tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
         version = project.pactVersion
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/ccd/CcdConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/ccd/CcdConsumerTest.java
@@ -54,7 +54,7 @@ public class CcdConsumerTest {
         RestAssured.config().encoderConfig(new EncoderConfig("UTF-8", "UTF-8"));
     }
 
-    @Pact(provider = "ccd_api", consumer = "sscs_tribunals_case_api")
+    @Pact(provider = "ccd", consumer = "sscs_tribunals_case_api")
     public RequestResponsePact executeStartCaseForCaseworkerAndGet200(PactDslWithProvider builder) {
 
         Map<String, String> headers = Maps.newHashMap();

--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/idam/IdamConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/idam/IdamConsumerTest.java
@@ -50,7 +50,7 @@ public class IdamConsumerTest {
         RestAssured.config().encoderConfig(new EncoderConfig("UTF-8", "UTF-8"));
     }
 
-    @Pact(provider = "idam_api", consumer = "sscs_tribunals_case_api")
+    @Pact(provider = "Idam_api", consumer = "sscs_tribunals_case_api")
     public RequestResponsePact executeGetIdamAuthCodeAndGet200Response(PactDslWithProvider builder) {
 
         Map<String, String> headers = Maps.newHashMap();

--- a/src/contractTest/java/uk/gov/hmcts/reform/sscs/idam/IdamConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/sscs/idam/IdamConsumerTest.java
@@ -71,7 +71,7 @@ public class IdamConsumerTest {
 
     }
 
-    @Pact(provider = "idam_api", consumer = "sscs_tribunals_case_api")
+    @Pact(provider = "Idam_api", consumer = "sscs_tribunals_case_api")
     public RequestResponsePact executeGetIdamAuthTokenAndGet200(PactDslWithProvider builder) {
 
         Map<String, String> headers = Maps.newHashMap();
@@ -94,7 +94,7 @@ public class IdamConsumerTest {
 
     }
 
-    @Pact(provider = "idam_api", consumer = "sscs_tribunals_case_api")
+    @Pact(provider = "Idam_api", consumer = "sscs_tribunals_case_api")
     public RequestResponsePact executeGetUserDetailsAndGet200(PactDslWithProvider builder) {
 
         Map<String, String> headers = Maps.newHashMap();


### PR DESCRIPTION
SSCS-9294 - Enable Pact tests on path to live

This PR has verified that the pact tests run and are published on a PR commit, since we only want it to be run on a commit to master it has been removed.