### PR TITLE
Revert "Disable functional tests as notifications to unblock rollback deployment"

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/handlers/AdminAppealWithdrawnNotificationsTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/handlers/AdminAppealWithdrawnNotificationsTest.java
@@ -11,7 +11,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -40,7 +39,6 @@ public class AdminAppealWithdrawnNotificationsTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     @Parameters({
         "Appellant, 8620e023-f663-477e-a771-9cfad50ee30f, 446c7b23-7342-42e1-adff-b4c367e951cb, 1, 1, 1",
         "Appointee, 8620e023-f663-477e-a771-9cfad50ee30f, 446c7b23-7342-42e1-adff-b4c367e951cb, 1, 1, 1",

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/DocmosisWithGovNotifyLetterFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/DocmosisWithGovNotifyLetterFunctionalTest.java
@@ -64,7 +64,6 @@ public class DocmosisWithGovNotifyLetterFunctionalTest extends AbstractFunctiona
     }
 
     @Test
-    @Ignore
     @Parameters(method = "expectedNumberOfLetters")
     public void shouldSendCorrectNumberOfDocmosisLetters(NotificationEventType notificationEventType,
                                                          int expectedNumberOfLetters)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/EvidenceReceivedFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/EvidenceReceivedFunctionalTest.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Field;
 import java.util.List;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.functional.tyanotifications.AbstractFunctionalTest;
@@ -39,7 +38,6 @@ public class EvidenceReceivedFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({"ORAL", "PAPER"})
     public void givenEvidenceReceivedWithRepsSubscription_shouldSendNotificationToReps(AppealHearingType appealHearingType)
         throws Exception {

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/JointPartyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/JointPartyFunctionalTest.java
@@ -133,7 +133,6 @@ public class JointPartyFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void sendsDirectionIssuedProvideInformationLetterToAppellantRepresentativeAndJointParty() throws IOException, NotificationClientException {
 
         NotificationEventType notificationEventType = NotificationEventType.DIRECTION_ISSUED;

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/NotificationsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/NotificationsFunctionalTest.java
@@ -160,7 +160,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendEvidenceReceivedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED);
 
@@ -172,7 +171,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingPostponedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(POSTPONEMENT);
 
@@ -180,7 +178,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendHearingAdjournedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(ADJOURNED);
 
@@ -191,7 +188,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionCreatedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_CREATED);
 
@@ -199,7 +195,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionUpdatedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED);
 
@@ -207,7 +202,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppellantNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "Callback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailId, appealCreatedAppellantSmsId);
@@ -216,7 +210,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppellantNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "Callback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailId, appealCreatedAppellantSmsId);
@@ -225,7 +218,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppointeeNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "AppointeeCallback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailId, appealCreatedAppointeeSmsId);
@@ -234,7 +226,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppointeeNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "AppointeeCallback.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailId, appealCreatedAppointeeSmsId);
@@ -243,7 +234,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({
         "pip,judge\\, doctor and disability expert",
         "esa,judge and a doctor",
@@ -266,7 +256,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldNotSendPaperDwpResponseReceivedNotificationIfNotSubscribed() throws NotificationClientException, IOException {
         simulateCcdCallback(DWP_RESPONSE_RECEIVED, BASE_PATH_TYAN + RESPONSE_RECEIVED_PAPER_PATH + "paper-no-subscriptions-"
                 + DWP_RESPONSE_RECEIVED.getId() + "Callback.json");
@@ -278,7 +267,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForOralCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
             BASE_PATH_TYAN + "appointee/oral-" + EVIDENCE_REMINDER.getId() + "Callback.json");
@@ -298,7 +286,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
             BASE_PATH_TYAN + "appointee/paper-" + EVIDENCE_REMINDER.getId() + "Callback.json");
@@ -318,7 +305,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppellantSubscriptionUpdateNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED,
             BASE_PATH_TYAN + "appellant-" + SUBSCRIPTION_UPDATED.getId() + "Callback.json");
