### PR TITLE
SSCS-9328 - Upload response fields shouldn't accept AV

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ResponseEventsAboutToSubmit.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/ResponseEventsAboutToSubmit.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.ccd.presubmit;
 
 import static java.util.Objects.isNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
+import static uk.gov.hmcts.reform.sscs.util.DocumentUtil.isFileAPdf;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -23,6 +24,8 @@ public class ResponseEventsAboutToSubmit {
         DocumentLink dwpUcbEvidenceDocument = sscsCaseData.getDwpUcbEvidenceDocument();
         if (isYes(sscsCaseData.getDwpUcb()) && dwpUcbEvidenceDocument == null) {
             preSubmitCallbackResponse.addError("Please upload a UCB document");
+        } else if (isYes(sscsCaseData.getDwpUcb()) && !isFileAPdf(dwpUcbEvidenceDocument)) {
+            preSubmitCallbackResponse.addError("UCB document must be a PDF.");
         } else if (!isYes(sscsCaseData.getDwpUcb()) && preSubmitCallbackResponse.getErrors().isEmpty()) {
             sscsCaseData.setDwpUcb(null);
             sscsCaseData.setDwpUcbEvidenceDocument(null);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandler.java
@@ -193,7 +193,7 @@ public class DwpUploadResponseAboutToSubmitHandler extends ResponseEventsAboutTo
         }
     }
 
