### PR TITLE
SSCSSI-352 | Fix prefetching issue with service bus topic message listeners

### DIFF
--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -182,6 +182,8 @@ amqp.password=${AMQP_PASSWORD:}
 amqp.topic=${TOPIC_NAME:sscs-topic}
 amqp.subscription=${SUBSCRIPTION_NAME:test.queue}
 amqp.trustAllCerts=${TRUST_ALL_CERTS:true}
+amqp.prefetch.override=${AMQP_PREFETCH_OVERRIDE:true}
+amqp.prefetch.topicPrefetch=${AMQP_TOPIC_PREFETCH:1}
 
 docmosis.template.english.dl6.name=TB-SCS-GNO-ENG-00010.doc
 docmosis.template.english.dl16.name=TB-SCS-GNO-ENG-00011.doc


### PR DESCRIPTION

### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/SSCSSI-352

### Change description ###

- Currently as the app uses spring jms directly, the default prefetch policy is enabled.
- It prefetches (max 1000) messages into local cache while other listeners are idle
- Message lock duration on subscription is 1 minute. So if all messages in local cache are not processed (which is likely when the cache has more than a few messages) with in 1 minute, service bus will  send this to another listener while this still processes the messages.
- This leads to duplicate message processing and the queues getting piled up with same message for up to 10 times (max redeliveries set on subscription).
- This causes exponential impact and AAT topic goes up to 3000 messages at a given time, making entire AAT blocked. 
- It may turn unmanageable this if it occurs to this level on production.
- A bit more details in Azure documentation  https://learn.microsoft.com/en-us/azure/developer/java/spring-framework/spring-jms-troubleshooting-guide#prefetch-issue 

### Impact on case
Case will be updated with same event over and over again causing data inconsistency .

![image-2024-05-24-15-05-14-594](https://github.com/user-attachments/assets/1391074c-48a3-4bf0-a294-1a6ff66797a1)

### Volumes

AAT - 11,424 messages processed with duplication in 1 month

![Screenshot 2024-07-10 at 09 24 10](https://github.com/user-attachments/assets/f2eeb669-0d47-44bb-a4eb-acbf952ffc55)


Prod - 100 messages processed with duplication in 1 month , less impact due to less volumes of cases.

<img width="1036" alt="Screenshot 2024-07-10 at 09 18 39" src="https://github.com/user-attachments/assets/fbaeaf11-9c53-470f-9051-11661b901190">


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
