### PR TITLE
SSCSCI-553 - Edited documents not showing in Response Reviewed event

### DIFF
--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -499,7 +499,7 @@ ccd:
 
   #Use this image to import your CCD definition. To have an image available, create a git tag and push it.
   ccd-definition-importer:
-    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:S-10526nonProd
+    image: hmctspublic.azurecr.io/sscs/ccd-definition-importer-benefit:S-SCI-553nonProd
     definitionFilename: sscs-ccd.xlsx
     redirectUri: http://${SERVICE_NAME}-ccd-admin-web/oauth2redirect
     environment:
@@ -518,7 +518,7 @@ ccd:
       CCD_DEF_MYA_REPRESENTATIVE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_MYA_APPOINTEE_LINK: http://${SERVICE_NAME}-ccd-definition-store
       CCD_DEF_ENV: 'PROD'
-      CCD_DEF_VERSION: S-10526nonProd
+      CCD_DEF_VERSION: S-SCI-553nonProd
     secrets: []
     userRoles:
       - citizen


### PR DESCRIPTION

### Change description ###
Enable cases with edited documents due to potentially harmful or confidential evidence to be seen during the Response Reviewed event.
This is a copy of Master to put changes that are only in ccd defs into preview.
