### PR TITLE
Add support for test UI suites

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -138,6 +138,9 @@ withPipeline(type, product, component) {
             env.CASE_TYPE = "Benefit-${CHANGE_ID}"
             setAatEnvVars();
         }
+
+        def tests = githubApi.getLabelsbyPattern(env.BRANCH_NAME, "test-suite")
+        env.TEST_SUITE = tests.size() > 0 ? tests.collect { it.replace("test-suite:", "@") }.join(",") : "@preview-pipeline"
     }
     onDemo {
         env.ENVIRONMENT = "demo"

--- a/definitions/test/e2e/write-and-issue-final-decision.spec.ts
+++ b/definitions/test/e2e/write-and-issue-final-decision.spec.ts
@@ -6,7 +6,7 @@ let caseId: string;
 
 test.describe('Issue Final Decision - PIP Appeal Type', {tag: '@nightly-pipeline'}, async () => {
 
-    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'Yes' notice generated. - No Award Given",
+    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'Yes' notice generated. - No Award Given", {tag: ['@regression']},
         async ({issueFinalDecisionSteps}) => {
             test.slow();
             let pipCaseId = await createCaseBasedOnCaseType('PIP');
@@ -15,7 +15,7 @@ test.describe('Issue Final Decision - PIP Appeal Type', {tag: '@nightly-pipeline
             // await performAppealDormantOnCase(pipCaseId);
         });
 
-    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'Yes' notice generated. - Yes Award is Given", {tag: '@preview-pipeline'}, 
+    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'Yes' notice generated. - Yes Award is Given", {tag: ['@preview-pipeline', '@regression']},
         async ({issueFinalDecisionSteps}) => {
             test.slow();
             let pipCaseId = await createCaseBasedOnCaseType('PIP');
@@ -28,7 +28,7 @@ test.describe('Issue Final Decision - PIP Appeal Type', {tag: '@nightly-pipeline
 
 test.describe('Issue Final Decision - Tax Credit Appeal Type', {tag: ['@nightly-pipeline']},  async () => {
 
-    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'No' notice generated",
+    test("Issue Final Decision - Upload Response with Further Information as No - Simple Decision Notice - 'No' notice generated", {tag: ['@regression']},
         async ({issueFinalDecisionSteps}) => {
             test.slow();
             let taxCreditCaseId = await createCaseBasedOnCaseType('TAX CREDIT');

--- a/definitions/test/package.json
+++ b/definitions/test/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "node index.js",
-    "test:preview": "PLAYWRIGHT_HTML_REPORT=playwright-report PW_TEST_HTML_REPORT_OPEN=never npx playwright install && npx playwright test --config ./playwright.config.ts --project chromium --reporter=html --grep-invert @work-allocation --grep @preview-pipeline",
+    "test:preview": "PLAYWRIGHT_HTML_REPORT=playwright-report PW_TEST_HTML_REPORT_OPEN=never npx playwright install && npx playwright test --config ./playwright.config.ts --project chromium --reporter=html --grep-invert @work-allocation --grep $TEST_SUITE",
     "test:preview-hearings": "HEARINGS_ENABLED=Yes PLAYWRIGHT_HTML_REPORT=playwright-report PW_TEST_HTML_REPORT_OPEN=never npx playwright install && npx playwright test --config ./playwright.config.ts --project chromium --reporter=html --grep-invert @work-allocation",
     "test:aat": "PLAYWRIGHT_HTML_REPORT=playwright-report PW_TEST_HTML_REPORT_OPEN=never npx playwright install && npx playwright test --config ./playwright.config.ts --project chromium --reporter=html --grep-invert @work-allocation --grep @master-pipeline",
     "test:fullfunctional": "PLAYWRIGHT_HTML_REPORT=playwright-report PW_TEST_HTML_REPORT_OPEN=never npx playwright install && npx playwright test --config ./playwright.config.ts --project chromium --reporter=html --grep-invert @work-allocation --grep @nightly-pipeline"


### PR DESCRIPTION
Allow selection of UI test suites by adding a label `test-suite:suiteName` to PRs