### PR TITLE
SSCS-8366 - Add missing functional test for Bundling service

### DIFF
--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/BaseHandler.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/BaseHandler.java
@@ -13,31 +13,41 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import uk.gov.hmcts.reform.sscs.ccd.callback.DwpDocumentType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.functional.sya.SubmitHelper;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.idam.IdamTokens;
+import uk.gov.hmcts.reform.sscs.service.PdfStoreService;
 
 @Slf4j
 public class BaseHandler {
 
     protected static final String CREATED_BY_FUNCTIONAL_TEST = "created by functional test";
-
+    private static final List<String> DWP_DOCUMENT_TYPES = Arrays.stream(DwpDocumentType.values())
+            .map(DwpDocumentType::getValue)
+            .collect(Collectors.toList());
     @Autowired
     protected CcdService ccdService;
 
     @Autowired
     private IdamService idamService;
+
+    @Autowired
+    SubmitHelper submitHelper;
+
+    @Autowired
+    PdfStoreService pdfStoreService;
 
     protected IdamTokens idamTokens;
 
@@ -49,6 +59,58 @@ public class BaseHandler {
         baseURI = testUrl;
         useRelaxedHTTPSValidation();
         idamTokens = idamService.getIdamTokens();
+    }
+
+    protected SscsCaseDetails addDocumentsToCase(SscsCaseData sscsCaseData, List<UploadDocument> docs) {
+        final List<SscsDocument> sscsDocuments = docs.stream()
+                .flatMap(doc -> pdfStoreService.store(doc.getData(), doc.getFilename(), doc.getDocumentType())
+                        .stream()
+                        .peek(sscsDoc -> sscsDoc.getValue().setBundleAddition(doc.getBundleAddition()))
+                        .peek(sscsDoc -> updateEditedDocument(doc.isHasEditedDocumentLink(), sscsDoc)))
+                .collect(Collectors.toList());
+
+        sscsCaseData.setSscsDocument(sscsDocuments.stream()
+                .filter(doc -> !DWP_DOCUMENT_TYPES.contains(doc.getValue().getDocumentType()))
+                .collect(Collectors.toList()));
+
+        sscsCaseData.setDwpDocuments(sscsDocuments.stream()
+                .filter(doc -> DWP_DOCUMENT_TYPES.contains(doc.getValue().getDocumentType()))
+                .map(this::toDwpDocument)
+                .collect(Collectors.toList()));
+
+        return runEvent(sscsCaseData, EventType.UPDATE_CASE_ONLY);
+    }
+
+    private DwpDocument toDwpDocument(SscsDocument sscsDoc) {
+        return DwpDocument.builder().value(DwpDocumentDetails.builder()
+                .documentLink(sscsDoc.getValue().getDocumentLink())
+                .documentType(sscsDoc.getValue().getDocumentType())
+                .editedDocumentLink(sscsDoc.getValue().getEditedDocumentLink())
+                .bundleAddition(sscsDoc.getValue().getBundleAddition())
+                .documentDateTimeAdded(LocalDateTime.now())
+                .shouldBundleIncludeDocLink(YesNo.YES)
+                .build()).build();
+    }
+
+    private void updateEditedDocument(boolean hasEditedDocumentLink, SscsDocument doc) {
+        if (hasEditedDocumentLink) {
+            doc.getValue().setEditedDocumentLink(doc.getValue().getDocumentLink());
+        }
+    }
+
+    public SscsCaseDetails runEvent(final SscsCaseData sscsCaseData, final EventType eventType) {
+        return ccdService.updateCase(sscsCaseData, Long.valueOf(sscsCaseData.getCcdCaseId()), eventType.getCcdType(), CREATED_BY_FUNCTIONAL_TEST, CREATED_BY_FUNCTIONAL_TEST, idamTokens);
+    }
+
+    protected SscsCaseDetails createCase() {
+        final SscsCaseData sscsCaseData = buildSscsCaseDataForTesting("Bowie", submitHelper.getRandomNino());
+        sscsCaseData.getAppeal().getMrnDetails().setMrnDate(submitHelper.getRandomMrnDate().toString());
+        return ccdService.createCase(sscsCaseData,
+                EventType.CREATE_WITH_DWP_TEST_CASE.getCcdType(), CREATED_BY_FUNCTIONAL_TEST, CREATED_BY_FUNCTIONAL_TEST, idamTokens);
+    }
+
+    protected SscsCaseDetails getByCaseId(Long id) {
+        return ccdService.getByCaseId(id, idamTokens);
     }
 
     protected SscsCaseDetails createCaseInResponseReceivedState(int retry) throws Exception {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/PdfHelper.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/PdfHelper.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.sscs.functional.handlers;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+
+public class PdfHelper {
+
+    private PdfHelper() {
+        // noop
+    }
+
+    public static byte[] getPdf(String text) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            try (PDDocument doc = new PDDocument()) {
+                PDPage pdPage = new PDPage();
+                try (PDPageContentStream contentStream = new PDPageContentStream(doc, pdPage)) {
+                    contentStream.beginText();
+                    contentStream.setFont(PDType1Font.TIMES_ROMAN, 12);
+                    contentStream.showText(text);
+                    contentStream.newLineAtOffset(2, 10);
+                    contentStream.endText();
+                }
+                doc.addPage(pdPage);
+                doc.save(baos);
+            }
+            return baos.toByteArray();
+        }
+    }
+}

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/UploadDocument.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/UploadDocument.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.reform.sscs.functional.handlers;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder(toBuilder = true)
+public class UploadDocument {
+    private final byte[] data;
+    private final String filename;
+    private final String documentType;
+    private final String bundleAddition;
+    private final boolean hasEditedDocumentLink;
+}

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
@@ -1,0 +1,124 @@
+package uk.gov.hmcts.reform.sscs.functional.handlers.createbundle;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static uk.gov.hmcts.reform.sscs.functional.handlers.PdfHelper.getPdf;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.sscs.ccd.callback.DocumentType;
+import uk.gov.hmcts.reform.sscs.ccd.callback.DwpDocumentType;
+import uk.gov.hmcts.reform.sscs.ccd.domain.*;
+import uk.gov.hmcts.reform.sscs.functional.handlers.BaseHandler;
+import uk.gov.hmcts.reform.sscs.functional.handlers.UploadDocument;
+
+
+@RunWith(SpringRunner.class)
+@TestPropertySource(locations = "classpath:config/application_e2e.properties")
+@SpringBootTest
+@Slf4j
+public class CreateBundleAboutToSubmitHandlerFunctionalTest extends BaseHandler {
+
+    @Test
+    public void checkEditedDocumentInTheBundleIsCorrect() throws Exception {
+        SscsCaseDetails caseDetails = createCase();
+        List<UploadDocument> docs = List.of(
+                UploadDocument.builder()
+                        .data(getPdf("dwpResponse"))
+                        .filename("dwpResponse.pdf")
+                        .documentType(DwpDocumentType.DWP_RESPONSE.getValue())
+                        .hasEditedDocumentLink(true)
+                        .build(),
+                UploadDocument.builder()
+                        .data(getPdf("dwpEvidenceBundle"))
+                        .filename("dwpEvidenceBundle.pdf")
+                        .documentType(DwpDocumentType.DWP_EVIDENCE_BUNDLE.getValue())
+                        .hasEditedDocumentLink(true)
+                        .build()
+        );
+        caseDetails = addDocumentsToCase(caseDetails.getData(), docs);
+        caseDetails.getData().setPhmeGranted(YesNo.YES);
+
+        runEvent(caseDetails.getData(), EventType.CREATE_BUNDLE);
+
+        verifyAsyncBundleHasTakenPlace(caseDetails);
+        final SscsCaseDetails updatedCaseDetails = getByCaseId(caseDetails.getId());
+        assertThat(updatedCaseDetails.getData().getCaseBundles(), is(notNullValue()));
+        assertThat(updatedCaseDetails.getData().getCaseBundles().size(), is(2));
+        final BundleDetails bundle1 = updatedCaseDetails.getData().getCaseBundles().get(0).getValue();
+        final BundleDetails bundle2 = updatedCaseDetails.getData().getCaseBundles().get(1).getValue();
+        assertThat(bundle1.getTitle(), is("SSCS Bundle Original"));
+        assertThat(bundle2.getTitle(), is("SSCS Bundle Edited"));
+        validateBundleFolder(bundle1.getFolders());
+        validateBundleFolder(bundle2.getFolders());
+    }
+
+    private void validateBundleFolder(List<BundleFolder> bundleFolders) {
+        assertThat(bundleFolders.size(), is(2));
+        assertThat(bundleFolders.get(0).getValue().getName(), is("DWP"));
+        assertThat(bundleFolders.get(0).getValue().getDocuments().size(), is(2));
+        assertThat(bundleFolders.get(1).getValue().getName(), is("Further additions"));
+        assertThat(bundleFolders.get(1).getValue().getDocuments().size(), is(2));
+    }
+
+    @Test
+    public void checkBundleAdditionIsAddedCorrectly() throws Exception {
+        SscsCaseDetails caseDetails = createCase();
+        List<UploadDocument> docs = List.of(
+                UploadDocument.builder()
+                        .data(getPdf("appellant"))
+                        .filename("appellant.pdf")
+                        .documentType(DocumentType.APPELLANT_EVIDENCE.getValue())
+                        .bundleAddition("A")
+                        .build(),
+                UploadDocument.builder()
+                        .data(getPdf("dwpResponse"))
+                        .filename("dwpResponse.pdf")
+                        .documentType(DwpDocumentType.DWP_RESPONSE.getValue())
+                        .build(),
+                UploadDocument.builder()
+                        .data(getPdf("dwpEvidenceBundle"))
+                        .filename("dwpEvidenceBundle.pdf")
+                        .documentType(DwpDocumentType.DWP_EVIDENCE_BUNDLE.getValue())
+                        .build()
+        );
+        caseDetails = addDocumentsToCase(caseDetails.getData(), docs);
+        runEvent(caseDetails.getData(), EventType.CREATE_BUNDLE);
+
+        verifyAsyncBundleHasTakenPlace(caseDetails);
+
+        final SscsCaseDetails updatedCaseDetails = getByCaseId(caseDetails.getId());
+        assertThat(updatedCaseDetails.getData().getCaseBundles(), is(notNullValue()));
+        assertThat(updatedCaseDetails.getData().getCaseBundles().size(), is(1));
+        final List<BundleFolder> folders = updatedCaseDetails.getData().getCaseBundles().get(0).getValue().getFolders();
+        assertThat(folders.size(), is(2));
+        assertThat(folders.get(0).getValue().getName(), is("DWP"));
+        assertThat(folders.get(0).getValue().getDocuments().size(), is(2));
+        assertThat(folders.get(1).getValue().getName(), is("Further additions"));
+        assertThat(folders.get(1).getValue().getDocuments().size(), is(3));
+    }
+
+    private void verifyAsyncBundleHasTakenPlace(final SscsCaseDetails caseDetails) {
+        IntStream.range(0, 15)
+                .peek(i -> log.info("sleeping one second to verify the async bundle action has taken place."))
+                .peek(i -> sleepOneSecond())
+                .mapToObj(i -> getByCaseId(caseDetails.getId()))
+                .anyMatch(data -> data.getData().getCaseBundles() != null && data.getData().getCaseBundles().size() > 0);
+    }
+
+    private void sleepOneSecond() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            log.error("Error sleeping", e);
+        }
+    }
+
+}

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static uk.gov.hmcts.reform.sscs.functional.handlers.PdfHelper.getPdf;
 
 import java.util.List;
