### PR TITLE
Change FTs to fetch correspondence for only 1 test

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -112,7 +112,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
   ]
 }
 
-def branchesToSync = ['demo', 'ithc', 'perftest']
+def branchesToSync = ['ithc', 'perftest']
 
 withPipeline(type, product, component) {
     def githubApi = new GithubAPI(this)

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/handlers/AdminAppealWithdrawnNotificationsTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/functional/tyanotifications/handlers/AdminAppealWithdrawnNotificationsTest.java
@@ -71,7 +71,6 @@ public class AdminAppealWithdrawnNotificationsTest extends AbstractFunctionalTes
     }
 
     private boolean fetchLettersFromCase(int expectedNumLetters, String subscription) {
-        int fetchCount = 0;
         do {
             if (getNumberOfLetterCorrespondence(subscription) == expectedNumLetters) {
                 return true;


### PR DESCRIPTION
- Currently these tests are very flaky because we are waiting for correspondence pdf to be attached on the case. 
- This process is async, we poll the pdf from gov notify in an async process and attach it to the case. 
- This can take up a maximum of 10-15 minutes as discussed with Gov Notify before. 
- Since, we didn't want to remove the capability of testing the pdf attaching process, I am just limiting to one test while other 2 just confirm that letter has been sent to gov notify. 
- Also increased the timeout the test to 10 minutes. Though its a bit too much, its betetr than rerunning whole pipeline.
- An example case where i saw that the test failed, but pdf eventually got attached after ~7 mins.
- Timings of the pdf names are misleading, its the time when notification is sent to Gov notify, not when its attached to case.
<img width="1432" alt="Screenshot 2024-11-20 at 11 23 16" src="https://github.com/user-attachments/assets/45209866-7e37-471f-9784-230318431150">
<img width="1436" alt="Screenshot 2024-11-20 at 11 23 28" src="https://github.com/user-attachments/assets/b0e17b8d-8285-4640-a3ee-bfecd4c65f7c">





### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
