### PR TITLE
Feat/sscs 10335 10328 - Further fix

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/IssueFinalDecisionAboutToSubmitHandler.java
@@ -98,14 +98,15 @@ public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
                 .getSchedulingAndListingFields().getHearingRoute(), sscsCaseData.getCcdCaseId());
         log.info("Issue final decision request: Sscscasedata case state {} for case {}", sscsCaseData.getState(),
                 sscsCaseData.getCcdCaseId());
-        log.info("Issue final decision request: Overall case state {} for case {}", callback.getCaseDetails()
+        log.info("Issue final decision request: Callback case state {} for case {}", callback.getCaseDetails()
                         .getState(), sscsCaseData.getCcdCaseId());
-        log.info("Issue final decision request: Overall case state before {} for case {}",
+        log.info("Issue final decision request: Callback case state before {} for case {}",
                 callback.getCaseDetailsBefore().map(CaseDetails::getState).orElse(null),
                 sscsCaseData.getCcdCaseId());
         log.info("Issue final decision request: condition outcome 1 ({})", isScheduleListingEnabled);
         log.info("Issue final decision request: condition outcome 2 ({})", SscsUtil
-                .isValidCaseState(callback.getCaseDetails().getState(), List.of(State.HEARING, State.READY_TO_LIST)));
+                .isValidCaseState(callback.getCaseDetailsBefore().map(CaseDetails::getState).orElse(State.UNKNOWN),
+                        List.of(State.HEARING, State.READY_TO_LIST)));
         log.info("Issue final decision request: condition outcome 3 ({})", SscsUtil.isSAndLCase(sscsCaseData));
         log.info("Issue final decision request: consolidated condition ({})", eligibleForHearingsCancel
                 .test(callback));
@@ -127,8 +128,8 @@ public class IssueFinalDecisionAboutToSubmitHandler implements PreSubmitCallback
     }
 
     private final Predicate<Callback<SscsCaseData>> eligibleForHearingsCancel = callback -> isScheduleListingEnabled
-            && SscsUtil.isValidCaseState(callback.getCaseDetails().getState(),
-                List.of(State.HEARING, State.READY_TO_LIST))
+            && SscsUtil.isValidCaseState(callback.getCaseDetailsBefore().map(CaseDetails::getState)
+                    .orElse(State.UNKNOWN), List.of(State.HEARING, State.READY_TO_LIST))
             && SscsUtil.isSAndLCase(callback.getCaseDetails().getCaseData());
 
     private void calculateOutcomeCode(SscsCaseData sscsCaseData, PreSubmitCallbackResponse<SscsCaseData> preSubmitCallbackResponse) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/esa/EsaIssueFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/esa/EsaIssueFinalDecisionAboutToSubmitHandlerTest.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import junitparams.JUnitParamsRunner;
@@ -100,6 +101,7 @@ public class EsaIssueFinalDecisionAboutToSubmitHandlerTest {
 
         when(callback.getEvent()).thenReturn(EventType.ISSUE_FINAL_DECISION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetailsBefore()).thenReturn(Optional.of(caseDetails));
 
         List<SscsDocument> documentList = new ArrayList<>();
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/pip/PipIssueFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/pip/PipIssueFinalDecisionAboutToSubmitHandlerTest.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import junitparams.JUnitParamsRunner;
@@ -105,6 +106,7 @@ public class PipIssueFinalDecisionAboutToSubmitHandlerTest {
 
         when(callback.getEvent()).thenReturn(EventType.ISSUE_FINAL_DECISION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetailsBefore()).thenReturn(Optional.of(caseDetails));
 
         List<SscsDocument> documentList = new ArrayList<>();
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/uc/UcIssueFinalDecisionAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issuefinaldecision/uc/UcIssueFinalDecisionAboutToSubmitHandlerTest.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import junitparams.JUnitParamsRunner;
@@ -100,6 +101,7 @@ public class UcIssueFinalDecisionAboutToSubmitHandlerTest {
 
         when(callback.getEvent()).thenReturn(EventType.ISSUE_FINAL_DECISION);
         when(callback.getCaseDetails()).thenReturn(caseDetails);
+        when(callback.getCaseDetailsBefore()).thenReturn(Optional.of(caseDetails));
 
         List<SscsDocument> documentList = new ArrayList<>();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10335


### Change description ###
Fix to use callback.casedetailsbefore.state instead of SscsCaseData.state in determining condition for hearings cancel message broadcast


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