-import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +47,6 @@ public class CreateBundleAboutToSubmitHandlerFunctionalTest extends BaseHandler 
 
         runEvent(caseDetails.getData(), EventType.CREATE_BUNDLE);
 
-        verifyAsyncBundleHasTakenPlace(caseDetails);
         final SscsCaseDetails updatedCaseDetails = getByCaseId(caseDetails.getId());
         assertThat(updatedCaseDetails.getData().getCaseBundles(), is(notNullValue()));
         assertThat(updatedCaseDetails.getData().getCaseBundles().size(), is(2));
@@ -92,8 +90,6 @@ public class CreateBundleAboutToSubmitHandlerFunctionalTest extends BaseHandler 
         caseDetails = addDocumentsToCase(caseDetails.getData(), docs);
         runEvent(caseDetails.getData(), EventType.CREATE_BUNDLE);
 
-        verifyAsyncBundleHasTakenPlace(caseDetails);
-
         final SscsCaseDetails updatedCaseDetails = getByCaseId(caseDetails.getId());
         assertThat(updatedCaseDetails.getData().getCaseBundles(), is(notNullValue()));
         assertThat(updatedCaseDetails.getData().getCaseBundles().size(), is(1));
@@ -104,21 +100,4 @@ public class CreateBundleAboutToSubmitHandlerFunctionalTest extends BaseHandler 
         assertThat(folders.get(1).getValue().getName(), is("Further additions"));
         assertThat(folders.get(1).getValue().getDocuments().size(), is(3));
     }
