### PR TITLE
stop creating CCD containers in staging

### DIFF
--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.39
+version: 0.0.40
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team
@@ -36,6 +36,7 @@ dependencies:
   - name: ccd
     version: 5.0.2
     repository: '@hmctspublic'
+    condition: ccd.enabled
     tags:
       - sscs-ccd-idam-pr
   - name: sscs-tribunals-frontend

--- a/charts/sscs-tribunals-api/values.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.preview.template.yaml
@@ -76,6 +76,7 @@ xui-webapp:
           - system-user-password
 
 ccd:
+  enabled: true
   ccd:
     adminWeb:
       enabled: true

--- a/charts/sscs-tribunals-api/values.yaml
+++ b/charts/sscs-tribunals-api/values.yaml
@@ -67,3 +67,5 @@ sscs-tribunals-frontend:
   enabled: false
 redis:
   enabled: false
+ccd:
+  enabled: false


### PR DESCRIPTION
stop creating CCD containers in staging

There is no need to create the ccd staging containers
```
sscs-tribunals-api-staging-ccd-admin-web-5b8b44d98f-zm4kf         0/1     ContainerCreating   0          23m
sscs-tribunals-api-staging-ccd-data-store-api-7fdd6d4bdf-w2hb7    0/1     ContainerCreating   0          23m
sscs-tribunals-api-staging-ccd-definition-store-78c5ccc7-f5q86    0/1     ContainerCreating   0          23m
sscs-tribunals-api-staging-ccd-user-profile-api-68b6fd95679xbpq   0/1     ContainerCreating   0          23m
sscs-tribunals-api-staging-java-7c899d9fd7-bnjcn                  1/1     Running             0          23m
sscs-tribunals-api-staging-postgresql-0                           1/1     Running             0          23m
sscs-tribunals-api-staging-s2s-75df9cf7d9-5978s                   0/1     ContainerCreating   0          23m
```