### PR TITLE
Derive who review case label value using enum rather than dynamic list

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/addnote/AddNoteAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/addnote/AddNoteAboutToSubmitHandler.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.sscs.ccd.presubmit.addnote;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,11 +15,12 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.PreSubmitCallbackResponse;
 import uk.gov.hmcts.reform.sscs.ccd.domain.*;
 import uk.gov.hmcts.reform.sscs.ccd.domain.InterlocReferralReason;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
+import uk.gov.hmcts.reform.sscs.ccd.presubmit.SelectWhoReviewsCase;
 import uk.gov.hmcts.reform.sscs.service.AddNoteService;
 
 @Component
 @Slf4j
-public class AddNoteAboutToSubmitHandler  implements PreSubmitCallbackHandler<SscsCaseData> {
+public class AddNoteAboutToSubmitHandler implements PreSubmitCallbackHandler<SscsCaseData> {
 
     protected final AddNoteService addNoteService;
 
@@ -62,10 +65,17 @@ public class AddNoteAboutToSubmitHandler  implements PreSubmitCallbackHandler<Ss
             log.info("Add note details for case id {} - select who reviews case: {}, interloc referral reason: {}",
                     sscsCaseData.getCcdCaseId(), sscsCaseData.getSelectWhoReviewsCase(), sscsCaseData.getInterlocReferralReason());
 
+            String whoReviewsCaseCode = sscsCaseData.getSelectWhoReviewsCase().getValue().getCode();
+
+            Optional<String> whoReviewsCaseLabel = Arrays.stream(SelectWhoReviewsCase.values())
+                    .filter(selectWhoReviewsCase -> selectWhoReviewsCase.getId().equals(whoReviewsCaseCode))
+                    .map(selectWhoReviewsCase -> selectWhoReviewsCase.getLabel().toLowerCase())
+                    .findFirst();
+
             if (nonNull(note) && StringUtils.isNoneBlank(note)) {
-                note = "Referred to interloc for " + sscsCaseData.getSelectWhoReviewsCase().getValue().getLabel().toLowerCase() + " - " + reasonLabel + " - " + note;
+                note = "Referred to interloc for " + whoReviewsCaseLabel.orElse("") + " - " + reasonLabel + " - " + note;
             } else {
-                note = "Referred to interloc for " + sscsCaseData.getSelectWhoReviewsCase().getValue().getLabel().toLowerCase() + " - " + reasonLabel;
+                note = "Referred to interloc for " + whoReviewsCaseLabel.orElse("") + " - " + reasonLabel;
             }
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/addnote/AddNoteAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/addnote/AddNoteAboutToSubmitHandlerTest.java
@@ -6,12 +6,15 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.APPEAL_RECEIVED;
 import static uk.gov.hmcts.reform.sscs.ccd.domain.EventType.HMCTS_RESPONSE_REVIEWED;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.SelectWhoReviewsCase.REVIEW_BY_JUDGE;
+import static uk.gov.hmcts.reform.sscs.ccd.presubmit.SelectWhoReviewsCase.REVIEW_BY_TCW;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -74,10 +77,16 @@ public class AddNoteAboutToSubmitHandlerTest {
 
     @Test
     public void testTempNoteFilledIsNullAndResponseReviewedEvent_thenNoteIsAdded() {
+        List<DynamicListItem> listOptions = new ArrayList<>();
+        listOptions.add(new DynamicListItem(REVIEW_BY_TCW.getId(), REVIEW_BY_TCW.getLabel()));
+        listOptions.add(new DynamicListItem(REVIEW_BY_JUDGE.getId(), REVIEW_BY_JUDGE.getLabel()));
+
+        DynamicList dynamicList = new DynamicList(new DynamicListItem("reviewByJudge", "Review by Judge"), listOptions);
+
         when(callback.getEvent()).thenReturn(HMCTS_RESPONSE_REVIEWED);
         sscsCaseData.setTempNoteDetail(null);
         sscsCaseData.setInterlocReferralReason(InterlocReferralReason.OVER_300_PAGES);
-        sscsCaseData.setSelectWhoReviewsCase(new DynamicList("Review by Judge"));
+        sscsCaseData.setSelectWhoReviewsCase(getWhoReviewsCaseDynamicList());
 
         PreSubmitCallbackResponse<SscsCaseData> response =
                 handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -106,7 +115,7 @@ public class AddNoteAboutToSubmitHandlerTest {
         when(callback.getEvent()).thenReturn(HMCTS_RESPONSE_REVIEWED);
         sscsCaseData.setTempNoteDetail(null);
         sscsCaseData.setInterlocReferralReason(InterlocReferralReason.NONE);
-        sscsCaseData.setSelectWhoReviewsCase(new DynamicList("Review by Judge"));
+        sscsCaseData.setSelectWhoReviewsCase(getWhoReviewsCaseDynamicList());
 
         PreSubmitCallbackResponse<SscsCaseData> response =
                 handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -157,10 +166,16 @@ public class AddNoteAboutToSubmitHandlerTest {
         "NO_RESPONSE_TO_DIRECTION"
     })
     public void ifEventIsResponseReviewed_AddInterlocReferralReasonToNote(InterlocReferralReason value) {
+        List<DynamicListItem> listOptions = new ArrayList<>();
+        listOptions.add(new DynamicListItem(REVIEW_BY_TCW.getId(), REVIEW_BY_TCW.getLabel()));
+        listOptions.add(new DynamicListItem(REVIEW_BY_JUDGE.getId(), REVIEW_BY_JUDGE.getLabel()));
+
+        DynamicList selectWhoReviewsCaseDynamicList = new DynamicList(new DynamicListItem("reviewByJudge", "Review by Judge"), listOptions);
+
         when(callback.getEvent()).thenReturn(HMCTS_RESPONSE_REVIEWED);
         sscsCaseData.setTempNoteDetail("Here is my note");
         sscsCaseData.setInterlocReferralReason(value);
-        sscsCaseData.setSelectWhoReviewsCase(new DynamicList("Review by Judge"));
+        sscsCaseData.setSelectWhoReviewsCase(getWhoReviewsCaseDynamicList());
 
         PreSubmitCallbackResponse<SscsCaseData> response =
                 handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
@@ -232,4 +247,13 @@ public class AddNoteAboutToSubmitHandlerTest {
 
         handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
     }
+
+    @NotNull
+    private static DynamicList getWhoReviewsCaseDynamicList() {
+        List<DynamicListItem> listOptions = new ArrayList<>();
+        listOptions.add(new DynamicListItem(REVIEW_BY_TCW.getId(), REVIEW_BY_TCW.getLabel()));
+        listOptions.add(new DynamicListItem(REVIEW_BY_JUDGE.getId(), REVIEW_BY_JUDGE.getLabel()));
+        return new DynamicList(new DynamicListItem("reviewByJudge",null), listOptions);
+    }
+
 }


### PR DESCRIPTION

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-554

### Change description ###

- EXUI seems to be loosing value for label in dynamic list. As a result it would be good to rely on code and then get the label value from enum rather than relying on the dynamic list as it fails with null pointer exception.

`
"selectWhoReviewsCase": {
      "value": {
        "code": "reviewByJudge",
        "label": null
      },
      "list_items": null
    },
`