### PR TITLE
SSCS-9331 - Address fortify backend issues

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/generatecoversheet/GenerateCoversheetAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/generatecoversheet/GenerateCoversheetAboutToStartHandler.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.ccd.presubmit.generatecoversheet;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.springframework.http.MediaType.APPLICATION_PDF;
 
 import java.util.Optional;
@@ -64,7 +65,7 @@ public class GenerateCoversheetAboutToStartHandler implements PreSubmitCallbackH
             uploadResponse = evidenceManagementService.upload(singletonList(file), DM_STORE_USER_ID);
         }
 
-        if (nonNull(uploadResponse) && nonNull(uploadResponse.getEmbedded()) && !uploadResponse.getEmbedded().getDocuments().isEmpty()) {
+        if (nonNull(uploadResponse) && nonNull(uploadResponse.getEmbedded()) && isNotEmpty(uploadResponse.getEmbedded().getDocuments())) {
             String location = uploadResponse.getEmbedded().getDocuments().get(0).links.self.href;
             DocumentLink newDoc = DocumentLink.builder().documentFilename(FILENAME).documentUrl(location).documentBinaryUrl(location + "/binary").build();
             caseData.setPreviewDocument(newDoc);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/evidence/EvidenceUploadService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/evidence/EvidenceUploadService.java
@@ -4,6 +4,7 @@ import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.collections4.ListUtils.union;
+import static org.apache.commons.lang3.StringUtils.endsWithIgnoreCase;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.*;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState.REVIEW_BY_JUDGE;
 import static uk.gov.hmcts.reform.sscs.service.pdf.StoreEvidenceDescriptionService.TEMP_UNIQUE_ID;
@@ -332,7 +333,7 @@ public class EvidenceUploadService {
         while (iterator.hasNext()) {
             SscsDocument document = iterator.next();
             String filename = document.getValue().getDocumentFileName();
-            if (filename != null && (filename.toLowerCase().endsWith("mp3") || filename.toLowerCase().endsWith("mp4"))) {
+            if (filename != null && (endsWithIgnoreCase(filename, "mp3") || endsWithIgnoreCase(filename, "mp4"))) {
                 audioVideoFiles.add(document);
                 iterator.remove();
             }


### PR DESCRIPTION
SSCS-9331 - Address fortify backend issues

https://emea.fortify.com/Releases/53243/Issues?t=-5102

- The method handle() in GenerateCoversheetAboutToStartHandler.java can crash the program by dereferencing a null-pointer on line 67.The program can potentially dereference a null-pointer, thereby causing a null-pointer exception.
- The call to endsWith() on line 335 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.Unexpected portability problems can be found when the locale is not specified.
- The call to endsWith() on line 335 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.Unexpected portability problems can be found when the locale is not specified.
