### PR TITLE
SSCS-9717 - Fix NPE when Actioning Hearing Recording Requests

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionhearingrecordingrequest/ActionHearingRecordingRequestAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/actionhearingrecordingrequest/ActionHearingRecordingRequestAboutToSubmitHandler.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.model.PartyItemList;
 
-
 @Service
 @Slf4j
 public class ActionHearingRecordingRequestAboutToSubmitHandler implements PreSubmitCallbackHandler<SscsCaseData> {
@@ -113,6 +112,8 @@ public class ActionHearingRecordingRequestAboutToSubmitHandler implements PreSub
 
             Set<HearingRecordingRequest> partyHearingRecordingsRequests = allHearingRecordingsRequests.stream()
                     .filter(isFromRequestingParty(partyItemList))
+                    .filter(hr -> nonNull(hr.getValue().getSscsHearingRecording()))
+                    .filter(hr -> nonNull(hr.getValue().getSscsHearingRecording().getHearingId()))
                     .filter(hasHearingId(hearingId))
                     .collect(Collectors.toSet());
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/actionhearingrecordingrequest/ActionHearingRecordingRequestService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/actionhearingrecordingrequest/ActionHearingRecordingRequestService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscs.service.actionhearingrecordingrequest;
 
+import static java.util.Objects.nonNull;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 import static uk.gov.hmcts.reform.sscs.model.RequestStatus.GRANTED;
 import static uk.gov.hmcts.reform.sscs.model.RequestStatus.REFUSED;
@@ -47,6 +48,8 @@ public class ActionHearingRecordingRequestService {
     private boolean hasHearingRequestInCollection(PartyItemList party, Hearing hearing, List<HearingRecordingRequest> hearingRecordingCollection) {
         return emptyIfNull(hearingRecordingCollection).stream()
                 .filter(r -> r.getValue().getRequestingParty().equals(party.getCode()))
+                .filter(hr -> nonNull(hr.getValue().getSscsHearingRecording()))
+                .filter(hr -> nonNull(hr.getValue().getSscsHearingRecording().getHearingId()))
                 .anyMatch(hr -> hr.getValue().getSscsHearingRecording().getHearingId().equals(hearing.getValue().getHearingId()));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/processhearingrecordingrequest/ActionHearingRecordingRequestServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/processhearingrecordingrequest/ActionHearingRecordingRequestServiceTest.java
@@ -98,6 +98,19 @@ public class ActionHearingRecordingRequestServiceTest {
         assertThat(changedRequestStatus.get(), is(status));
     }
 
+    @Test
+    public void whenHearingRecordingRequestHasNoHearingRecordings_thenDoNotThrowAnError() {
+        final HearingRecordingRequest hearingRecordingRequest = getHearingRecordingRequest(PartyItemList.APPELLANT, REQUESTED);
+
+        hearingRecordingRequest.getValue().setSscsHearingRecording(null);
+        final SscsHearingRecordingCaseData sscsHearingRecordingCaseData = SscsHearingRecordingCaseData.builder()
+                .requestedHearings(newArrayList(hearingRecordingRequest))
+                .build();
+        SscsCaseData sscsCaseData = SscsCaseData.builder().sscsHearingRecordingCaseData(sscsHearingRecordingCaseData).hearings(newArrayList(HEARING)).build();
+        final Optional<RequestStatus> requestStatus = service.getRequestStatus(PartyItemList.APPELLANT, HEARING, sscsCaseData);
+        assertThat(requestStatus, is(Optional.empty()));
+    }
+
     private ProcessHearingRecordingRequest processHearingRecordingRequests(RequestStatus status) {
         return ProcessHearingRecordingRequest.builder()
                 .value(ProcessHearingRecordingRequestDetails.builder()


### PR DESCRIPTION
SSCS-9717 - Fix NPE when Actioning Hearing Recording Requests

This PR fixes a NPE bug.

The functionality to be able to process hearing recording requests from the Upload Doc FE event is not done on this ticket. There will be a new ticket to do this functionality.