### PR TITLE
changes ccd-definition-importer image to latest version

### DIFF
--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -311,7 +311,7 @@ ccd:
 
   #Use this image to import your CCD definition. To have an image available, create a git tag and push it.
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:S10538-22nonProd
+    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:latest
     definitionFilename: sscs-ccd.xlsx
     redirectUri: http://${SERVICE_NAME}-ccd-admin-web/oauth2redirect
     environment:
@@ -330,7 +330,7 @@ ccd:
       CCD_DEF_MYA_REPRESENTATIVE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_MYA_APPOINTEE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_ENV: 'PROD'
-      CCD_DEF_VERSION: S10538-22
+      CCD_DEF_VERSION: LATEST
     secrets: []
     userRoles:
       - citizen

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -311,7 +311,7 @@ ccd:
 
   #Use this image to import your CCD definition. To have an image available, create a git tag and push it.
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:latest
+    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer:latest
     definitionFilename: sscs-ccd.xlsx
     redirectUri: http://${SERVICE_NAME}-ccd-admin-web/oauth2redirect
     environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Sets the default ccd version to latest in preview template. This means that for tribunals PRs which do not require their own ccd defs, you will not need to create a new branch in ccd off master and tag it. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
