### PR TITLE
SSCSCI-1561: hide caseOutcomeMigration event

### DIFF
--- a/.github/workflows/ccd-diff.yaml
+++ b/.github/workflows/ccd-diff.yaml
@@ -58,10 +58,10 @@ jobs:
         run: |
           echo "${{ steps.ccd-diff.outputs.content }}"
       - name: Add report
-        uses: thollander/actions-comment-pull-request@v1
+        uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
             # CCD diff report
             ${{ steps.ccd-diff.outputs.content }}
-          comment_tag: CCD diff report
+          comment-tag: CCD_diff_report
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/definitions/benefit/sheets/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/benefit/sheets/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -972,7 +972,7 @@
   {"LiveFrom": "03/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "removeCaseOutcome", "AccessProfile": "caseworker-sscs-superuser", "CRUD": "CRUD"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs-systemupdate", "CRUD": "CRU"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs", "CRUD": "R"},
-  {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs-superuser", "CRUD": "CRU"},
+  {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs-superuser", "CRUD": "R"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "clearExpiredFilters", "AccessProfile": "caseworker-sscs-systemupdate", "CRUD": "CRU"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "clearExpiredFilters", "AccessProfile": "caseworker-sscs", "CRUD": "R"}
 ]

--- a/definitions/benefit/sheets/AuthorisationCaseEvent/AuthorisationCaseEvent.json
+++ b/definitions/benefit/sheets/AuthorisationCaseEvent/AuthorisationCaseEvent.json
@@ -972,7 +972,6 @@
   {"LiveFrom": "03/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "removeCaseOutcome", "AccessProfile": "caseworker-sscs-superuser", "CRUD": "CRUD"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs-systemupdate", "CRUD": "CRU"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs", "CRUD": "R"},
-  {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "caseOutcomeMigration", "AccessProfile": "caseworker-sscs-superuser", "CRUD": "R"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "clearExpiredFilters", "AccessProfile": "caseworker-sscs-systemupdate", "CRUD": "CRU"},
   {"LiveFrom": "02/12/2024", "CaseTypeID": "Benefit", "CaseEventID": "clearExpiredFilters", "AccessProfile": "caseworker-sscs", "CRUD": "R"}
 ]

--- a/definitions/benefit/sheets/CaseEvent/CaseEvent.json
+++ b/definitions/benefit/sheets/CaseEvent/CaseEvent.json
@@ -3263,7 +3263,7 @@
     "CaseTypeID": "Benefit",
     "ID": "caseOutcomeMigration",
     "Name": "Case migrated automatically",
-    "DisplayOrder": 142,
+    "DisplayOrder": 10007,
     "PreConditionState(s)": "*",
     "PostConditionState": "*",
     "SecurityClassification": "Public"


### PR DESCRIPTION
### Jira link

See [SSCSCI-1561](https://tools.hmcts.net/jira/browse/SSCSCI-1561)

### Change description

- Changed caseOutcomeMigration event access to read only for anyone but `systemupdate` to hide it in Next Step
- Updated GitHub action to avoid reposting CCD diff report 

### Testing done

#### Test migration result for hearingOutcomesMigration:

> u.g.h.r.m.service.CaseOutcomeMigrationServiceImpl Completed hearing found for case id 1736937034340606 with hearing id 2030031053
> u.g.h.r.m.service.CaseOutcomeMigrationServiceImpl case outcome found with value 9 and set to null for case id 1736937034340606
> u.g.h.r.m.service.CaseOutcomeMigrationServiceImpl did Po Attend found with value No and set to null for case id 1736937034340606
> u.g.h.r.m.service.CaseOutcomeMigrationServiceImpl Completed migration for case outcome migration. Case id: 1736937034340606
> u.g.hmcts.reform.migration.CaseMigrationProcessor Case 1736937034340606 successfully updated
> u.g.hmcts.reform.migration.CaseMigrationProcessor -----------------------------------------
> Data migration completed

<img width="550" alt="SSCSCI-1561_migration_outcome" src="https://github.com/user-attachments/assets/c20f93cb-58cf-4855-91ab-3dcae309ef68" />

#### Next step with caseworker:

<img width="280" alt="Next_Step_caseworker" src="https://github.com/user-attachments/assets/ff81de6f-9d2c-4544-abaf-9364f181e7c4" />

#### Next step with superuser:

<img width="280" alt="Next_Step_superuser" src="https://github.com/user-attachments/assets/686e73ed-3fd5-468b-813a-91d51d7b2c76" />

#### Next step with systemupdate role:

<img width="240" alt="Screenshot 2025-01-22 at 11 54 49" src="https://github.com/user-attachments/assets/98a9fd1e-8fd1-4c13-a2cc-27f93eafbe5f" />

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
