### PR TITLE
Update plugin version to 0.12.70 as previous version doesn't run dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.gorylenko.gradle-git-properties' version '2.5.0'
     id 'com.github.ben-manes.versions' version '0.53.0'
-    id 'org.owasp.dependencycheck' version '12.2.2'
+    id 'org.owasp.dependencycheck' version '12.1.3'
     id 'au.com.dius.pact' version '4.6.19'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.1856'
     id 'info.solidsoft.pitest' version '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'org.sonarqube' version '6.2.0.5505'
     id 'jacoco'
     id 'org.springframework.boot' version '3.5.6'
-    id 'uk.gov.hmcts.java' version '0.12.67'
+    id 'uk.gov.hmcts.java' version '0.12.70'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.gorylenko.gradle-git-properties' version '2.5.0'
     id 'com.github.ben-manes.versions' version '0.53.0'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.gorylenko.gradle-git-properties' version '2.5.0'
     id 'com.github.ben-manes.versions' version '0.53.0'
-    id 'org.owasp.dependencycheck' version '12.1.3'
+    id 'org.owasp.dependencycheck' version '12.2.2'
     id 'au.com.dius.pact' version '4.6.19'
     id 'com.github.hmcts.rse-cft-lib' version '0.19.1856'
     id 'info.solidsoft.pitest' version '1.15.0'
@@ -303,50 +303,9 @@ dependencyManagement {
             mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2025.0.2'
         }
 
-        // CVE-2025-66168, CVE-2026-34197, CVE-2026-40466, CVE-2026-41044, CVE-2026-39304, CVE-2026-41043, CVE-2026-33227
-        //dependency group: 'org.apache.activemq', name: 'activemq-client', version: '6.2.5'
-
         // CVE-2023-36415, CVE-2024-35255
         dependency group: 'com.azure', name: 'azure-identity', version: '1.18.3'
         dependency group: 'com.microsoft.azure', name: 'msal4j', version: '1.24.1'
-
-        // CVE-2025-48924
-        //dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
-
-        // CVE-2026-41417
-//        dependencySet(group: 'io.netty', version: '4.2.13.Final') {
-//            entry 'netty-buffer'
-//            entry 'netty-codec'
-//            entry 'netty-codec-dns'
-//            entry 'netty-codec-http'
-//            entry 'netty-codec-http2'
-//            entry 'netty-codec-socks'
-//            entry 'netty-common'
-//            entry 'netty-handler'
-//            entry 'netty-handler-proxy'
-//            entry 'netty-resolver'
-//            entry 'netty-resolver-dns'
-//            entry 'netty-resolver-dns-classes-macos'
-//            entry 'netty-resolver-dns-native-macos'
-//            entry 'netty-transport'
-//            entry 'netty-transport-classes-epoll'
-//            entry 'netty-transport-classes-kqueue'
-//            entry 'netty-transport-native-epoll'
-//            entry 'netty-transport-native-kqueue'
-//            entry 'netty-transport-native-unix-common'
-//        }
-
-        // CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477
-//        dependencySet(group: 'org.apache.logging.log4j', version: '2.26.0') {
-//            entry 'log4j-api'
-//            entry 'log4j-core'
-//        }
-
-        // CVE-2020-29582
-//        dependencySet(group: 'com.squareup.okio', version: '3.17.0') {
-//            entry 'okio'
-//            entry 'okio-jvm'
-//        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'pmd'
     id 'org.sonarqube' version '6.2.0.5505'
     id 'jacoco'
-    id 'org.springframework.boot' version '3.5.6'
+    id 'org.springframework.boot' version '3.5.14'
     id 'uk.gov.hmcts.java' version '0.12.70'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.gorylenko.gradle-git-properties' version '2.5.0'
