### PR TITLE
Revert SSCSCI-2547 confidentiality timestamp DateTime change

### DIFF
--- a/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
+++ b/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
@@ -1,6 +1,6 @@
 [
-  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
-  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "16/03/2026", "ID": "otherParty", "ListElementCode": "domesticViolenceMarker", "FieldType": "FixedRadioList", "FieldTypeParameter": "FL_yesNoUnknown", "ElementLabel": "DV marker?", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "13/05/2026", "ID": "appeal", "ListElementCode": "isOtherPartyAddedForChildMaintUCCase", "FieldType": "YesOrNo", "ElementLabel": "Show Appellant Confidentiality Required Option", "SecurityClassification": "PUBLIC"}
 ]


### PR DESCRIPTION
Reverts #5294 (SSCSCI-2547)

Raised as a precaution while investigating the AAT definition import (400) failure. Draft until we confirm whether the DateTime change is the cause.