### PR TITLE
SSCSCI-855: remove default from chart var, set in jenkins

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -68,7 +68,8 @@ def secretsForPR = [
                 secret('docmosis-api-key', 'PDF_SERVICE_ACCESS_KEY'),
                 secret('AppInsightsInstrumentationKey', 'APPINSIGHTS_INSTRUMENTATIONKEY'),
                 secret('sscs-servicebus-connection-string-tf', 'SERVICE_BUS_CONNECTION_STRING'),
-                secret('preview-ccd-db-password-2', 'PREVIEW_DB_PASSWORD_2')
+                secret('preview-ccd-db-password-2', 'PREVIEW_DB_PASSWORD_2'),
+                secret('preview-shared-db-password', 'SHARED_DB_PASSWORD')
         ],
         's2s-${env}'      : [
                 secret('microservicekey-ccd-gw', 'CCD_API_GATEWAY_S2S_SECRET'),

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -74,7 +74,7 @@ java:
             CREATE DATABASE "sscsjobscheduler" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
     auth:
       username: "hmcts"
-      password: "${SHARED_DB_PASSWORD}"
+      password: ${SHARED_DB_PASSWORD}
 
 
 idam-pr:

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -206,7 +206,7 @@ ccd:
     postgresql:
       auth:
         postgresUsername: hmcts
-        postgresPassword: "${postgresPassword:hmcts}"
+        postgresPassword: "${SHARED_DB_PASSWORD}"
 
   am-role-assignment-service:
     java:
@@ -264,7 +264,7 @@ ccd:
       enabled: false
     extraEnvs:
       - name: DATA_STORE_PASS
-        value: hmcts
+        value: ${SHARED_DB_PASSWORD}
       - name: DATA_STORE_URL
         value: "jdbc:postgresql://${SERVICE_NAME}-postgresql:5432/data-store?ssl=disable&stringtype=unspecified"
       - name: DATA_STORE_USER
@@ -302,7 +302,7 @@ ccd:
           jdbc {
             jdbc_connection_string => "jdbc:postgresql://${SERVICE_NAME}-postgresql:5432/data-store?ssl=disable&stringtype=unspecified"
             jdbc_user => "hmcts"
-            jdbc_password => "hmcts"
+            jdbc_password => ${SHARED_DB_PASSWORD}
             jdbc_validate_connection => true
             jdbc_validation_timeout => "1"
             jdbc_driver_library => "/usr/share/logstash/ccd/postgresql.jar"
@@ -598,7 +598,7 @@ sscs-tya-notif:
       JOB_SCHEDULER_DB_HOST: ${SERVICE_NAME}-postgresql
       JOB_SCHEDULER_DB_CONNECTION_OPTIONS: "?stringtype=unspecified&ssl=disable&gssEncMode=disable"
       JOB_SCHEDULER_DB_USERNAME: hmcts
-      JOB_SCHEDULER_DB_PASSWORD: "${JOB_SCHEDULER:hmcts}"
+      JOB_SCHEDULER_DB_PASSWORD: "${SHARED_DB_PASSWORD}"
       HOURS_START_TIME: 0
       HOURS_END_TIME: 23
       RUN_DB_MIGRATION_ON_STARTUP: true

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -74,7 +74,7 @@ java:
             CREATE DATABASE "sscsjobscheduler" WITH OWNER = hmcts ENCODING = 'UTF-8' CONNECTION LIMIT = -1;
     auth:
       username: "hmcts"
-      password: "${SHARED_DB_PASSWORD:hmcts}"
+      password: "${SHARED_DB_PASSWORD}"
 
 
 idam-pr:

--- a/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
+++ b/charts/sscs-tribunals-api/values.ccd.preview.template.yaml
@@ -206,7 +206,7 @@ ccd:
     postgresql:
       auth:
         postgresUsername: hmcts
-        postgresPassword: "${SHARED_DB_PASSWORD}"
+        postgresPassword: ${SHARED_DB_PASSWORD}
 
   am-role-assignment-service:
     java:
@@ -598,7 +598,7 @@ sscs-tya-notif:
       JOB_SCHEDULER_DB_HOST: ${SERVICE_NAME}-postgresql
       JOB_SCHEDULER_DB_CONNECTION_OPTIONS: "?stringtype=unspecified&ssl=disable&gssEncMode=disable"
       JOB_SCHEDULER_DB_USERNAME: hmcts
-      JOB_SCHEDULER_DB_PASSWORD: "${SHARED_DB_PASSWORD}"
+      JOB_SCHEDULER_DB_PASSWORD: ${SHARED_DB_PASSWORD}
       HOURS_START_TIME: 0
       HOURS_END_TIME: 23
       RUN_DB_MIGRATION_ON_STARTUP: true


### PR DESCRIPTION
### Jira link (if applicable)
- https://tools.hmcts.net/jira/browse/SSCSCI-855

### Change description ###
- remove default from env var evaluation in helm chart, because it's invalid syntax
- set the env var value in Jenkins, which is reading it from https://portal.azure.com/#@HMCTS.NET/asset/Microsoft_Azure_KeyVault/Secret/https://sscs-aat.vault.azure.net/secrets/preview-shared-db-password