### PR TITLE
SSCS-9634 - Action further evidence on “Not listable” doesn’t add addition

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandler.java
@@ -27,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -57,10 +58,11 @@ public class ActionFurtherEvidenceAboutToSubmitHandler implements PreSubmitCallb
                     SEND_TO_INTERLOC_REVIEW_BY_JUDGE, SEND_TO_INTERLOC_REVIEW_BY_TCW).stream()
             .map(FurtherEvidenceActionDynamicListItems::getCode)
             .collect(Collectors.toUnmodifiableList());
+    private static final Set<State> ADDITION_VALID_STATES = Set.of(State.DORMANT_APPEAL_STATE, State.RESPONSE_RECEIVED, State.READY_TO_LIST, State.HEARING, State.NOT_LISTABLE, State.WITH_DWP);
 
     private final FooterService footerService;
     private final BundleAdditionFilenameBuilder bundleAdditionFilenameBuilder;
-    private UserDetailsService userDetailsService;
+    private final UserDetailsService userDetailsService;
 
 
     @Autowired
@@ -454,11 +456,7 @@ public class ActionFurtherEvidenceAboutToSubmitHandler implements PreSubmitCallb
     }
 
     private Boolean isCaseStateAdditionValid(State caseState) {
-        return caseState.equals(State.DORMANT_APPEAL_STATE)
-                || caseState.equals(State.RESPONSE_RECEIVED)
-                || caseState.equals(State.READY_TO_LIST)
-                || caseState.equals(State.HEARING)
-                || caseState.equals(State.WITH_DWP);
+        return ADDITION_VALID_STATES.contains(caseState);
     }
 
     private DocumentType getSubtype(String originalSenderCode, ScannedDocument scannedDocument) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/furtherevidence/actionfurtherevidence/ActionFurtherEvidenceAboutToSubmitHandlerTest.java
@@ -778,7 +778,7 @@ public class ActionFurtherEvidenceAboutToSubmitHandlerTest {
     }
 
     @Test
-    @Parameters({"READY_TO_LIST,1", "RESPONSE_RECEIVED,1", "DORMANT_APPEAL_STATE,1", "HEARING,1", "WITH_DWP,1", "VALID_APPEAL,0"})
+    @Parameters({"READY_TO_LIST,1", "RESPONSE_RECEIVED,1", "DORMANT_APPEAL_STATE,1", "HEARING,1", "WITH_DWP,1", "VALID_APPEAL,0", "NOT_LISTABLE,1"})
     public void shouldSetBundleAdditionBasedOnPreviousState(@Nullable State state, int occurrs) {
 
         actionFurtherEvidenceAboutToSubmitHandler = new ActionFurtherEvidenceAboutToSubmitHandler(footerService, bundleAdditionFilenameBuilder, userDetailsService);


### PR DESCRIPTION
SSCS-9634 - Action further evidence on “Not listable” doesn’t add addition