### PR TITLE
SSCSCI-2547 display confidentiality timestamp in same format as confidentiality tab (re-apply)

### DIFF
--- a/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
+++ b/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
@@ -1,6 +1,6 @@
 [
-  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
-  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "16/03/2026", "ID": "otherParty", "ListElementCode": "domesticViolenceMarker", "FieldType": "FixedRadioList", "FieldTypeParameter": "FL_yesNoUnknown", "ElementLabel": "DV marker?", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "13/05/2026", "ID": "appeal", "ListElementCode": "isOtherPartyAddedForChildMaintUCCase", "FieldType": "YesOrNo", "ElementLabel": "Show Appellant Confidentiality Required Option", "SecurityClassification": "PUBLIC"}
 ]

--- a/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
+++ b/definitions/benefit/sheets/ComplexTypes/ComplexTypes-cm-nonprod.json
@@ -1,6 +1,6 @@
 [
-  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
-  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "DateTime", "ElementLabel": "Confidentiality Confirmed", "DisplayContextParameter": "#DATETIMEDISPLAY(d MMM yyyy, h:mm:ss a)", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "otherParty", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
+  {"LiveFrom": "02/02/2026", "ID": "appellant", "ListElementCode": "confidentialityRequiredChangedDate", "FieldType": "Text", "ElementLabel": "Confidentiality Confirmed", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "16/03/2026", "ID": "otherParty", "ListElementCode": "domesticViolenceMarker", "FieldType": "FixedRadioList", "FieldTypeParameter": "FL_yesNoUnknown", "ElementLabel": "DV marker?", "SecurityClassification": "PUBLIC"},
   {"LiveFrom": "13/05/2026", "ID": "appeal", "ListElementCode": "isOtherPartyAddedForChildMaintUCCase", "FieldType": "YesOrNo", "ElementLabel": "Show Appellant Confidentiality Required Option", "SecurityClassification": "PUBLIC"}
 ]


### PR DESCRIPTION
### Jira link

See [SSCSCI-2547](https://tools.hmcts.net/jira/browse/SSCSCI-2547)

### Change description

Switches the "Confidentiality Confirmed" timestamp on the Appeal Details and Other Party Details tabs to render in the same format as the Confidentiality tab (`d MMM yyyy, h:mm:ss a`, Locale.UK) instead of the raw ISO `LocalDateTime`.

> Re-applies #5294 after it was reverted (#5301) to unblock AAT. Hold until the AAT Elasticsearch re-index is done (Nitin) - merge only after the field type change is safe to re-introduce.

### Testing done

Verified locally with `bootWithCCD` and CM_OTHER_PARTY_CONFIDENTIALITY_ENABLED=true. All 3 ACs passed (Other Party Details tab, Appeal Details tab, Confidentiality tab — all show the formatted timestamp; status, banner, and underlying storage unchanged). Evidence attached to the JIRA ticket (AC1-2547.mov, AC2-2547.mov, AC3-2547.mov).

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
