### PR TITLE
SSCSCI-902 - Remove properties-volume-spring-boot-starter from dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,7 +323,6 @@ dependencies {
     implementation group: 'com.squareup.okio', name: 'okio-jvm', version: '3.5.0'
 
     implementation group: 'com.github.hmcts', name: 'auth-checker-lib', version: '2.1.5'
-    implementation group: 'com.github.hmcts', name: 'properties-volume-spring-boot-starter', version: '0.1.1'
 
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
 


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/SSCSCI-902


### Change description ###
Removed properties-volume-spring-boot-starter. Configtree was already in application.properties

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