-    private void validateDocumentIsAPdf(String documentMessage, DocumentLink documentLink , PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+    private void validateDocumentIsAPdf(String documentMessage, DocumentLink documentLink, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
         if (!isFileAPdf(documentLink)) {
             preSubmitCallbackResponse.addError(format("%s must be a PDF.", documentMessage));
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandler.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscs.ccd.presubmit.dwpuploadresponse;
 
+import static java.lang.String.format;
 import static java.util.Collections.*;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.collections4.CollectionUtils.*;
@@ -8,6 +9,7 @@ import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReferralReason.REVI
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState.REVIEW_BY_JUDGE;
 import static uk.gov.hmcts.reform.sscs.ccd.presubmit.InterlocReviewState.REVIEW_BY_TCW;
 import static uk.gov.hmcts.reform.sscs.util.AudioVideoEvidenceUtil.setHasUnprocessedAudioVideoEvidenceFlag;
+import static uk.gov.hmcts.reform.sscs.util.DocumentUtil.isFileAPdf;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -31,8 +33,8 @@ import uk.gov.hmcts.reform.sscs.service.DwpDocumentService;
 public class DwpUploadResponseAboutToSubmitHandler extends ResponseEventsAboutToSubmit implements PreSubmitCallbackHandler<SscsCaseData> {
 
     private static final DateTimeFormatter DD_MM_YYYY_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    private DwpDocumentService dwpDocumentService;
-    private AddNoteService addNoteService;
+    private final DwpDocumentService dwpDocumentService;
+    private final AddNoteService addNoteService;
 
     @Autowired
     public DwpUploadResponseAboutToSubmitHandler(DwpDocumentService dwpDocumentService, AddNoteService addNoteService) {
@@ -115,23 +117,13 @@ public class DwpUploadResponseAboutToSubmitHandler extends ResponseEventsAboutTo
     private PreSubmitCallbackResponse<SscsCaseData> checkErrors(SscsCaseData sscsCaseData) {
         PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse = new PreSubmitCallbackResponse<>(sscsCaseData);
 
-        if (sscsCaseData.getDwpResponseDocument() == null) {
-            preSubmitCallbackResponse.addError("DWP response document cannot be empty.");
-        }
+        validateDwpResponseDocuments(sscsCaseData, preSubmitCallbackResponse);
 
-        if (sscsCaseData.getDwpEvidenceBundleDocument() == null) {
-            preSubmitCallbackResponse.addError("DWP evidence bundle cannot be empty.");
-        }
+        validateDwpAudioVideoEvidence(sscsCaseData, preSubmitCallbackResponse);
+        return preSubmitCallbackResponse;
+    }
 
-        if (sscsCaseData.getDwpEditedEvidenceReason() != null) {
-            if (sscsCaseData.getDwpEditedResponseDocument() == null || sscsCaseData.getDwpEditedResponseDocument().getDocumentLink() == null) {
-                preSubmitCallbackResponse.addError("You must upload an edited DWP response document");
-            }
-
-            if (sscsCaseData.getDwpEditedEvidenceBundleDocument() == null || sscsCaseData.getDwpEditedEvidenceBundleDocument().getDocumentLink() == null) {
-                preSubmitCallbackResponse.addError("You must upload an edited DWP evidence bundle");
-            }
-        }
+    private void validateDwpAudioVideoEvidence(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
         if (sscsCaseData.getDwpUploadAudioVideoEvidence() != null) {
             for (AudioVideoEvidence audioVideoEvidence : sscsCaseData.getDwpUploadAudioVideoEvidence()) {
                 if (audioVideoEvidence.getValue().getRip1Document() != null && audioVideoEvidence.getValue().getDocumentLink() == null) {
@@ -139,7 +131,72 @@ public class DwpUploadResponseAboutToSubmitHandler extends ResponseEventsAboutTo
                 }
             }
         }
-        return preSubmitCallbackResponse;
+    }
+
+    private void validateDwpResponseDocuments(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        validateDwpResponseDocument(sscsCaseData.getDwpResponseDocument(), preSubmitCallbackResponse);
+
+        validateDwpAt38Document(sscsCaseData.getDwpAT38Document(), preSubmitCallbackResponse);
+
+        validateDwpEvidenceBundle(sscsCaseData, preSubmitCallbackResponse);
+
+        if (sscsCaseData.getDwpEditedEvidenceReason() != null) {
+            validateEditedDwpResponseDocument(sscsCaseData.getDwpEditedResponseDocument(), preSubmitCallbackResponse);
+
+            validateEditedDwpEvidenceBundle(sscsCaseData.getDwpEditedEvidenceBundleDocument(), preSubmitCallbackResponse);
+
+            validateAppendix12(sscsCaseData.getAppendix12Doc(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateAppendix12(DwpResponseDocument appendix12Document, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (appendix12Document != null && appendix12Document.getDocumentLink() != null) {
+            validateDocumentIsAPdf("Appendix 12 document", appendix12Document.getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateEditedDwpEvidenceBundle(DwpResponseDocument dwpResponseDocument, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (dwpResponseDocument == null || dwpResponseDocument.getDocumentLink() == null) {
+            preSubmitCallbackResponse.addError("You must upload an edited DWP evidence bundle");
+        } else {
+            validateDocumentIsAPdf("DWP edited evidence bundle", dwpResponseDocument.getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateEditedDwpResponseDocument(DwpResponseDocument dwpEditedResponseDocument, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (dwpEditedResponseDocument == null || dwpEditedResponseDocument.getDocumentLink() == null) {
+            preSubmitCallbackResponse.addError("You must upload an edited DWP response document");
+        } else {
+            validateDocumentIsAPdf("DWP edited response document", dwpEditedResponseDocument.getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateDwpEvidenceBundle(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (sscsCaseData.getDwpEvidenceBundleDocument() == null || sscsCaseData.getDwpEvidenceBundleDocument().getDocumentLink() == null) {
+            preSubmitCallbackResponse.addError("DWP evidence bundle cannot be empty.");
+        } else {
+            validateDocumentIsAPdf("DWP evidence bundle", sscsCaseData.getDwpEvidenceBundleDocument().getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateDwpAt38Document(DwpResponseDocument dwpResponseDocument, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (dwpResponseDocument != null && dwpResponseDocument.getDocumentLink() != null) {
+            validateDocumentIsAPdf("DWP AT38 document", dwpResponseDocument.getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateDwpResponseDocument(DwpResponseDocument dwpResponseDocument, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (dwpResponseDocument == null || dwpResponseDocument.getDocumentLink() == null) {
+            preSubmitCallbackResponse.addError("DWP response document cannot be empty.");
+        } else {
+            validateDocumentIsAPdf("DWP response document", dwpResponseDocument.getDocumentLink(), preSubmitCallbackResponse);
+        }
+    }
+
+    private void validateDocumentIsAPdf(String documentMessage, DocumentLink documentLink , PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {
+        if (!isFileAPdf(documentLink)) {
+            preSubmitCallbackResponse.addError(format("%s must be a PDF.", documentMessage));
+        }
     }
 
     private void handleEditedDocuments(SscsCaseData sscsCaseData, String userAuthorisation) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
@@ -504,7 +504,7 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
     @Test
     public void givenUcbSelectedAndUploadedUcbDoc_thenNoErrors() {
         sscsCaseData.setDwpUcb(YES.getValue());
-        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().build());
+        sscsCaseData.setDwpUcbEvidenceDocument(getPdfDocument().getDocumentLink());
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertThat(response.getErrors().size(), is(0));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
@@ -492,13 +492,13 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
     @Test
     public void givenUcbSelectedIsNo_thenTheFieldsAreCleared() {
         sscsCaseData.setDwpUcb(NO.getValue());
-        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().build());
+        sscsCaseData.setDwpUcbEvidenceDocument(getPdfDocument().getDocumentLink());
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertThat(response.getErrors().size(), is(0));
         assertThat(sscsCaseData.getDwpUcb(), is(nullValue()));
         assertThat(sscsCaseData.getDwpUcbEvidenceDocument(), is(nullValue()));
-        assertThat(sscsCaseData.getDwpDocuments(), is(nullValue()));
+        assertThat(sscsCaseData.getDwpDocuments().size(), is(2));
     }
 
     @Test
@@ -510,7 +510,7 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
         assertThat(response.getErrors().size(), is(0));
         assertThat(sscsCaseData.getDwpUcb(), is(YES.getValue()));
         assertThat(sscsCaseData.getDwpUcbEvidenceDocument(), is(nullValue()));
-        assertThat(sscsCaseData.getDwpDocuments().size(), is(1));
+        assertThat(sscsCaseData.getDwpDocuments().size(), is(3));
     }
 
     @Test
@@ -803,6 +803,17 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
         assertThat(response.getErrors().size(), is(1));
         assertThat(response.getErrors().iterator().next(), is("Appendix 12 document must be a PDF."));
+    }
+
+    @Test
+    public void ucbEvidenceDocument_mustBeAPdf() {
+        sscsCaseData.setDwpUcb(YES.getValue());
+        sscsCaseData.setDwpUcbEvidenceDocument(getMovieDocument().getDocumentLink());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("UCB document must be a PDF."));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/dwpuploadresponse/DwpUploadResponseAboutToSubmitHandlerTest.java
@@ -71,8 +71,8 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
             .benefitCode("002")
             .issueCode("CC")
             .dwpFurtherInfo("Yes")
-            .dwpResponseDocument(DwpResponseDocument.builder().documentLink(DocumentLink.builder().build()).build())
-            .dwpEvidenceBundleDocument(DwpResponseDocument.builder().documentLink(DocumentLink.builder().build()).build())
+            .dwpResponseDocument(DwpResponseDocument.builder().documentLink(DocumentLink.builder().documentUrl("a.pdf").documentFilename("a.pdf").build()).build())
+            .dwpEvidenceBundleDocument(DwpResponseDocument.builder().documentLink(DocumentLink.builder().documentUrl("b.pdf").documentFilename("b.pdf").build()).build())
             .appeal(Appeal.builder().build())
             .build();
 
@@ -450,20 +450,22 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
 
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
-        assertEquals(2, response.getData().getDwpDocuments().size());
+        assertEquals(4, response.getData().getDwpDocuments().size());
 
         String todayDate = LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
 
         assertEquals("Appendix 12 received on " + todayDate, response.getData().getDwpDocuments().get(0).getValue().getDocumentFileName());
         assertEquals("Appendix 12 received on " + todayDate + ".pdf", response.getData().getDwpDocuments().get(0).getValue().getDocumentLink().getDocumentFilename());
         assertEquals(DwpDocumentType.APPENDIX_12.getValue(), response.getData().getDwpDocuments().get(0).getValue().getDocumentType());
-        assertEquals("existingDoc", response.getData().getDwpDocuments().get(1).getValue().getDocumentFileName());
+        assertEquals("existingDoc", response.getData().getDwpDocuments().get(3).getValue().getDocumentFileName());
     }
 
     @Test
     @Parameters(method = "emptyAppendix12Documents")
     public void givenEmptyAppendix12Document_thenDoNotMoveDocumentToDwpDocumentsCollection(@Nullable DwpResponseDocument dwpResponseDocument) {
         callback.getCaseDetails().getCaseData().setAppendix12Doc(dwpResponseDocument);
+        callback.getCaseDetails().getCaseData().setDwpResponseDocument(dwpResponseDocument);
+        callback.getCaseDetails().getCaseData().setDwpEvidenceBundleDocument(dwpResponseDocument);
 
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
@@ -738,6 +740,69 @@ public class DwpUploadResponseAboutToSubmitHandlerTest {
         PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertEquals(2, response.getData().getDwpDocuments().size());
+    }
+
+    private DwpResponseDocument getMovieDocument() {
+        return DwpResponseDocument.builder().documentLink(DocumentLink.builder().documentUrl("0101").documentFilename("movie.mov").build()).build();
+    }
+
+    private DwpResponseDocument getPdfDocument() {
+        return DwpResponseDocument.builder().documentLink(DocumentLink.builder().documentUrl("0101").documentFilename("a.pdf").build()).build();
+    }
+
+    @Test
+    public void dwpResponseDocument_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpResponseDocument(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("DWP response document must be a PDF."));
+    }
+
+    @Test
+    public void dwpEvidenceBundleDocument_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpEvidenceBundleDocument(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("DWP evidence bundle must be a PDF."));
+    }
+
+    @Test
+    public void at38_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpAT38Document(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("DWP AT38 document must be a PDF."));
+    }
+
+    @Test
+    public void dwpEditedEvidenceDocument_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceReason("phme");
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceBundleDocument(getPdfDocument());
+        callback.getCaseDetails().getCaseData().setDwpEditedResponseDocument(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("DWP edited response document must be a PDF."));
+    }
+
+    @Test
+    public void dwpEditedEvidenceBundle_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceReason("phme");
+        callback.getCaseDetails().getCaseData().setDwpEditedResponseDocument(getPdfDocument());
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceBundleDocument(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("DWP edited evidence bundle must be a PDF."));
+    }
+
+    @Test
+    public void appendix12_mustBeAPdf() {
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceReason("phme");
+        callback.getCaseDetails().getCaseData().setDwpEditedResponseDocument(getPdfDocument());
+        callback.getCaseDetails().getCaseData().setDwpEditedEvidenceBundleDocument(getPdfDocument());
+        callback.getCaseDetails().getCaseData().setAppendix12Doc(getMovieDocument());
+        PreSubmitCallbackResponse<SscsCaseData> response = dwpUploadResponseAboutToSubmitHandler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+        assertThat(response.getErrors().size(), is(1));
+        assertThat(response.getErrors().iterator().next(), is("Appendix 12 document must be a PDF."));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/hmctsresponsereviewed/HmctsResponseReviewedAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/hmctsresponsereviewed/HmctsResponseReviewedAboutToSubmitHandlerTest.java
@@ -167,7 +167,7 @@ public class HmctsResponseReviewedAboutToSubmitHandlerTest {
     @Test
     public void givenUcbSelectedIsNo_thenTheFieldsAreCleared() {
         sscsCaseData.setDwpUcb(NO.getValue());
-        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().build());
+        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().documentUrl("121").documentFilename("1.pdf").build());
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertThat(response.getErrors().size(), is(0));
@@ -179,7 +179,7 @@ public class HmctsResponseReviewedAboutToSubmitHandlerTest {
     @Test
     public void givenUcbSelectedAndUploadedUcbDoc_thenNoErrors() {
         sscsCaseData.setDwpUcb(YES.getValue());
-        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().build());
+        sscsCaseData.setDwpUcbEvidenceDocument(DocumentLink.builder().documentUrl("11").documentFilename("file.pdf").build());
         PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
 
         assertThat(response.getErrors().size(), is(0));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controller/CreateCaseControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controller/CreateCaseControllerTest.java
@@ -97,6 +97,9 @@ public class CreateCaseControllerTest {
     public void twoCallsToRandomMrnDateHaveAGoodChanceOfBeingDifferent() {
         LocalDate mrnDate1 = controller.getRandomMrnDate();
         LocalDate mrnDate2 = controller.getRandomMrnDate();
+        if (mrnDate2.equals(mrnDate1)) {
+            mrnDate2 = controller.getRandomMrnDate();
+        }
         assertThat(mrnDate1, not(mrnDate2));
     }
 


### PR DESCRIPTION
# SSCS-9328 - Upload response fields shouldn't accept AV

DWP response, AT38, DWP evidence bundle, DWP edited response, DWP edited response, Appendix 12 fields should allow PDF's