### PR TITLE
Update wa system user classification to RESTRICTED

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/config/HighLevelDataSetupApp.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/config/HighLevelDataSetupApp.java
@@ -35,7 +35,7 @@ public class HighLevelDataSetupApp extends DataLoaderToDefinitionStore {
         new CcdRoleConfig("caseworker-sscs-pcqextractor", "PUBLIC"),
         new CcdRoleConfig("caseworker-sscs-hmrcresponsewriter", "PUBLIC"),
         new CcdRoleConfig("caseworker-sscs-ibcaresponsewriter", "PUBLIC"),
-        new CcdRoleConfig("caseworker-wa-task-configuration", "PUBLIC"),
+        new CcdRoleConfig("caseworker-wa-task-configuration", "RESTRICTED"),
         new CcdRoleConfig("caseworker-ras-validation", "PUBLIC"),
         new CcdRoleConfig("GS_profile", "PUBLIC")
     };


### PR DESCRIPTION
- We have noticed that some service teams using WA have a CCD HighLevelDataSetupApp file which is configuring the WA system user role with a security classification of PUBLIC . 
- However this should actually be set to RESTRICTED since this system user ought to be able to access all Cases.  Since this runs in production this will mean that any Task initiations related to a restricted case will fail.
- Please can we ask all these service teams (sscs, prl, civil, civil general apps, sptribs) to urgently update the security classification to RESTRICTED to prevent any failures in the above scenario.