### PR TITLE
Update ibca reference regex to allow fourth character to be either letter or digit

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidator.java
@@ -759,7 +759,7 @@ public class SscsCaseValidator implements CaseValidator {
     private void checkAppellantIbcaReference(Appellant appellant, String personType) {
         if (appellant != null && appellant.getIdentity() != null && appellant.getIdentity().getIbcaReference() != null) {
             if (!String.join("", appellant.getIdentity().getIbcaReference().split(" ")).matches(
-                "^[A-z]\\d{2}[A-z]\\d{2}$")) {
+                "^[A-Za-z]\\d{2}[A-Za-z0-9]\\d{2}$")) {
                 warnings.add(getMessageByCallbackType(callbackType, personType,
                     getWarningMessageName(personType, appellant) + IBCA_REFERENCE, IS_INVALID));
             }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandler.java
@@ -31,13 +31,13 @@ public class CreateCaseMidEventHandler implements PreSubmitCallbackHandler<SscsC
             "An IBCA reference is required to update this case. The IBCA Reference format is 1 letter, 2 digits, 1 letter, 2 digits e.g. E24A45.";
 
     public static final String IBCA_REFERENCE_VALIDATION_ERROR =
-            "The IBCA reference must be 6 characters and match the format. The IBCA Reference format is 1 letter, 2 digits, 1 letter, 2 digits e.g. E24A45";
+            "The IBCA reference must be 6 characters and match the format. The IBCA Reference format is 1 letter, 2 digits, 1 letter or digit, 2 digits e.g. E24A45";
 
     private static final String HEARING_ROUTE_ERROR_MESSAGE = "Hearing route must be List Assist";
 
     private final PostcodeValidator postcodeValidator = new PostcodeValidator();
 
-    private static final Pattern IBCA_REFERENCE_REGEX = Pattern.compile("^[A-Za-z]\\d{2}[A-HJKMNP-Z]\\d{2}$");
+    private static final Pattern IBCA_REFERENCE_REGEX = Pattern.compile("^[A-Za-z]\\d{2}[A-Za-z0-9]\\d{2}$");
 
     @Override
     public boolean canHandle(CallbackType callbackType, Callback<SscsCaseData> callback) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidatorTest.java
@@ -66,6 +66,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.sscs.bulkscan.bulkscancore.domain.ExceptionRecord;
@@ -1176,6 +1177,34 @@ public class SscsCaseValidatorTest {
         assertTrue(actualError.contains("person1_as_poa"));
         assertTrue(actualError.contains("person1_for_self"));
         assertTrue(actualError.contains("person1_for_person_under_18"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"A12112", "A11A12", "A12b12", "A12012"})
+    public void givenSscs8ContainValidIbcaReferenceWithFourthCharacterAsDigitOrNumber_thenDoNotAddAWarningOrError(String ibcaReference) {
+        Appellant appellant = buildAppellant(false);
+        appellant.getIdentity().setIbcaReference(ibcaReference);
+        ocrCaseData.put(IBC_ROLE_FOR_SELF, true);
+
+        CaseResponse response = validator
+                .validateExceptionRecord(transformResponse, exceptionRecord, buildMinimumAppealData(appellant, true, FormType.SSCS8),
+                        false);
+
+        assertThat(response.getWarnings()).doesNotContain("person1_ibca_reference is invalid");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"A1211R", "A11A1F"})
+    public void givenSscs8ContainInValidIbcaReferenceWithFourthCharacterAsDigitOrNumber_thenAddAWarnings(String ibcaReference) {
+        Appellant appellant = buildAppellant(false);
+        appellant.getIdentity().setIbcaReference(ibcaReference);
+        ocrCaseData.put(IBC_ROLE_FOR_SELF, true);
+
+        CaseResponse response = validator
+                .validateExceptionRecord(transformResponse, exceptionRecord, buildMinimumAppealData(appellant, true, FormType.SSCS8),
+                        false);
+
+        assertThat(response.getWarnings()).contains("person1_ibca_reference is invalid");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/bulkscan/validators/SscsCaseValidatorTest.java
@@ -1185,12 +1185,14 @@ public class SscsCaseValidatorTest {
         Appellant appellant = buildAppellant(false);
         appellant.getIdentity().setIbcaReference(ibcaReference);
         ocrCaseData.put(IBC_ROLE_FOR_SELF, true);
+        AppealReasons appealReasons = AppealReasons.builder().reasons(List.of(AppealReason.builder().value(AppealReasonDetails.builder().reason("some reason").description("some description").build()).build())).build();
 
         CaseResponse response = validator
-                .validateExceptionRecord(transformResponse, exceptionRecord, buildMinimumAppealData(appellant, true, FormType.SSCS8),
+                .validateExceptionRecord(transformResponse, exceptionRecord,
+                        buildMinimumAppealDataWithBenefitTypeWithAppealReasons(INFECTED_BLOOD_COMPENSATION.getShortName(), appellant, true, FormType.SSCS8, appealReasons),
                         false);
 
-        assertThat(response.getWarnings()).doesNotContain("person1_ibca_reference is invalid");
+        assertThat(response.getWarnings()).isEmpty();
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/createcase/CreateCaseMidEventHandlerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -264,8 +265,9 @@ public class CreateCaseMidEventHandlerTest {
         assertThat(response.getWarnings()).contains(IBCA_REFERENCE_VALIDATION_ERROR);
     }
 
-    @Test
-    void shouldNotReturnErrorsOnMidEventForIbcaCase() {
+    @ParameterizedTest
+    @ValueSource(strings = {"A12112", "A11A12", "A12b12", "A12012"})
+    void shouldNotReturnErrorsOnMidEventForIbcaCase(String ibcaReference) {
         SscsCaseData caseData = SscsCaseData.builder()
                 .appeal(Appeal.builder()
                         .appellant(Appellant.builder()
@@ -281,7 +283,7 @@ public class CreateCaseMidEventHandlerTest {
                                         .inMainlandUk(NO)
                                         .build()
                                 )
-                                .identity(Identity.builder().ibcaReference("E24A45").build())
+                                .identity(Identity.builder().ibcaReference(ibcaReference).build())
                                 .build()
                         )
                         .rep(Representative.builder().build())


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/SSCSCI-2481


### Change description

**Existing regex**  `[A-z]\d{2}[A-z]\d{2}$` 

> Letter + 2 digits + Letter + 2 digits

 **Updated regex** `^[A-Za-z]\d{2}[A-Za-z0-9]\d{2}$`

> Letter + digit + digit + (letter OR digit) + digit + digit

- Also regex is now consistent in all places as it was bit inconsistent in create case and case update handlers as below.

`^[A-Za-z]\d{2}[A-HJKMNP-Z]\d{2}$`

> Letter + digit + digit + (restricted uppercase letter) + digit + digit

**Below journeys should be QA verified**
- Create case for IBCA
- Update case for IBCA
- Bulk scan exception record for IBCA
- This is backend change and there needs to be corresponding change in SYA 
