### PR TITLE
Dependency patches

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'pmd'
     id 'org.sonarqube' version '4.3.0.3225'
     id 'jacoco'
-    id 'org.springframework.boot' version '2.7.14'
+    id 'org.springframework.boot' version '2.7.18'
     id 'uk.gov.hmcts.java' version '0.12.43'
     id 'com.gorylenko.gradle-git-properties' version '2.4.1'
     id 'com.github.ben-manes.versions' version '0.46.0'
@@ -262,27 +262,20 @@ dependencyManagement {
             entry 'snakeyaml'
         }
 
-        // CVE-2022-41881, CVE-2022-41915
-        dependencySet(group: 'io.netty', version: '4.1.95.Final') {
-            entry 'netty-buffer'
-            entry 'netty-common'
-            entry 'netty-codec'
-            entry 'netty-codec-dns'
-            entry 'netty-codec-http'
-            entry 'netty-codec-http2'
-            entry 'netty-codec-socks'
-            entry 'netty-handler'
-            entry 'netty-handler-proxy'
-            entry 'netty-resolver'
-            entry 'netty-resolver-dns'
-            entry 'netty-resolver-dns-classes-macos'
-            entry 'netty-resolver-dns-native-macos'
-            entry 'netty-transport'
-            entry 'netty-transport-classes-epoll'
-            entry 'netty-transport-classes-kqueue'
-            entry 'netty-transport-native-epoll'
-            entry 'netty-transport-native-kqueue'
-            entry 'netty-transport-native-unix-common'
+        //CVE-2023-33202
+        dependencySet(group: 'org.springframework.security', version: '1.1.1') {
+            entry 'spring-security-rsa'
+        }
+
+        //CVE-2024-25710
+        dependencySet(group: 'org.apache.commons', version: '1.26.0') {
+            entry 'commons-compress'
+        }
+
+        //CVE-2023-6378, CVE-2023-6481
+        dependencySet(group: 'ch.qos.logback', version: '1.2.13') {
+            entry 'logback-core'
+            entry 'logback-classic'
         }
 
         imports {
@@ -302,10 +295,10 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-activemq'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
 
-    implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.8.5'
-    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.5'
-    implementation group: 'org.springframework.security', name: 'spring-security-config', version: '5.8.5'
-    implementation group: 'org.springframework.security', name: 'spring-security-web', version: '5.8.5'
+    implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.8.10'
+    implementation group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.10'
+    implementation group: 'org.springframework.security', name: 'spring-security-config', version: '5.8.10'
+    implementation group: 'org.springframework.security', name: 'spring-security-web', version: '5.8.10'
 
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
     implementation group: 'org.springframework.retry', name: 'spring-retry', version: '1.3.4'
@@ -342,8 +335,8 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.1'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.8.13'
 
-    implementation group: 'com.azure', name: 'azure-core', version: '1.42.0'
-    implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.2'
+    implementation group: 'com.azure', name: 'azure-core', version: '1.46.0'
+    implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.15.1'
 
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.5.8'
 
@@ -383,8 +376,8 @@ dependencies {
 
     implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.81"
     
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.80'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.80'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.86'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '9.0.86'
 
     integrationTestImplementation group: 'commons-io', name: 'commons-io', version:  '2.13.0'
 
@@ -399,8 +392,8 @@ dependencies {
 
     testImplementation group: 'org.apache.httpcomponents', name: 'fluent-hc', version:  '4.5.14'
 
-    testImplementation group: 'com.azure', name: 'azure-core', version: '1.42.0'
-    testImplementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.14.2'
+    testImplementation group: 'com.azure', name: 'azure-core', version: '1.46.0'
+    testImplementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.15.1'
 
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.11.0'
     testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '2.37.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,20 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-03-01">
-    <cve>CVE-2023-5072</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
     <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-36052</cve>
-    <cve>CVE-2023-46604</cve>
-    <cve>CVE-2023-33202</cve>
-    <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-6481</cve>
-    <cve>CVE-2023-34042</cve>
-    <cve>CVE-2024-25710</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-758

### Change description ###

CVE-2023-44487
io.netty packages were already added as a dependency set for version 4.1.95.Final as a CVE fix before, recommendation was to upgrade them to version 4.1.100.Final or above. **Removed the dependency set** because the org.springframework.boot:2.7.18 patch also fixes this CVE, it uses version 4.1.101.Final.

CVE-2023-44487, CVE-2023-42794, CVE-2023-42795, CVE-2023-45648, CVE-2023-46589
org.apache.tomcat.embed:tomcat-embed-core and tomcat-embed-websocket
Recommendation by CVE-2023-46589 was to upgrade to 9.0.83, so **updated the direct dependency** to latest available patch (9.0.86).

CVE-2023-35116
com.fasterxml.jackson.core:jackson-databind:2.14.3
Recommendation was to upgrade to 2.16.0 but patch broke the build with error `Unsatisfied dependency expressed through constructor parameter 0`, no other solution found, **suppressed**.

CVE-2023-36052
azure-core packages
Upgraded direct dependencies com.azure:azure-core and com.azure:azure-messaging-servicebus to latest available versions (both minor) but this doesn't resolve the CVE. Recommendation is to upgrade Azure-CLI but we do not use that package. Issue was raised with Microsoft as other services are also affected. **Suppressing** for now.

CVE-2023-46604
org.apache.activemq:activemq-broker and activemq-client version 5.16.6
Recommendation was to upgrade to version 5.16.7 but patch breaks functional test (givenValidSscs5AppealIsSubmitted_thenCreateValidAppeal – uk.gov.hmcts.reform.sscs.functional.sya.SubmitAppealTest), **didn't add as a new dependency** because the org.springframework.boot:2.7.18 patch also fixes this CVE, it uses version 5.16.7.

CVE-2023-33202
org.bouncycastle:bcprov-jdk15on:1.69
Not a direct dependency and artifact moved to bcprov-jdk18on after version 1.70, the recommendation was to upgrade to version 1.73. org.springframework.security:spring-security-rsa:1.1.1 was **added as a new dependency** set (uses bcprov-jdk18on:1.74) because couldn't find a patch/minor for any direct dependency.

CVE-2023-6378, CVE-2023-6481
ch.qos.logback:logback-core and logback-classic
**Added patch as a new dependency set** (as per recommendation), couldn't use any direct dependencies to fix CVE.

CVE-2023-34055
org.springframework.boot 2.7.14
**Patched** to version 2.7.18 as per recommendation.

CVE-2023-34042
org.springframework.security 5.8.5
**Upgraded to latest available patch**.

CVE-2024-25710
org.apache.commons:commons-compress:1.21
Followed recommendation and **added as a new dependency**, because it isn't a direct dependency and couldn't find patch an existing one.