-
-    private void verifyAsyncBundleHasTakenPlace(final SscsCaseDetails caseDetails) {
-        IntStream.range(0, 15)
-                .peek(i -> log.info("sleeping one second to verify the async bundle action has taken place."))
-                .peek(i -> sleepOneSecond())
-                .mapToObj(i -> getByCaseId(caseDetails.getId()))
-                .anyMatch(data -> data.getData().getCaseBundles() != null && data.getData().getCaseBundles().size() > 0);
-    }
-
-    private void sleepOneSecond() {
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            log.error("Error sleeping", e);
-        }
-    }
-
 }

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/handlers/createbundle/CreateBundleAboutToSubmitHandlerFunctionalTest.java
@@ -123,8 +123,7 @@ public class CreateBundleAboutToSubmitHandlerFunctionalTest extends BaseHandler 
                 .mapToObj(i -> getByCaseId(caseDetails.getId()))
                 .anyMatch(data -> data.getData().getCaseBundles() != null
                         && data.getData().getCaseBundles().size() > 0
-                        && !equalsIgnoreCase(data.getData().getCaseBundles().get(0).getValue().getStitchStatus(), "NEW")
-                );
+                        && !equalsIgnoreCase(data.getData().getCaseBundles().get(0).getValue().getStitchStatus(), "NEW"));
     }
 
     private void sleepOneSecond() {

--- a/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitHelper.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/sscs/functional/sya/SubmitHelper.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.functional.sya;
 import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.RandomStringUtils;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.ThreadLocalRandom;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseDetails;
@@ -27,6 +28,14 @@ public class SubmitHelper {
 
     public SscsCaseDetails findCaseInCcd(Long id, IdamTokens idamTokens) {
         return ccdService.getByCaseId(id, idamTokens);
+    }
+
+    public LocalDate getRandomMrnDate() {
+        long minDay = LocalDate.now().minusDays(1).toEpochDay();
+        long maxDay = LocalDate.now().minusDays(28).toEpochDay();
+        @SuppressWarnings("squid:S2245")
+        long randomDay = ThreadLocalRandom.current().nextLong(maxDay, minDay);
+        return LocalDate.ofEpochDay(randomDay);
     }
 
     public String getRandomNino() {


### PR DESCRIPTION
# SSCS-8366 - Add missing functional test for Bundling service

Currently we are not testing preview, since the event is being run on AAT, the callbacks in CCD are using AAT's version of tribunals.
When we tried to hit the about to submit endpoint on tribunals, it does not save any case information, and there will be no case bundles.

If we do use the label : pr-values:ccd in the PR, we would be correctly testing the preview endpoint. (But we haven't got it working properly yet)
