### PR TITLE
SSCSCI-588 - Update to case data event to handle lang mismatch

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/caseupdated/CaseUpdatedAboutToStartHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/caseupdated/CaseUpdatedAboutToStartHandler.java
@@ -52,10 +52,11 @@ public class CaseUpdatedAboutToStartHandler implements PreSubmitCallbackHandler<
 
             if (!StringUtils.isEmpty(existingLanguage)) {
                 Language language = verbalLanguagesService.getVerbalLanguage(existingLanguage);
-                DynamicListItem dynamicListItem = utils.getLanguageDynamicListItem(language);
-                interpreterLanguages.setValue(dynamicListItem);
+                if (null != language) {
+                    DynamicListItem dynamicListItem = utils.getLanguageDynamicListItem(language);
+                    interpreterLanguages.setValue(dynamicListItem);
+                }
             }
-
             hearingOptions.setLanguagesList(interpreterLanguages);
             log.info("Populated {} Languages in DynamicList for caseId {} for update to case data event",
                     interpreterLanguages.getListItems().size(), caseId);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/caseupdated/CaseUpdatedAboutToStartHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/caseupdated/CaseUpdatedAboutToStartHandlerTest.java
@@ -116,4 +116,25 @@ public class CaseUpdatedAboutToStartHandlerTest {
         Assertions.assertNotNull(hearingOptions.getLanguagesList());
         Assertions.assertEquals("Welsh", hearingOptions.getLanguagesList().getValue().getLabel());
     }
+
+    @Test
+    public void givenThatOriginalLanguageFieldIsNonEmptyandInvalid_thenSetDynamicListInitialValue() {
+        sscsCaseData = CaseDataUtils.buildCaseData();
+        sscsCaseData.getAppeal().getHearingOptions().setLanguages("Wales");
+
+        DynamicListItem item = new DynamicListItem("Wales", "Wales");
+        DynamicList list = new DynamicList(null, List.of(item));
+
+        given(caseDetails.getCaseData()).willReturn(sscsCaseData);
+        given(dynamicListLanguageUtil.generateInterpreterLanguageFields(any())).willReturn(list);
+        given(dynamicListLanguageUtil.getLanguageDynamicListItem(any())).willReturn(item);
+        given(verbalLanguagesService.getVerbalLanguage(any())).willReturn(null);
+
+        PreSubmitCallbackResponse<SscsCaseData> response = handler.handle(ABOUT_TO_START, callback, USER_AUTHORISATION);
+        HearingOptions hearingOptions = sscsCaseData.getAppeal().getHearingOptions();
+
+        Assertions.assertEquals(0, response.getErrors().size());
+        Assertions.assertNotNull(hearingOptions.getLanguagesList());
+        Assertions.assertNull(hearingOptions.getLanguagesList().getValue());
+    }
 }


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-588


### Change description ###
When there is a language mismatch between user typed and language ref. data dropdown, then user is still able to continue to update to case data page and have the interpreter language listed
