### PR TITLE
Upgrade: java-logging 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -328,7 +328,7 @@ dependencies {
 
     implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5'
     implementation group: 'com.github.hmcts', name: 'properties-volume-spring-boot-starter', version: '0.1.1'
-    implementation group: 'com.github.hmcts', name: 'java-logging', version: '5.1.9'
+    implementation group: 'com.github.hmcts', name: 'java-logging', version: '6.0.1'
     implementation group: 'com.github.hmcts', name: 'doc-assembly-client', version: '1.07'
     implementation group: 'com.github.hmcts', name: 'ccd-case-document-am-client', version: '1.7.3'
     //remove when secure doc store is live


### PR DESCRIPTION
Upgrading to latest java-logging version. Please carefully review the release notes for this latest version, as there are some removals to consider that may affect your application.