### PR TITLE
Perform null safe check when checking type of hearing in retrieving duration

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/util/SscsUtil.java
@@ -746,12 +746,11 @@ public class SscsUtil {
 
     public static Integer getDurationForAdjournment(SscsCaseData sscsCaseData, HearingDurationsService hearingDurationsService) {
         HearingDuration hearingDuration = hearingDurationsService.getHearingDuration(sscsCaseData.getBenefitCode(), sscsCaseData.getIssueCode());
-        Integer duration = sscsCaseData.getAdjournment().getTypeOfNextHearing().equals(AdjournCaseTypeOfHearing.PAPER)
+        return AdjournCaseTypeOfHearing.PAPER.equals(sscsCaseData.getAdjournment().getTypeOfNextHearing())
                 ? hearingDuration.getDurationPaper()
                 : YesNo.isYes(sscsCaseData.getAdjournment().getInterpreterRequired())
                 ? hearingDuration.getDurationInterpreter()
                 : hearingDuration.getDurationFaceToFace();
-        return duration;
     }
 
     public static boolean hasChannelChangedForAdjournment(SscsCaseData caseData) {


### PR DESCRIPTION
Fix for below issue
`Cannot invoke "uk.gov.hmcts.reform.sscs.ccd.domain.AdjournCaseTypeOfHearing.equals(Object)" because the return value of "uk.gov.hmcts.reform.sscs.ccd.domain.Adjournment.getTypeOfNextHearing()" is null`

