### PR TITLE
SSCSCI-2519 Set isConfidentialCase for UC cases on Update Other Party Data event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/updateotherparty/UpdateOtherPartyAboutToSubmitHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/updateotherparty/UpdateOtherPartyAboutToSubmitHandler.java
@@ -80,7 +80,7 @@ public class UpdateOtherPartyAboutToSubmitHandler implements PreSubmitCallbackHa
 
         final SscsCaseData sscsCaseData = callback.getCaseDetails().getCaseData();
         sscsCaseData.setOtherPartyUcb(getOtherPartyUcb(sscsCaseData.getOtherParties()));
-        sscsCaseData.setIsConfidentialCase(isConfidential(sscsCaseData));
+        sscsCaseData.setIsConfidentialCase(isConfidential(sscsCaseData, cmOtherPartyConfidentialityEnabled));
         sscsCaseData.getOtherParties().forEach(otherPartyCcdValue -> otherPartyCcdValue.getValue()
                 .setSendNewOtherPartyNotification(sendNewOtherPartyNotification(otherPartyCcdValue)));
         sscsCaseData.setOtherParties(clearOtherPartiesIfEmpty(sscsCaseData));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/updateotherparty/UpdateOtherPartyAboutToSubmitHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/ccd/presubmit/updateotherparty/UpdateOtherPartyAboutToSubmitHandlerTest.java
@@ -600,6 +600,36 @@ class UpdateOtherPartyAboutToSubmitHandlerTest {
 
 
     @Test
+    void givenUcCaseWithConfidentialOtherPartyAndCmFlagOn_thenIsConfidentialCaseSetToYes() {
+        final UpdateOtherPartyAboutToSubmitHandler handlerWithFlag = new UpdateOtherPartyAboutToSubmitHandler(idamService, true);
+        final SscsCaseData caseData = SscsCaseData.builder()
+            .appeal(Appeal.builder().benefitType(BenefitType.builder().code(Benefit.UC.getShortName()).build()).build())
+            .otherParties(singletonList(buildOtherParty("Yes", YES)))
+            .build();
+        when(caseDetails.getCaseData()).thenReturn(caseData);
+
+        final PreSubmitCallbackResponse<SscsCaseData> response =
+            handlerWithFlag.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertThat(response.getData().getIsConfidentialCase()).isEqualTo(YES);
+    }
+
+    @Test
+    void givenUcCaseWithAllNonConfidentialPartiesAndCmFlagOn_thenIsConfidentialCaseNotSet() {
+        final UpdateOtherPartyAboutToSubmitHandler handlerWithFlag = new UpdateOtherPartyAboutToSubmitHandler(idamService, true);
+        final SscsCaseData caseData = SscsCaseData.builder()
+            .appeal(Appeal.builder().benefitType(BenefitType.builder().code(Benefit.UC.getShortName()).build()).build())
+            .otherParties(singletonList(buildOtherParty("Yes", NO)))
+            .build();
+        when(caseDetails.getCaseData()).thenReturn(caseData);
+
+        final PreSubmitCallbackResponse<SscsCaseData> response =
+            handlerWithFlag.handle(ABOUT_TO_SUBMIT, callback, USER_AUTHORISATION);
+
+        assertThat(response.getData().getIsConfidentialCase()).isNull();
+    }
+
+    @Test
     void givenCmConfidentialityEnabledAndChildSupportBenefit_thenDirectionDueDateAndInterlocSet() {
         final UpdateOtherPartyAboutToSubmitHandler handlerWithFlag = new UpdateOtherPartyAboutToSubmitHandler(idamService, true);
         final SscsCaseData caseData = SscsCaseData.builder()


### PR DESCRIPTION
### Jira link

See [SSCSCI-2519](https://tools.hmcts.net/jira/browse/SSCSCI-2519)

### Change description

Fixes AC5/AC6 for UC appeals. The confidentiality case flag (`isConfidentialCase`) was not being set for UC cases when confidentiality was changed via the **Update Other Party Data** event, so the confidential banner did not appear on the Confidentiality tab.

Root cause: `UpdateOtherPartyAboutToSubmitHandler` called the no-arg `isConfidential(sscsCaseData)` overload, which hardcodes the CM confidentiality flag to `false`. For UC, `isValidBenefitTypeForConfidentiality` only treats UC as valid when that flag is `true`, so the case flag was never set. SSCSCI-2516 fixed the equivalent `caseUpdated` path but not this one.

Change: pass the injected `cmOtherPartyConfidentialityEnabled` flag through to `isConfidential()`, mirroring `CaseUpdatedAboutToSubmitHandler`.

### Testing done

Unit tests added to `UpdateOtherPartyAboutToSubmitHandlerTest`:
- UC case + confidential other party, flag on -> `isConfidentialCase` set to Yes (AC5)
- UC case + all non-confidential parties, flag on -> `isConfidentialCase` not set (AC6)

Manually verified locally on a UC case with an other party: banner was missing after Update Other Party Data on master, and the fix resolves it (matching behaviour of Case Updated).

### Security Vulnerability Assessment

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change