### PR TITLE
SSCS-9293 Fix AV bug in upload fe event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/uploaddocuments/UploadDocumentFurtherEvidenceAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/uploaddocuments/UploadDocumentFurtherEvidenceAboutToSubmitHandler.java
@@ -73,7 +73,7 @@ public class UploadDocumentFurtherEvidenceAboutToSubmitHandler implements PreSub
             response.addError("You need to upload PDF documents only");
         } else if (uploadAudioVideoEvidenceEnabled
             && !isFileUploadedAValid(caseData.getDraftSscsFurtherEvidenceDocument())) {
-            response.addError("You need to upload PDF,MP3 or MP4 file only");
+            response.addError("You need to upload PDF, MP3 or MP4 file only");
         }
 
         PdfState pdfState = isPdfReadable(caseData.getDraftSscsFurtherEvidenceDocument());
@@ -132,6 +132,8 @@ public class UploadDocumentFurtherEvidenceAboutToSubmitHandler implements PreSub
                     if (!PdfState.OK.equals(pdfState)) {
                         return pdfState;
                     }
+                } else if (DocumentUtil.isFileAMedia(doc.getValue().getDocumentLink())) {
+                    pdfState = PdfState.OK;
                 }
             }
         }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/uploaddocuments/UploadDocumentFurtherEvidenceAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/uploaddocuments/UploadDocumentFurtherEvidenceAboutToSubmitHandlerTest.java
@@ -106,7 +106,40 @@ public class UploadDocumentFurtherEvidenceAboutToSubmitHandlerTest extends BaseH
     }
 
     @Test
-    public void handleHappyPathWhenAudioVideoFileUploaded() throws IOException {
+    @Parameters({"audio.mp3","video.mp4"})
+    public void handleHappyPathWhenAudioVideoFileUploaded(String fileName) throws IOException {
+        UploadDocumentFurtherEvidenceAboutToSubmitHandler handler = new UploadDocumentFurtherEvidenceAboutToSubmitHandler(false, footerService);
+        Callback<SscsCaseData> callback = buildTestCallbackGivenData(UPLOAD_DOCUMENT_FURTHER_EVIDENCE,
+                "withDwp",
+                "representativeEvidence", "appellantEvidence",
+                UPLOAD_DOCUMENT_FE_CALLBACK_JSON);
+        List<SscsFurtherEvidenceDoc> draftDocuments = Collections.singletonList(SscsFurtherEvidenceDoc.builder()
+                .value(SscsFurtherEvidenceDocDetails.builder()
+                        .documentFileName(fileName)
+                        .documentType("representativeEvidence")
+                        .documentLink(DocumentLink.builder()
+                                .documentUrl("http://dm-store:5005/documents/abe3b75a-7a72-4e68-b136-4349b7d4f655")
+                                .documentFilename(fileName).build())
+                        .build())
+                .build());
+
+        callback.getCaseDetails().getCaseData().setDraftSscsFurtherEvidenceDocument(draftDocuments);
+
+        PreSubmitCallbackResponse<SscsCaseData> actualCaseData = handler.handle(ABOUT_TO_SUBMIT, callback,
+                USER_AUTHORISATION);
+
+        assertEquals(1, actualCaseData.getData().getAudioVideoEvidence().size());
+        assertEquals(fileName, actualCaseData.getData().getAudioVideoEvidence().get(0).getValue().getFileName());
+        assertEquals(UploadParty.CTSC, actualCaseData.getData().getAudioVideoEvidence().get(0).getValue().getPartyUploaded());
+        assertEquals(InterlocReviewState.REVIEW_BY_TCW.getId(), actualCaseData.getData().getInterlocReviewState());
+        assertEquals(REVIEW_AUDIO_VIDEO_EVIDENCE.getId(), actualCaseData.getData().getInterlocReferralReason());
+        assertNull(actualCaseData.getData().getDwpState());
+        assertNull(actualCaseData.getData().getDraftSscsFurtherEvidenceDocument());
+        assertEquals(YesNo.YES, actualCaseData.getData().getHasUnprocessedAudioVideoEvidence());
+    }
+
+    @Test
+    public void handleHappyPathWhenAudioVideoAndPdfFileUploaded() throws IOException {
         Callback<SscsCaseData> callback = buildTestCallbackGivenData(UPLOAD_DOCUMENT_FURTHER_EVIDENCE,"appealCreated",
                 DocumentType.OTHER_EVIDENCE.getId(), DocumentType.APPELLANT_EVIDENCE.getId(), UPLOAD_AUDIO_VIDEO_DOCUMENT_FE_CALLBACK_JSON);
 
@@ -246,7 +279,7 @@ public class UploadDocumentFurtherEvidenceAboutToSubmitHandlerTest extends BaseH
         assertNull(actualResponse.getData().getDwpState());
         assertNull(actualResponse.getData().getDraftSscsFurtherEvidenceDocument());
         long numberOfExpectedError = actualResponse.getErrors().stream()
-                .filter(error -> error.equalsIgnoreCase("You need to upload PDF,MP3 or MP4 file only"))
+                .filter(error -> error.equalsIgnoreCase("You need to upload PDF, MP3 or MP4 file only"))
                 .count();
         assertEquals(1, numberOfExpectedError);
     }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-9293

When only an AV document was uploaded, an error was shown saying 'Your PDF Document is not readable.'. The method to check if the PDF is valid was always returning 'UNKNOWN' status for any mp3 or mp4. The unit test that existed passed because it also had a PDF in the test data, hence a false positive. Have added a test to cover the scenario for when only an mp3 or mp4 is uploaded with no pdf, and updated the code with the fix. 