### PR TITLE
SSCSSI-352 Fix logging in topicconsumer

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/servicebus/TopicConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/servicebus/TopicConsumer.java
@@ -49,16 +49,14 @@ public class TopicConsumer {
 
     private void processMessageWithRetry(String message, int retry, String messageId) {
         try {
-            log.info("Message Id {} received from the service bus by evidence share service", messageId);
+            log.info("Message Id {} received from the service bus by evidence share service, attempt {}", messageId, retry);
             processMessage(message, messageId);
         } catch (Exception e) {
             if (retry > maxRetryAttempts || isException(e)) {
-                log.error(format("Caught unknown unrecoverable error %s for message id %s", e.getMessage(), messageId), e);
+                log.error("Caught unknown unrecoverable error %s for message id {}", messageId, e);
             } else {
-                log.info("Statcktrace is {}", e.getStackTrace());
-                log.info(String.format("Caught recoverable error %s, retrying %s out of %s for message id %s",
-                    e.getMessage(), retry, maxRetryAttempts, messageId));
-
+                log.error("Caught recoverable error {}, retrying {} out of {} for message id {}",
+                    e.getMessage(), retry, maxRetryAttempts, messageId, e);
                 processMessageWithRetry(message, retry + 1, messageId);
             }
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/service/servicebus/TopicConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/service/servicebus/TopicConsumer.java
@@ -55,8 +55,8 @@ public class TopicConsumer {
             if (retry > maxRetryAttempts || isException(e)) {
                 log.error("Caught unknown unrecoverable error %s for message id {}", messageId, e);
             } else {
-                log.error("Caught recoverable error {}, retrying {} out of {} for message id {}",
-                    e.getMessage(), retry, maxRetryAttempts, messageId, e);
+                log.error("Caught recoverable error while retrying {} out of {} for message id {}",
+                    retry, maxRetryAttempts, messageId, e);
                 processMessageWithRetry(message, retry + 1, messageId);
             }
         }


### PR DESCRIPTION
### Jira link (if applicable)


https://tools.hmcts.net/jira/browse/SSCSSI-352


### Change description ###

Current logging without attempt is misleading if its the message within custom retry or queue retry.

Also, stack trace is not printed for other errors `
Statcktrace is jdk.internal.reflect.GeneratedMethodAccessor1619.invoke(Unknown Source) ` 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
