### PR TITLE
SSCS-12005 - Tribunals changes for setting of adjournment duration standard timeslot

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandler.java
@@ -9,12 +9,14 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDateType
 import static uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDateType.FIRST_AVAILABLE_DATE;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDateType.FIRST_AVAILABLE_DATE_AFTER;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDurationType.NON_STANDARD;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseNextHearingDurationType.STANDARD;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.DwpState.ADJOURNMENT_NOTICE_ISSUED;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.NO;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.YES;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isNoOrNull;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.YesNo.isYes;
 import static uk.gov.hmcts.reform.sscs.reference.data.model.HearingChannel.PAPER;
+import static uk.gov.hmcts.reform.sscs.utility.HearingChannelUtil.isInterpreterRequired;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -327,18 +329,32 @@ public class IssueAdjournmentNoticeAboutToSubmitHandler extends IssueDocumentHan
     }
 
     private Integer handleHearingDuration(SscsCaseData caseData) {
-        Integer duration = caseData.getAdjournment().getNextHearingListingDuration();
         AdjournCaseNextHearingDurationType durationType = caseData.getAdjournment().getNextHearingListingDurationType();
 
-        if (nonNull(duration) && NON_STANDARD.equals(durationType)) {
-            AdjournCaseNextHearingDurationUnits units = caseData.getAdjournment().getNextHearingListingDurationUnits();
-            if (units == AdjournCaseNextHearingDurationUnits.SESSIONS && duration >= MIN_HEARING_SESSION_DURATION) {
-                return duration * DURATION_SESSIONS_MULTIPLIER;
-            } else if (units == AdjournCaseNextHearingDurationUnits.MINUTES && duration >= MIN_HEARING_DURATION) {
-                return duration;
+        if (STANDARD.equals(durationType)) {
+            Integer existingDuration = caseData.getSchedulingAndListingFields().getDefaultListingValues().getDuration();
+            if (nonNull(existingDuration)) {
+                if (isYes(caseData.getAppeal().getHearingOptions().getWantsToAttend())
+                    && isInterpreterRequired(caseData)) {
+                    return existingDuration + MIN_HEARING_DURATION;
+                } else {
+                    return existingDuration;
+                }
             }
+        }
 
-            return DURATION_DEFAULT;
+        if (NON_STANDARD.equals(durationType)) {
+            Integer nextDuration = caseData.getAdjournment().getNextHearingListingDuration();
+            if (nonNull(nextDuration)) {
+                AdjournCaseNextHearingDurationUnits units = caseData.getAdjournment().getNextHearingListingDurationUnits();
+                if (units == AdjournCaseNextHearingDurationUnits.SESSIONS && nextDuration >= MIN_HEARING_SESSION_DURATION) {
+                    return nextDuration * DURATION_SESSIONS_MULTIPLIER;
+                } else if (units == AdjournCaseNextHearingDurationUnits.MINUTES && nextDuration >= MIN_HEARING_DURATION) {
+                    return nextDuration;
+                }
+
+                return DURATION_DEFAULT;
+            }
         }
 
         return hearingDurationsService.getHearingDurationBenefitIssueCodes(caseData);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandlerMainTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandlerMainTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.model.VenueDetails;
@@ -82,6 +83,25 @@ public class IssueAdjournmentNoticeAboutToSubmitHandlerMainTest extends IssueAdj
 
         var hearingEpimsIds = overrideFields.getHearingVenueEpimsIds();
         assertThat(hearingEpimsIds).isNotNull().hasSize(1).allMatch(b -> b.getValue().getValue().equals(epimsId));
+    }
+
+    @DisplayName("Duration is set as existing duration when standard timeslot selected during adjournment")
+    @Test
+    void givenStandardDurationSelectedShouldSetExistingDuration() {
+        ReflectionTestUtils.setField(handler, "isAdjournmentEnabled", true);
+
+        var adjournment = sscsCaseData.getAdjournment();
+        adjournment.setNextHearingListingDuration(60);
+        adjournment.setNextHearingListingDurationType(AdjournCaseNextHearingDurationType.STANDARD);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        var schedulingAndListingFields = response.getData().getSchedulingAndListingFields();
+        assertThat(schedulingAndListingFields).isNotNull();
+
+        var overrideFields = schedulingAndListingFields.getDefaultListingValues();
+        assertThat(overrideFields).isNotNull();
+        assertThat(overrideFields.getDuration()).isEqualTo(45);
     }
 
     @DisplayName("Duration in sessions should be correctly converted in minutes in override duration field")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandlerTestBase.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/issueadjournment/IssueAdjournmentNoticeAboutToSubmitHandlerTestBase.java
@@ -126,7 +126,7 @@ abstract class IssueAdjournmentNoticeAboutToSubmitHandlerTestBase {
                 .adjournmentInProgress(YES)
                 .build())
             .schedulingAndListingFields(SchedulingAndListingFields.builder()
-                .defaultListingValues(OverrideFields.builder().build()).build())
+                .defaultListingValues(OverrideFields.builder().duration(45).build()).build())
         .build();
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-12005

### Change description ###

An issue has been found during UAT whereby the standard time slot is not generating the duration expected by the business. This is because there are multiple ways that this should be calculated depending on the type of case. The system currently calculates this value based on the reference data for each case type however for some cases this value is set to Null as a Judge must define the duration so currently this would then set a default time of 60 mins which is incorrect. 

For cases where the value is NULL the business would like us to use the same duration that was set for the previous hearing as these would have been all been set by the Judge. 

However, rather than having 2 different methods the business would prefer a change to the functionality for all case types to ensure that when a case is adjourned and the user selects 'Standard time slot' we always set the hearing duration to the same time as the previous hearing. And we also need to ensure that If an interpreter is added via the adjournment journey we add 30 mins to the hearing duration if there is not already an interpreter on the case. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
