### PR TITLE
SSCS-9680 - Process Audio/Video Evidence Event - Directions Notice Label

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -366,7 +366,7 @@ dependencies {
     compile group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
 
 
-    compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.5.3'
+    compile group: 'com.github.hmcts', name: 'sscs-common', version: '4.5.5-RC-SSCS-9680'
     compile group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.4.42'
 
     compile group:'org.overviewproject', name: 'mime-types', version: '1.0.2'

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionpostponementrequest/ActionPostponementRequestAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionpostponementrequest/ActionPostponementRequestAboutToSubmitHandler.java
@@ -146,6 +146,7 @@ public class ActionPostponementRequestAboutToSubmitHandler implements PreSubmitC
 
     private void clearTransientFields(SscsCaseData caseData) {
         caseData.setBodyContent(null);
+        caseData.setDirectionNoticeContent(null);
         caseData.setPreviewDocument(null);
         caseData.setGenerateNotice(null);
         caseData.setReservedToJudge(null);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/processaudiovideo/ProcessAudioVideoEvidenceAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/processaudiovideo/ProcessAudioVideoEvidenceAboutToSubmitHandler.java
@@ -329,6 +329,7 @@ public class ProcessAudioVideoEvidenceAboutToSubmitHandler implements PreSubmitC
 
     private void clearTransientFields(SscsCaseData caseData) {
         caseData.setBodyContent(null);
+        caseData.setDirectionNoticeContent(null);
         caseData.setPreviewDocument(null);
         caseData.setGenerateNotice(null);
         caseData.setReservedToJudge(null);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionpostponementrequest/ActionPostponementRequestAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionpostponementrequest/ActionPostponementRequestAboutToSubmitHandlerTest.java
@@ -64,6 +64,7 @@ public class ActionPostponementRequestAboutToSubmitHandlerTest {
         when(callback.getCaseDetails()).thenReturn(caseDetails);
 
         sscsCaseData = SscsCaseData.builder().ccdCaseId("ccdId")
+                .directionNoticeContent("Body Content")
                 .sscsHearingRecordingCaseData(SscsHearingRecordingCaseData.builder().build()).build();
         sscsCaseData.setAppeal(Appeal.builder().hearingOptions(HearingOptions.builder().build()).build());
 
@@ -133,6 +134,7 @@ public class ActionPostponementRequestAboutToSubmitHandlerTest {
         assertThat(response.getData().getSscsDocument(), is(not(empty())));
         assertThat(response.getData().getPostponementRequest().getUnprocessedPostponementRequest(), is(YesNo.NO));
         assertThat(response.getData().getDwpState(), is(DwpState.DIRECTION_ACTION_REQUIRED.getId()));
+        assertThat(response.getData().getDirectionNoticeContent(), is(nullValue()));
     }
 
     @Test
@@ -152,6 +154,7 @@ public class ActionPostponementRequestAboutToSubmitHandlerTest {
         assertThat(response.getData().getState(), is(State.NOT_LISTABLE));
         assertThat(response.getData().getPostponementRequest().getUnprocessedPostponementRequest(), is(YesNo.NO));
         assertThat(response.getData().getDwpState(), is(DwpState.DIRECTION_ACTION_REQUIRED.getId()));
+        assertThat(response.getData().getDirectionNoticeContent(), is(nullValue()));
     }
 
     @Test
@@ -171,6 +174,7 @@ public class ActionPostponementRequestAboutToSubmitHandlerTest {
         assertThat(response.getData().getInterlocReviewState(), is(WELSH_TRANSLATION.getId()));
         assertThat(response.getData().getTranslationWorkOutstanding(), is(YES.getValue()));
         assertThat(response.getData().getSscsDocument(), is(not(empty())));
+        assertThat(response.getData().getDirectionNoticeContent(), is(nullValue()));
     }
 
     private void populatePostponementSscsCaseData() {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/procesaudiovideo/ProcessAudioVideoEvidenceMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/procesaudiovideo/ProcessAudioVideoEvidenceMidEventHandlerTest.java
@@ -100,6 +100,7 @@ public class ProcessAudioVideoEvidenceMidEventHandlerTest {
                 .regionalProcessingCenter(RegionalProcessingCenter.builder().name("Birmingham").build())
                 .processAudioVideoAction(new DynamicList(ProcessAudioVideoActionDynamicListItems.ISSUE_DIRECTIONS_NOTICE.getCode()))
                 .selectedAudioVideoEvidence(new DynamicList(DOCUMENT_MANAGEMENT_URL + "/2124-12"))
+                .directionNoticeContent("Body Content")
                 .audioVideoEvidence(singletonList(AudioVideoEvidence.builder().value(
                         AudioVideoEvidenceDetails.builder()
                                 .documentLink(DOCUMENT_LINK)
@@ -329,6 +330,7 @@ public class ProcessAudioVideoEvidenceMidEventHandlerTest {
         assertEquals(NoticeIssuedTemplateBody.ENGLISH_IMAGE, payload.getImage());
         assertEquals("DIRECTIONS NOTICE", payload.getNoticeType());
         assertEquals("Appellant Lastname", payload.getAppellantFullName());
+        assertEquals(sscsCaseData.getDirectionNoticeContent(), payload.getNoticeBody());
         assertEquals(templateId, value.getTemplateId());
     }
 


### PR DESCRIPTION
SSCS-9680 - Process Audio/Video Evidence Event - Directions Notice Label

The new field directionNoticeContent is used in the Process Audio/Video evidence event and use in a similar manner to the field bodyContent.