### PR TITLE
Revert "Update Helm release java to v4.0.13"

### DIFF
--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -7,7 +7,7 @@ maintainers:
   - name: HMCTS SSCS Team
 dependencies:
   - name: java
-    version: 4.0.13
+    version: 4.0.12
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: idam-pr
     version: 2.2.6


### PR DESCRIPTION
Reverts hmcts/sscs-tribunals-case-api#3146