### PR TITLE
Update appeal handler to use trigger event v2 instead of overwriting data from submitted callback

### DIFF
--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.137
+version: 0.0.138
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team

--- a/charts/sscs-tribunals-api/values.yaml
+++ b/charts/sscs-tribunals-api/values.yaml
@@ -112,6 +112,7 @@ java: &javavalues #This is an anchor to reuse settings in Job mode.
     EMAIL_SMTP_SSL_TRUST: "*"
     BYPASS_EVIDENCE_SHARE_SERVICE: false
     HEARING_RECORDING_REQUEST_CASE_UPDATE_V2_ENABLED: false
+    TRIGGER_EVENT_V2_ENABLED: false
 
 idam-pr:
   enabled: false

--- a/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
@@ -6,6 +6,7 @@ import static uk.gov.hmcts.reform.sscs.ccd.domain.State.READY_TO_LIST;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.callback.CallbackHandler;
 import uk.gov.hmcts.reform.sscs.ccd.callback.Callback;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
@@ -22,14 +24,20 @@ public class AppealReceivedHandler implements CallbackHandler<SscsCaseData> {
 
     private final DispatchPriority dispatchPriority;
 
+    private final CcdService ccdService;
     private final UpdateCcdCaseService updateCcdCaseService;
 
     private final IdamService idamService;
 
+    @Value("${feature.trigger-eventV2.enabled}")
+    private boolean isTriggerEventV2Enabled;
+
     @Autowired
-    public AppealReceivedHandler(UpdateCcdCaseService updateCcdCaseService,
+    public AppealReceivedHandler(CcdService ccdService,
+                                 UpdateCcdCaseService updateCcdCaseService,
                                  IdamService idamService) {
         this.dispatchPriority = DispatchPriority.LATEST;
+        this.ccdService = ccdService;
         this.updateCcdCaseService = updateCcdCaseService;
         this.idamService = idamService;
     }
@@ -62,14 +70,26 @@ public class AppealReceivedHandler implements CallbackHandler<SscsCaseData> {
             log.error("Thread sleep interrupted: " + e.getMessage());
         }
 
-        log.info("About to update case v2 with appealReceived event for id {}", callback.getCaseDetails().getId());
-        updateCcdCaseService.triggerCaseEventV2(
-                callback.getCaseDetails().getId(),
-                APPEAL_RECEIVED.getCcdType(),
-                "Appeal received",
-                "Appeal received event has been triggered from Tribunals API for digital case",
-                idamService.getIdamTokens()
-        );
+        if (isTriggerEventV2Enabled) {
+            log.info("About to update case v2 with appealReceived event for id {}", callback.getCaseDetails().getId());
+            updateCcdCaseService.triggerCaseEventV2(
+                    callback.getCaseDetails().getId(),
+                    APPEAL_RECEIVED.getCcdType(),
+                    "Appeal received",
+                    "Appeal received event has been triggered from Tribunals API for digital case",
+                    idamService.getIdamTokens()
+            );
+        } else {
+            log.info("About to update case with appealReceived event for id {}", callback.getCaseDetails().getId());
+            ccdService.updateCase(
+                    callback.getCaseDetails().getCaseData(),
+                    callback.getCaseDetails().getId(),
+                    APPEAL_RECEIVED.getCcdType(),
+                    "Appeal received",
+                    "Appeal received event has been triggered from Evidence Share for digital case",
+                    idamService.getIdamTokens()
+            );
+        }
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
 @Slf4j
@@ -22,15 +23,15 @@ public class AppealReceivedHandler implements CallbackHandler<SscsCaseData> {
 
     private final DispatchPriority dispatchPriority;
 
-    private final CcdService ccdService;
+    private final UpdateCcdCaseService updateCcdCaseService;
 
     private final IdamService idamService;
 
     @Autowired
-    public AppealReceivedHandler(CcdService ccdService,
+    public AppealReceivedHandler(UpdateCcdCaseService updateCcdCaseService,
                                  IdamService idamService) {
         this.dispatchPriority = DispatchPriority.LATEST;
-        this.ccdService = ccdService;
+        this.updateCcdCaseService = updateCcdCaseService;
         this.idamService = idamService;
     }
 
@@ -62,8 +63,14 @@ public class AppealReceivedHandler implements CallbackHandler<SscsCaseData> {
             log.error("Thread sleep interrupted: " + e.getMessage());
         }
 
-        log.info("About to update case with appealReceived event for id {}", callback.getCaseDetails().getId());
-        ccdService.updateCase(callback.getCaseDetails().getCaseData(), callback.getCaseDetails().getId(), APPEAL_RECEIVED.getCcdType(), "Appeal received", "Appeal received event has been triggered from Evidence Share for digital case",  idamService.getIdamTokens());
+        log.info("About to update case v2 with appealReceived event for id {}", callback.getCaseDetails().getId());
+        updateCcdCaseService.triggerCaseEventV2(
+                callback.getCaseDetails().getId(),
+                APPEAL_RECEIVED.getCcdType(),
+                "Appeal received",
+                "Appeal received event has been triggered from Tribunals API for digital case",
+                idamService.getIdamTokens()
+        );
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandler.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.callback.DispatchPriority;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 

--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -147,6 +147,7 @@ feature.add-link-to-other-associated-cases-v2.enabled: ${ADD_LINK_TO_OTHER_ASSOC
 feature.bypass-evidence-share-service.enabled: ${BYPASS_EVIDENCE_SHARE_SERVICE:false}
 feature.log-selected-properties.enabled: ${LOG_SELECTED_ENVIRONMENT_VARIABLES:false}
 feature.hearings-recording-request.case-updateV2.enabled: ${HEARING_RECORDING_REQUEST_CASE_UPDATE_V2_ENABLED:false}
+feature.trigger-eventV2.enabled: ${TRIGGER_EVENT_V2_ENABLED:false}
 
 case_document_am.url=${CASE_DOCUMENT_AM_URL:http://localhost:4455}
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
 import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
+import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 
 @RunWith(JUnitParamsRunner.class)
@@ -33,7 +34,7 @@ public class AppealReceivedHandlerTest {
     public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
-    private CcdService ccdCaseService;
+    private UpdateCcdCaseService updateCcdCaseService;
 
     @Mock
     private IdamService idamService;
@@ -43,7 +44,7 @@ public class AppealReceivedHandlerTest {
 
     @Before
     public void setUp() {
-        handler = new AppealReceivedHandler(ccdCaseService, idamService);
+        handler = new AppealReceivedHandler(updateCcdCaseService, idamService);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -80,13 +81,13 @@ public class AppealReceivedHandlerTest {
     public void givenValidEventAndDigitalCase_thenTriggerAppealReceivedEvent(EventType eventType) {
         handler.handle(SUBMITTED, HandlerHelper.buildTestCallbackForGivenData(SscsCaseData.builder().createdInGapsFrom(READY_TO_LIST.getId()).build(), INTERLOCUTORY_REVIEW_STATE, eventType));
 
-        verify(ccdCaseService).updateCase(any(), eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
+        verify(updateCcdCaseService).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
     }
 
     @Test(expected = IllegalStateException.class)
     public void givenValidEventAndNonDigitalCase_thenThrowException() {
         handler.handle(SUBMITTED, HandlerHelper.buildTestCallbackForGivenData(SscsCaseData.builder().createdInGapsFrom(VALID_APPEAL.getId()).build(), INTERLOCUTORY_REVIEW_STATE, EventType.VALID_APPEAL_CREATED));
 
-        verify(ccdCaseService, times(0)).updateCase(any(), eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
+        verify(updateCcdCaseService, times(0)).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
@@ -80,13 +80,13 @@ public class AppealReceivedHandlerTest {
     public void givenValidEventAndDigitalCase_thenTriggerAppealReceivedEvent(EventType eventType) {
         handler.handle(SUBMITTED, HandlerHelper.buildTestCallbackForGivenData(SscsCaseData.builder().createdInGapsFrom(READY_TO_LIST.getId()).build(), INTERLOCUTORY_REVIEW_STATE, eventType));
 
-        verify(updateCcdCaseService).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
+        verify(updateCcdCaseService).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Tribunals API for digital case"), any());
     }
 
     @Test(expected = IllegalStateException.class)
     public void givenValidEventAndNonDigitalCase_thenThrowException() {
         handler.handle(SUBMITTED, HandlerHelper.buildTestCallbackForGivenData(SscsCaseData.builder().createdInGapsFrom(VALID_APPEAL.getId()).build(), INTERLOCUTORY_REVIEW_STATE, EventType.VALID_APPEAL_CREATED));
 
-        verify(updateCcdCaseService, times(0)).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Evidence Share for digital case"), any());
+        verify(updateCcdCaseService, times(0)).triggerCaseEventV2(eq(1L), eq(EventType.APPEAL_RECEIVED.getCcdType()), eq("Appeal received"), eq("Appeal received event has been triggered from Tribunals API for digital case"), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/evidenceshare/callback/handlers/AppealReceivedHandlerTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.MockitoRule;
 import uk.gov.hmcts.reform.sscs.ccd.callback.CallbackType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.EventType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-import uk.gov.hmcts.reform.sscs.ccd.service.CcdService;
 import uk.gov.hmcts.reform.sscs.ccd.service.UpdateCcdCaseService;
 import uk.gov.hmcts.reform.sscs.idam.IdamService;
 


### PR DESCRIPTION

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSSI-227

- This change uses trigger event v2 which does not uses callback case data to overwrite case data in DB.
-  This change impact below submitted events

```
EventType.VALID_APPEAL_CREATED
EventType.DRAFT_TO_VALID_APPEAL_CREATED
EventType.VALID_APPEAL
EventType.INTERLOC_VALID_APPEAL
CaseData().getCreatedInGapsFrom() is READY_TO_LIST
```