### PR TITLE
Change environment var to avoid conflict

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -421,7 +421,7 @@ gov:
 
 
 subscription.hmac.secret.text: ${EMAIL_MAC_SECRET_TEXT:our-big-secret}
-tya.evidence.submission.info.link: ${EVIDENCE_SUBMISSION_INFO_LINK:http://localhost:3000/evidence/appeal_id}
+tya.evidence.submission.info.link: ${TYA_EVIDENCE_SUBMISSION_INFO_LINK:http://localhost:3000/evidence/appeal_id}
 manage.emails.link: ${SSCS_MANAGE_EMAILS_LINK:http://localhost:3000/manage-email-notifications/mac}
 track.appeal.link: ${SSCS_TRACK_YOUR_APPEAL_LINK:http://localhost:3000/trackyourappeal/appeal_id}
 hearing.info.link: ${HEARING_INFO_LINK:http://localhost:3000/abouthearing/appeal_id}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SSCSSI-391

### Change description

Currently, there is a conflict when spring tries to auto unbox the env var and it clashes with envidence. config.

### Testing done

Proved on demo that it's the cause of issue.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