@@ -300,14 +300,67 @@ tasks.register('runGitPreCommitTasks') {
 dependencyManagement {
     dependencies {
         imports {
-            mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2025.0.0'
+            mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2025.0.2'
         }
+
+        // CVE-2025-66168, CVE-2026-34197, CVE-2026-40466, CVE-2026-41044, CVE-2026-39304, CVE-2026-41043, CVE-2026-33227
+        //dependency group: 'org.apache.activemq', name: 'activemq-client', version: '6.2.5'
+
+        // CVE-2023-36415, CVE-2024-35255
+        dependency group: 'com.azure', name: 'azure-identity', version: '1.18.3'
+        dependency group: 'com.microsoft.azure', name: 'msal4j', version: '1.24.1'
+
+        // CVE-2025-48924
+        //dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.20.0'
+
+        // CVE-2026-41417
+//        dependencySet(group: 'io.netty', version: '4.2.13.Final') {
+//            entry 'netty-buffer'
+//            entry 'netty-codec'
+//            entry 'netty-codec-dns'
+//            entry 'netty-codec-http'
+//            entry 'netty-codec-http2'
+//            entry 'netty-codec-socks'
+//            entry 'netty-common'
+//            entry 'netty-handler'
+//            entry 'netty-handler-proxy'
+//            entry 'netty-resolver'
+//            entry 'netty-resolver-dns'
+//            entry 'netty-resolver-dns-classes-macos'
+//            entry 'netty-resolver-dns-native-macos'
+//            entry 'netty-transport'
+//            entry 'netty-transport-classes-epoll'
+//            entry 'netty-transport-classes-kqueue'
+//            entry 'netty-transport-native-epoll'
+//            entry 'netty-transport-native-kqueue'
+//            entry 'netty-transport-native-unix-common'
+//        }
+
+        // CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477
+//        dependencySet(group: 'org.apache.logging.log4j', version: '2.26.0') {
+//            entry 'log4j-api'
+//            entry 'log4j-core'
+//        }
+
+        // CVE-2020-29582
+//        dependencySet(group: 'com.squareup.okio', version: '3.17.0') {
+//            entry 'okio'
+//            entry 'okio-jvm'
+//        }
     }
+}
+
+ext {
+    set('activemq.version', '6.2.5')
+    set('netty.version', '4.2.13.Final')
+    set('log4j2.version', '2.26.0')
+    set('commons-lang3.version', '3.20.0')
+    set('kotlin.version', '2.2.21')
 }
 
 def versions = [
         springboot     : springBoot.class.package.implementationVersion,
-        springsecurity : '6.5.5',
+        springsecurity : '6.5.10',
         jackson        : '2.19.0',
         lombok         : '1.18.38',
         commonsio      : '2.19.0',
@@ -375,32 +428,32 @@ dependencies {
 
     implementation group: 'com.azure', name: 'azure-core', version: '1.55.3'
     implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.11'
-    implementation group: 'com.azure', name: 'azure-servicebus-jms', version: '2.0.0'
-    implementation group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '3.7.2'
+    implementation group: 'com.azure', name: 'azure-servicebus-jms', version: '2.1.0'
+    implementation group: 'com.microsoft.azure', name: 'applicationinsights-web', version: '3.7.8'
 
     implementation group: 'jakarta.inject', name: 'jakarta.inject-api', version: '2.0.1'
     implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
     implementation group: 'javax.validation', name: 'validation-api', version: '2.0.1.Final'
     implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
 
-    implementation group: 'com.mchange', name: 'c3p0', version: '0.11.2'
+    implementation group: 'com.mchange', name: 'c3p0', version: '0.13.0'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '11.8.2'
     implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '11.8.2'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.7'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.11'
     implementation group: 'org.quartz-scheduler', name: 'quartz', version: '2.5.0'
 
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.7.6'
     implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '9.2.4'
 
-    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
-    implementation group: 'com.squareup.okio', name: 'okio-jvm', version: '3.16.0'
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '5.3.2'
+    implementation group: 'com.squareup.okio', name: 'okio-jvm', version: '3.17.0'
     implementation group: 'commons-io', name: 'commons-io', version:  versions.commonsio
 
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.8.8'
 
     implementation group: 'com.google.guava', name: 'guava', version: '33.4.8-jre'
-    implementation group: 'com.opencsv', name: 'opencsv', version: '5.11'
+    implementation group: 'com.opencsv', name: 'opencsv', version: '5.12.0'
     implementation group: 'net.objectlab.kit', name: 'datecalc-jdk8', version: '1.4.8'
     implementation group: 'org.commonmark', name: 'commonmark', version: '0.24.0'
     implementation group: 'org.overviewproject', name: 'mime-types', version: '2.0.0'
@@ -412,11 +465,11 @@ dependencies {
 
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.5.0'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.13.1'
-    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.5'
-    implementation group: 'org.apache.pdfbox', name: 'xmpbox', version: '3.0.5'
+    implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.7'
+    implementation group: 'org.apache.pdfbox', name: 'xmpbox', version: '3.0.7'
     implementation group: 'org.apache.tika', name: 'tika-core', version: '3.2.3'
     implementation group: 'org.apache.tika', name: 'tika-parsers', version: '3.2.3'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.8'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.22'
 
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,7 @@ ext {
     set('log4j2.version', '2.26.0')
     set('commons-lang3.version', '3.20.0')
     set('kotlin.version', '2.2.21')
+    set('tomcat.version', '10.1.55')
 }
 
 def versions = [
@@ -428,7 +429,7 @@ dependencies {
     implementation group: 'org.apache.pdfbox', name: 'xmpbox', version: '3.0.7'
     implementation group: 'org.apache.tika', name: 'tika-core', version: '3.2.3'
     implementation group: 'org.apache.tika', name: 'tika-parsers', version: '3.2.3'
-    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.22'
+    implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.55'
 
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,2 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd"/>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until = "2026-06-03">
+        <cve>CVE-2025-21199</cve>
+        <cve>CVE-2026-23907</cve>
+        <cve>CVE-2026-33929</cve>
+        <cve>CVE-2023-36415</cve>
+        <cve>CVE-2024-35255</cve>
+    </suppress>
+</suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,5 +7,6 @@
         <cve>CVE-2023-36415</cve>
         <cve>CVE-2024-35255</cve>
         <cve>CVE-2025-15104</cve>
+        <cve>CVE-2026-33117</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -6,5 +6,6 @@
         <cve>CVE-2026-33929</cve>
         <cve>CVE-2023-36415</cve>
         <cve>CVE-2024-35255</cve>
+        <cve>CVE-2025-15104</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description

#### Updates

| Name | Change | Relates to |
| --- | --- | --- |
| [org.springframework.boot](https://spring.io/projects/spring-boot) | `3.5.6` -> `3.5.14` | CVE-2026-22731, CVE-2026-22733, CVE-2026-40972, CVE-2026-40975, CVE-2026-40973, CVE-2026-40977 |
| uk.gov.hmcts.java | `0.12.67` -> `0.12.70` |  |
| org.springframework.cloud | `2025.0.0` -> `2025.0.2` |  |
| com.azure:azure-identity | `1.18.0` -> `1.18.3` | CVE-2023-36415, CVE-2024-35255 |
| com.microsoft.azure:msal4j | `1.23.1` -> `1.24.1` | CVE-2024-35255 |
| activemq | `6.1.8` -> `6.2.5` | CVE-2025-66168, CVE-2026-34197, CVE-2026-40466, CVE-2026-41044, CVE-2026-39304, CVE-2026-41043, CVE-2026-33227 |
| netty | `4.1.132` -> `4.2.13.Final` | CVE-2026-41417 |
| log4j2 | `2.24.3` -> `2.26.0` | CVE-2026-34478, CVE-2026-34479, CVE-2026-34480, CVE-2025-68161, CVE-2026-34477 |
| commons-lang3 | `3.17.0` -> `3.20.0` | CVE-2025-48924 |
| kotlin | `1.9.25` -> `2.2.21` | CVE-2020-29582 |
| spring-security | `6.5.5` -> `6.5.10` | CVE-2026-22732, CVE-2026-22748, CVE-2026-22751, CVE-2026-22746 |
| com.azure:azure-servicebus-jms | `2.0.0` -> `2.1.0` | CVE-2023-36415, CVE-2024-35255 |
| com.microsoft.azure:applicationinsights-web | `3.7.2` -> `3.7.8` | CVE-2023-36415, CVE-2024-35255 |
| com.mchange:c3p0 | `0.11.2` -> `0.13.0` | CVE-2026-27727 |
| org.postgresql | `42.7.7` -> `42.7.11` | CVE-2026-42198 |
| com.squareup.okhttp3 | `4.12.0` -> `5.3.2` | CVE-2020-29582 |
| com.squareup.okio | `3.16.0` -> `3.17.0` | CVE-2020-29582 |
| com.opencsv | `5.11` -> `5.12.0` | CVE-2025-48734 |
| org.apache.pdfbox | `3.0.5` -> `3.0.7` | CVE-2026-23907, CVE-2026-33929 |
| org.apache.tomcat.embed | `11.0.8` -> `10.1.55` | CVE-2026-43514, CVE-2026-41284, CVE-2026-42498 |

#### False positives so they are suppressed

| CVE | Why |
| --- | --- |
| CVE-2025-21199 | CPE False Positive, flagged for [com.microsoft.azure/applicationinsights-web](https://github.com/Microsoft/ApplicationInsights-Java) but vulnerability affects [Azure Agent for Backup](https://learn.microsoft.com/en-us/azure/backup/about-restore-microsoft-azure-recovery-services) and [Azure Agent for Site Recovery](https://azure.microsoft.com/en-us/products/site-recovery) ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21199)) |
| CVE-2026-23907 | Flagged for the ExtractEmbeddedFiles example in Apache PDFBox, documentation issue. If code doesn't use the example it can be ignored. May need a more thorough examination but found no evidence this time. [Source](https://lists.apache.org/thread/gyfq5tcrxfv7rx0z2yyx4hb3h53ndffw)|
| CVE-2026-33929 | Flagged for the ExtractEmbeddedFiles example in Apache PDFBox, documentation issue. If code doesn't use the example it can be ignored. May need a more thorough examination but found no evidence this time. [Source](https://lists.apache.org/thread/gyfq5tcrxfv7rx0z2yyx4hb3h53ndffw)|
| CVE-2023-36415 | CPE False Positive, flagged for [com.azure:azure-identity:1.18.0](https://github.com/Azure/azure-sdk-for-java) but since we are using the java version and the vulnerability is resolved for `1.10.2`, this can be ignored ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36415)). Consider moving to `com.azure.spring:spring-cloud-azure-starter-servicebus-jms:6.2.0` |
| CVE-2024-35255 | CPE False Positive, flagged for [com.microsoft.azure:msal4j:1.23.1](https://github.com/AzureAD/microsoft-authentication-library-for-java) but since we are using the java version and the vulnerability is resolved for `1.15.1`, this can be ignored ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)). Consider moving to `com.azure.spring:spring-cloud-azure-starter-servicebus-jms:6.2.0` |
| CVE-2025-15104 | CPE False Positive, flagged for [json-schema-validator](https://github.com/networknt/json-schema-validator) but vulnerability affects [The Nu Html Checker](https://github.com/validator/validator) |
| CVE-2026-33117 | CPE False Positive, flagged for `azure-core`, `azure-identity` and `azure-json`. The vulnerability is for [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java) but we only import `azure-core:1.55.3`, `azure-messaging-servicebus:7.17.11`, `azure-servicebus-jms:2.1.0` and `applicationinsights-web`  not the main azure-sdk. The sub-libraries are up-to-date, so ignoring this one. |

### Testing done


### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change