### PR TITLE
Ni postcode venue

### DIFF
--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-caseUpdated.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-caseUpdated.json
@@ -268,7 +268,7 @@
     "LiveFrom": "01/01/2018",
     "FieldDisplayOrder": 16,
     "PageID": "1.0",
-    "EventElementLabel": "Does the appellant live in England, Wales or Scotland?"
+    "EventElementLabel": "Does the appellant live in England, Wales, Scotland or Northern Ireland?"
   },
   {
     "CaseEventID": "caseUpdated",

--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-nonprod.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-nonprod.json
@@ -1,0 +1,13 @@
+[
+  {
+    "CaseEventID": "incompleteApplicationReceived",
+    "CaseFieldID": "appeal",
+    "ListElementCode": "appellant.address.inMainlandUk",
+    "DisplayContext": "MANDATORY",
+    "FieldShowCondition": "appeal.benefitType.descriptionSelection=\"093\"",
+    "LiveFrom": "01/01/2018",
+    "FieldDisplayOrder": 8,
+    "PageID": "1.0",
+    "EventElementLabel": "Does the appellant live in England, Wales, Scotland or Northern Ireland?"
+  }
+]

--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-prod.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-prod.json
@@ -1,0 +1,13 @@
+[
+  {
+  "CaseEventID": "incompleteApplicationReceived",
+  "CaseFieldID": "appeal",
+  "ListElementCode": "appellant.address.inMainlandUk",
+  "DisplayContext": "MANDATORY",
+  "FieldShowCondition": "appeal.benefitType.descriptionSelection=\"093\"",
+  "LiveFrom": "01/01/2018",
+  "FieldDisplayOrder": 8,
+  "PageID": "1.0",
+  "EventElementLabel": "Does the appellant live in England, Wales or Scotland?"
+  }
+]

--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived.json
@@ -264,7 +264,7 @@
     "LiveFrom": "01/01/2018",
     "FieldDisplayOrder": 8,
     "PageID": "1.0",
-    "EventElementLabel": "Does the appellant live in England, Wales or Scotland?"
+    "EventElementLabel": "Does the appellant live in England, Wales, Scotland or Northern Ireland?"
   },
   {
     "CaseEventID": "incompleteApplicationReceived",

--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived.json
@@ -258,17 +258,6 @@
   {
     "CaseEventID": "incompleteApplicationReceived",
     "CaseFieldID": "appeal",
-    "ListElementCode": "appellant.address.inMainlandUk",
-    "DisplayContext": "MANDATORY",
-    "FieldShowCondition": "appeal.benefitType.descriptionSelection=\"093\"",
-    "LiveFrom": "01/01/2018",
-    "FieldDisplayOrder": 8,
-    "PageID": "1.0",
-    "EventElementLabel": "Does the appellant live in England, Wales, Scotland or Northern Ireland?"
-  },
-  {
-    "CaseEventID": "incompleteApplicationReceived",
-    "CaseFieldID": "appeal",
     "ListElementCode": "appellant.address.ukPortOfEntryList",
     "DisplayContext": "OPTIONAL",
     "FieldShowCondition": "appeal.appellant.address.inMainlandUk=\"No\"",

--- a/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-updateOtherPartyData.json
+++ b/definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-updateOtherPartyData.json
@@ -141,7 +141,7 @@
     "FieldDisplayOrder": 12,
     "PageID": "1.0",
     "FieldShowCondition": "appeal.benefitType.code=\"infectedBloodCompensation\"",
-    "EventElementLabel": "Does the appellant live in England, Wales or Scotland?"
+    "EventElementLabel": "Does the appellant live in England, Wales, Scotland or Northern Ireland?"
   },
   {
     "CaseEventID": "updateOtherPartyData",

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -220,6 +220,8 @@ evidenceDescription:
             template:
                 path: /templates/evidenceDescriptionWelsh.html
 feature:
+    ibc-ni-postcodes:
+        enabled: ${IBC_NI_POSTCODES_FEATURE:false}
     case-access-management:
         enabled: ${CASE_ACCESS_MANAGEMENT_FEATURE:false}
     deleted-redacted-doc:

--- a/src/main/resources/templates/appellant_appeal_template.html
+++ b/src/main/resources/templates/appellant_appeal_template.html
@@ -176,7 +176,7 @@
 
         {% if isIbcCase %}
         <div>
-            <dt class="cya-question">Does the appellant live in England, Wales or Scotland?</dt>
+            <dt class="cya-question">Does the appellant live in England, Wales, Scotland or Northern Ireland?</dt>
             <dd class="cya-answer">{{ PdfWrapper.sscsCaseData.appeal.appellant.address.inMainlandUk }}</dd>
         </div>
         {% endif %}

--- a/src/main/resources/templates/appellant_appeal_welsh_template.html
+++ b/src/main/resources/templates/appellant_appeal_welsh_template.html
@@ -691,7 +691,7 @@
 
         {% if isIbcCase %}
         <div>
-            <dt class="cya-question">Does the appellant live in England, Wales or Scotland?</dt>
+            <dt class="cya-question">Does the appellant live in England, Wales, Scotland or Northern Ireland?</dt>
             <dd class="cya-answer">{{ PdfWrapper.sscsCaseData.appeal.appellant.address.inMainlandUk }}</dd>
         </div>
         {% endif %}


### PR DESCRIPTION
# Update CaseEventToComplexTypes for incompleteApplicationReceived Event in Non-Prod Environment

### Jira link

See [SSCSCI-1823](https://tools.hmcts.net/jira/browse/SSCSCI-1823)

### Summary
Update `EventElementLabel` for `appellant.address.inMainlandUk` in `CaseEventToComplexTypes-incompleteApplicationReceived` file to align the EventElementLabel for the appellant.address.inMainlandUk field with the requirements for the non-production environment.

I've also added tests 

Tested and working correctly locally. 

### Changes Made
Updated the EventElementLabel for the appellant.address.inMainlandUk field in the CaseEventToComplexTypes-incompleteApplicationReceived-nonprod.json file to:
- New Label: "Does the appellant live in England, Wales, Scotland or Northern Ireland?"

### Files Modified
- definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-nonprod.json
- definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived-prod.json
- definitions/benefit/sheets/CaseEventToComplexTypes/CaseEventToComplexTypes-incompleteApplicationReceived.json

### Reason for Change

`EventElementLabel` label requires update to include "Northern Ireland". 

# Testing
- Verified that the updated label is correctly reflected in the non-production environment.
- Ensured no other fields or configurations were impacted by this change.s, exercise the code before and after the change and verify the behavior remains the same.
