### PR TITLE
SSCSCI-1898 Missing Error Message for Has Representative

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandler.java
@@ -71,7 +71,7 @@ public class CreateCaseMidEventHandler implements PreSubmitCallbackHandler<SscsC
 
         errorResponse.addErrors(validateAddress(caseData.getAppeal().getAppellant()));
 
-        if (isYes(caseData.getAppeal().getRep().getHasRepresentative())
+        if (caseData.getAppeal().getRep() != null && isYes(caseData.getAppeal().getRep().getHasRepresentative())
                 && (isEmpty(caseData.getAppeal().getRep().getAddress())
                 || isEmpty(caseData.getAppeal().getRep().getAddress().getInMainlandUk()))) {
             errorResponse.addError("You must enter Living in the UK for the representative");


### PR DESCRIPTION
SSCSCI-1898 Missing Error Message for Has Representative
https://tools.hmcts.net/jira/browse/SSCSCI-1898

No new message needed, the root cause was a null pointer. This PR fix it