### PR TITLE
Revert "Update repo due to a change in the way bitnami Helm charts are consumed"

### DIFF
--- a/charts/sscs-tribunals-api/Chart.yaml
+++ b/charts/sscs-tribunals-api/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sscs-tribunals-api
 home: https://github.com/hmcts/sscs-tribunals-case-api
-version: 0.0.180
+version: 0.0.179
 description: SSCS Tribunals Case API
 maintainers:
   - name: HMCTS SSCS Team
@@ -38,7 +38,7 @@ dependencies:
     condition: sscs-tribunals-frontend.enabled
   - name: redis
     version: 20.7.0
-    repository: "oci://registry-1.docker.io/bitnamicharts"
+    repository: "https://charts.bitnami.com/bitnami"
     condition: redis.enabled
   - name: em-ccdorc
     version: 2.0.25


### PR DESCRIPTION
Reverts hmcts/sscs-tribunals-case-api#4441