@@ -336,7 +322,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeSubscriptionUpdateNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(SUBSCRIPTION_UPDATED,
             BASE_PATH_TYAN + "appointee-" + SUBSCRIPTION_UPDATED.getId() + "Callback.json");
@@ -352,7 +337,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReceivedPaperNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED,
             BASE_PATH_TYAN + "appointee/paper-" + EVIDENCE_RECEIVED.getId() + "Callback.json");
@@ -367,7 +351,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeHearingAdjournedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(ADJOURNED,
             BASE_PATH_TYAN + "appointee/" + ADJOURNED.getId() + "Callback.json");
@@ -381,7 +364,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeAppealLapsedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
             BASE_PATH_TYAN + "appointee/" + APPEAL_LAPSED.getId() + "Callback.json");
@@ -400,7 +382,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeDwpAppealLapsedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
             BASE_PATH_TYAN + "appointee/dwpAppealLapsedCallback.json");
@@ -415,7 +396,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeResponseReceivedForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(DWP_RESPONSE_RECEIVED,
             BASE_PATH_TYAN + "appointee/" + DWP_RESPONSE_RECEIVED.getId() + "Callback.json");
@@ -460,7 +440,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReceivedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED,
             BASE_PATH_TYAN + "appointee/" + EVIDENCE_RECEIVED.getId() + "Callback.json");
@@ -471,7 +450,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeHearingPostponedNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(POSTPONEMENT,
             BASE_PATH_TYAN + "appointee/" + POSTPONEMENT.getId() + "Callback.json");
