### PR TITLE
SSCSCI: new suppression

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,5 +8,6 @@
         <cve>CVE-2024-35255</cve>
         <cve>CVE-2025-15104</cve>
         <cve>CVE-2026-33117</cve>
+        <cve>CVE-2026-33117</cve>
     </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -8,6 +8,6 @@
         <cve>CVE-2024-35255</cve>
         <cve>CVE-2025-15104</cve>
         <cve>CVE-2026-33117</cve>
-        <cve>CVE-2026-33117</cve>
+        <cve>CVE-2025-7962</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description

Suppressing CVE-2025-7962. This is flagged for `org.eclipse.angus/angus-activation@2.0.3` which this is a transitive dependency via `org.eclipse.angus:jakarta.mail:2.0.5`. The vulnerability itself is fixed in `jakarta.mail:2.0.2`. CPE False Positive, adding to suppressions.

Dependency tree
```
org.eclipse.angus:angus-activation:2.0.3
\--- org.eclipse.angus:jakarta.mail:2.0.5
     \--- org.springframework.boot:spring-boot-starter-mail:3.5.14
          \--- runtimeClasspath
```

### Testing done

Pipeline passes

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

Existing suppressions

| CVE | Why |
| --- | --- |
| CVE-2025-21199 | CPE False Positive, flagged for [com.microsoft.azure/applicationinsights-web](https://github.com/Microsoft/ApplicationInsights-Java) but vulnerability affects [Azure Agent for Backup](https://learn.microsoft.com/en-us/azure/backup/about-restore-microsoft-azure-recovery-services) and [Azure Agent for Site Recovery](https://azure.microsoft.com/en-us/products/site-recovery) ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-21199)) |
| CVE-2026-23907 | Flagged for the ExtractEmbeddedFiles example in Apache PDFBox, documentation issue. If code doesn't use the example it can be ignored. May need a more thorough examination but found no evidence this time. [Source](https://lists.apache.org/thread/gyfq5tcrxfv7rx0z2yyx4hb3h53ndffw)|
| CVE-2026-33929 | Flagged for the ExtractEmbeddedFiles example in Apache PDFBox, documentation issue. If code doesn't use the example it can be ignored. May need a more thorough examination but found no evidence this time. [Source](https://lists.apache.org/thread/gyfq5tcrxfv7rx0z2yyx4hb3h53ndffw)|
| CVE-2023-36415 | CPE False Positive, flagged for [com.azure:azure-identity:1.18.0](https://github.com/Azure/azure-sdk-for-java) but since we are using the java version and the vulnerability is resolved for `1.10.2`, this can be ignored ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36415)). Consider moving to `com.azure.spring:spring-cloud-azure-starter-servicebus-jms:6.2.0` |
| CVE-2024-35255 | CPE False Positive, flagged for [com.microsoft.azure:msal4j:1.23.1](https://github.com/AzureAD/microsoft-authentication-library-for-java) but since we are using the java version and the vulnerability is resolved for `1.15.1`, this can be ignored ([source](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-35255)). Consider moving to `com.azure.spring:spring-cloud-azure-starter-servicebus-jms:6.2.0` |
| CVE-2025-15104 | CPE False Positive, flagged for [json-schema-validator](https://github.com/networknt/json-schema-validator) but vulnerability affects [The Nu Html Checker](https://github.com/validator/validator) |
| CVE-2026-33117 | CPE False Positive, flagged for `azure-core`, `azure-identity` and `azure-json`. The vulnerability is for [azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java) but we only import `azure-core:1.55.3`, `azure-messaging-servicebus:7.17.11`, `azure-servicebus-jms:2.1.0` and `applicationinsights-web`  not the main azure-sdk. The sub-libraries are up-to-date, so ignoring this one. |

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
