### PR TITLE
Update sscs-common to 5.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -266,11 +266,6 @@ dependencyManagement {
             entry 'spring-security-rsa'
         }
 
-        //CVE-2024-25710
-        dependencySet(group: 'org.apache.commons', version: '1.26.0') {
-            entry 'commons-compress'
-        }
-
         //CVE-2023-6378, CVE-2023-6481
         dependencySet(group: 'ch.qos.logback', version: '1.2.13') {
             entry 'logback-core'

--- a/build.gradle
+++ b/build.gradle
@@ -331,7 +331,7 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'document-management-client', version: '7.0.0'
     implementation group: 'com.github.hmcts', name: 'cmc-pdf-service-client', version: '7.0.1'
 
-    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.2'
+    implementation group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.4'
     implementation group: 'com.github.hmcts', name: 'sscs-pdf-email-common', version: '1.8.13'
 
     implementation group: 'com.azure', name: 'azure-core', version: '1.46.0'


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSCI-769

### Change description ###

- Updated sscs-common to 5.3.4
- Removed dependency of org.apache.commons:commons-compress:1.26.0 (CVE-2024-25710) because that was coming from sscs-common.