### PR TITLE
bumps apache tomcat to 9.0.68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ dependencyManagement {
             entry 'kotlin-reflect'
         }
         // CVE-2020-13934, CVE-2020-13935, CVE-2020-17527, CVE-2020-17527,
-        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
+        dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.68') {
             entry 'tomcat-embed-core'
             entry 'tomcat-embed-el'
             entry 'tomcat-annotations-api'


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
To fix CVE-2022-42252


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