@@ -483,7 +461,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSaveReasonableAdjustmentNotificationForAppellant() throws IOException, NotificationClientException {
         simulateCcdCallback(APPEAL_RECEIVED, BASE_PATH_TYAN + APPEAL_RECEIVED.getId() + "AppellantReasonableAdjustmentCallback.json");
 
@@ -501,7 +478,6 @@ public class NotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSaveReasonableAdjustmentNotificationForAppellantAndRep() throws IOException, NotificationClientException {
         simulateCcdCallback(APPEAL_RECEIVED, BASE_PATH_TYAN + APPEAL_RECEIVED.getId() + "AppellantRepReasonableAdjustmentCallback.json");
         delayInSeconds(10);

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/OtherPartyFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/OtherPartyFunctionalTest.java
@@ -7,7 +7,6 @@ import java.util.Arrays;
 import java.util.List;
 import junitparams.Parameters;
 import junitparams.converters.Nullable;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
@@ -47,7 +46,6 @@ public class OtherPartyFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     @Parameters({"oral-,DWP_UPLOAD_RESPONSE, oralDwpUploadResponseJointPartySmsId, oralDwpUploadResponseOtherPartyEmailId"})
     public void willSendDwpUploadResponse(@Nullable String prefix, NotificationEventType notificationEventType, String... fieldNames) throws Exception {
 
@@ -67,7 +65,6 @@ public class OtherPartyFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters({
         "ADJOURNED, 0, hearingAdjournedOtherPartyEmailTemplateId, hearingAdjournedOtherPartySmsTemplateId",
         "POSTPONEMENT, 0, hearingPostponedOtherPartyEmailTemplateId",

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/WelshNotificationsFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/WelshNotificationsFunctionalTest.java
@@ -176,7 +176,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendEvidenceReceivedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(EVIDENCE_RECEIVED);
         tryFetchNotificationsForTestCase(
@@ -188,7 +187,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendPaperEvidenceReceivedNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_RECEIVED, BASE_PATH_TYAN + "paper-" + EVIDENCE_RECEIVED.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(
@@ -200,7 +198,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingPostponedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(POSTPONEMENT);
 
@@ -223,7 +220,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendHearingAdjournedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(ADJOURNED);
 
@@ -236,7 +232,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionCreatedNotificationWelsh() throws NotificationClientException, IOException {
 
         simulateWelshCcdCallback(SUBSCRIPTION_CREATED);
@@ -246,7 +241,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendSubscriptionUpdatedNotificationWelsh() throws NotificationClientException, IOException {
         simulateWelshCcdCallback(SUBSCRIPTION_UPDATED);
 
@@ -254,7 +248,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppellantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "CallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailIdWelsh, appealCreatedAppellantSmsIdWelsh);
@@ -264,7 +257,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppellantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "CallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppellantEmailIdWelsh, appealCreatedAppellantSmsIdWelsh);
@@ -273,7 +265,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealCreatedAppointeeNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(SYA_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "AppointeeCallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailIdWelsh, appealCreatedAppointeeSmsIdWelsh);
@@ -283,7 +274,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
 
 
     @Test
-    @Ignore
     public void shouldSendValidAppealCreatedAppointeeNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(VALID_APPEAL_CREATED, BASE_PATH_TYAN + SYA_APPEAL_CREATED.getId() + "AppointeeCallbackWelsh.json");
         List<Notification> notifications = tryFetchNotificationsForTestCase(appealCreatedAppointeeEmailIdWelsh, appealCreatedAppointeeSmsIdWelsh);
@@ -292,7 +282,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForPaperCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
             BASE_PATH_TYAN + "appointee/paper-" + EVIDENCE_REMINDER.getId() + "CallbackWelsh.json");
@@ -314,7 +303,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendPaperAppealDormantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_DORMANT, BASE_PATH_TYAN + "paper-" + APPEAL_DORMANT.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(
@@ -325,14 +313,12 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendOralAppealDormantNotificationWelsh() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_DORMANT, BASE_PATH_TYAN + "oral-" + APPEAL_DORMANT.getId() + "CallbackWelsh.json");
         tryFetchNotificationsForTestCase(appealDormantOralJointPartyEmailTemplateIdWelsh, appealDormantOralAppellantEmailTemplateIdWelsh);
     }
 
     @Test
-    @Ignore
     public void shouldSendAppealLapsedNotificationToAppointeeJointPartyAndRep() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_LAPSED,
             "tyanotifications/appointee/" + APPEAL_LAPSED.getId() + "CallbackWelsh.json");
@@ -356,7 +342,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeAppealWithdrawnNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(APPEAL_WITHDRAWN,
             "tyanotifications/appointee/" + APPEAL_WITHDRAWN.getId() + "CallbackWelsh.json");
@@ -383,7 +368,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     public void shouldSendAppointeeEvidenceReminderForOralCaseNotification() throws NotificationClientException, IOException {
         simulateCcdCallback(EVIDENCE_REMINDER,
             "tyanotifications/appointee/oral-" + EVIDENCE_REMINDER.getId() + "CallbackWelsh.json");
@@ -405,7 +389,6 @@ public class WelshNotificationsFunctionalTest extends AbstractFunctionalTest {
     }
 
     @Test
-    @Ignore
     @Parameters(method = "docmosisTestSetup")
     public void shouldSendDocmosisLettersViaGovNotify(NotificationEventType notificationEventType,
                                                       Optional<String> resourceParam,

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/WithRepresentativePersonalisationTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/sya/notifications/WithRepresentativePersonalisationTest.java
@@ -5,7 +5,6 @@ import static uk.gov.hmcts.reform.sscs.tyanotifications.domain.notify.Notificati
 import java.lang.reflect.Field;
 import java.util.List;
 import junitparams.Parameters;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.sscs.functional.tyanotifications.AbstractFunctionalTest;
@@ -92,7 +91,6 @@ public class WithRepresentativePersonalisationTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     @Parameters(method = "eventTypeAndSubscriptions")
     public void givenEventAndRepsSubscription_shouldSendNotificationToReps(NotificationEventType notificationEventType)
         throws Exception {
@@ -111,7 +109,6 @@ public class WithRepresentativePersonalisationTest extends AbstractFunctionalTes
     }
 
     @Test
-    @Ignore
     public void givenHearingPostponedEventAndRepsSubscription_shouldSendEmailOnlyNotificationToReps()
         throws Exception {
 


### PR DESCRIPTION
Reverts hmcts/sscs-tribunals-case-api#4133