### PR TITLE
Add sampling for health requests

### DIFF
--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -2,5 +2,20 @@
   "connectionString": "${file:/mnt/secrets/sscs/app-insights-connection-string}",
   "role": {
     "name": "TribunalsCaseApi"
+  },
+  "sampling": {
+    "overrides": [
+      {
+        "telemetryType": "request",
+        "attributes": [
+          {
+            "key": "http.url",
+            "value": "https?://[^/]+/health.*",
+            "matchType": "regexp"
+          }
+        ],
+        "percentage": 1
+      }
+    ]
   }
 }


### PR DESCRIPTION
Currently, we nearly send 900k requests for /health on just AAT which are of no purpose.

<img width="746" alt="Screenshot 2024-11-08 at 15 03 23" src="https://github.com/user-attachments/assets/4253f95c-e193-4a03-98c9-44df5b47f9b3">


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
