### PR TITLE
SSCSCI-84  - Postponement doc appears twice

### DIFF
--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -499,7 +499,7 @@ ccd:
 
   #Use this image to import your CCD definition. To have an image available, create a git tag and push it.
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:S-10526nonProd
+    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:SSCSI-84nonProd
     definitionFilename: sscs-ccd.xlsx
     redirectUri: http://${SERVICE_NAME}-ccd-admin-web/oauth2redirect
     environment:
@@ -518,7 +518,7 @@ ccd:
       CCD_DEF_MYA_REPRESENTATIVE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_MYA_APPOINTEE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_ENV: 'PROD'
-      CCD_DEF_VERSION: S-10526nonProd
+      CCD_DEF_VERSION: SSCSI-84nonProd
     secrets: []
     userRoles:
       - citizen

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -562,6 +562,7 @@ sscs-evidence-share:
       ROBOTICS_EMAIL_PIP_AE_TO: "fake3"
       CASE_ACCESS_MANAGEMENT_FEATURE: true
       ISSUE_GENERIC_LETTER: true
+      ALLOW_CONFIG_MUTATIONS: true
     secrets:
       AMQP_PASSWORD:
         secretRef: sscs-sb-preview

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/postponementrequest/PostponementRequestAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/postponementrequest/PostponementRequestAboutToSubmitHandler.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.UploadParty;
 import uk.gov.hmcts.reform.sscs.ccd.presubmit.PreSubmitCallbackHandler;
 import uk.gov.hmcts.reform.sscs.service.FooterService;
 import uk.gov.hmcts.reform.sscs.service.PostponementRequestService;
-import uk.gov.hmcts.reform.sscs.util.SscsUtil;
 
 @Service
 public class PostponementRequestAboutToSubmitHandler implements PreSubmitCallbackHandler<SscsCaseData> {
@@ -49,7 +48,7 @@ public class PostponementRequestAboutToSubmitHandler implements PreSubmitCallbac
         if (response.getErrors().isEmpty()) {
             postponementRequestService.processPostponementRequest(sscsCaseData, UploadParty.DWP);
             List<SscsDocument> documents = sscsCaseData.getSscsDocument();
-            SscsUtil.addDocumentToBundle(footerService, sscsCaseData, documents.get(documents.size() - 1));
+            documents.get(documents.size() - 1).getValue().setBundleAddition(footerService.getNextBundleAddition(documents));
         }
 
         return response;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
@@ -178,13 +178,6 @@ public class SscsUtil {
         caseData.setSscsDocument(documents);
     }
 
-    public static void addDocumentToBundle(FooterService footerService, SscsCaseData sscsCaseData, SscsDocument sscsDocument) {
-        DocumentLink url = sscsDocument.getValue().getDocumentLink();
-        DocumentType documentType = DocumentType.fromValue(sscsDocument.getValue().getDocumentType());
-        String dateIssued = LocalDate.now().format(DateTimeFormatter.ofPattern("dd-MM-yyyy"));
-        footerService.createFooterAndAddDocToCase(url, sscsCaseData, documentType, dateIssued, null, null, null);
-    }
-
     public static DocumentType getPostHearingReviewDocumentType(PostHearing postHearing, boolean isPostHearingsEnabled) {
         if (isPostHearingsEnabled && nonNull(postHearing.getReviewType())) {
             return getPostHearingReviewDocumentType(postHearing);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/postponementrequest/PostponementRequestAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/postponementrequest/PostponementRequestAboutToSubmitHandlerTest.java
@@ -4,11 +4,10 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType.ABOUT_TO_SUBMIT;
@@ -111,6 +110,7 @@ public class PostponementRequestAboutToSubmitHandlerTest {
         when(caseDetails.getCaseData()).thenReturn(sscsCaseData);
         when(caseDetails.getState()).thenReturn(sscsCaseData.getState());
         when(idamService.getUserDetails(USER_AUTHORISATION)).thenReturn(userDetails);
+        when(footerService.getNextBundleAddition(any())).thenReturn("A");
 
         expectedDocument = SscsDocument.builder().value(SscsDocumentDetails.builder()
                 .documentLink(sscsCaseData.getPostponementRequest().getPostponementPreviewDocument())
@@ -172,7 +172,6 @@ public class PostponementRequestAboutToSubmitHandlerTest {
         final PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
         List<SscsDocument> sscsDocuments = response.getData().getSscsDocument();
         Assert.assertEquals(sscsDocuments, Collections.singletonList(expectedDocument));
-        verify(footerService).createFooterAndAddDocToCase(eq(expectedDocument.getValue().getDocumentLink()), any(),
-                eq(POSTPONEMENT_REQUEST), any(), any(), eq(null), eq(null));
+        assertEquals("A", response.getData().getSscsDocument().get(0).getValue().getBundleAddition());
     }
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-84

### Change description ###

Ensuring the postponement request is only stored in the documents tab once (instead of twice) and that this request is always included in bundles
