### PR TITLE
SSCS-12536 - Add Defensive Coding / Null Check on PostHearingRequestType in PostHearingReviewAboutToSubmitHandler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
@@ -489,6 +489,11 @@ public class SscsUtil {
     }
 
     public static void clearPostHearingRequestFormatAndContentFields(SscsCaseData caseData, PostHearingRequestType requestType) {
+        if (isNull(requestType)) {
+            log.info("PostHearingRequestType is null during clearing of request format and body content fields for case id : {}", caseData.getCcdCaseId());
+            return;
+        }
+
         PostHearing postHearing = caseData.getPostHearing();
         DocumentGeneration docGen = caseData.getDocumentGeneration();
 


### PR DESCRIPTION
… fields for body content and request format.

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCS-12536

### Change description ###

As part of WA SRT in AAT, it was discovered during full regression that we have a potential null pointer in existing post hearing code.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
