### PR TITLE
SSCSCI: dependency issue fix for httpcomponents

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -306,6 +306,13 @@ dependencyManagement {
         // CVE-2023-36415, CVE-2024-35255
         dependency group: 'com.azure', name: 'azure-identity', version: '1.18.3'
         dependency group: 'com.microsoft.azure', name: 'msal4j', version: '1.24.1'
+
+        // CVE-2026-54399, CVE-2026-54428
+        dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
+            entry 'httpcore5'
+            entry 'httpcore5-h2'
+        }
+        dependency group: '', name: '', version: ''
     }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,5 +17,7 @@
         <cve>CVE-2026-42588</cve>
         <cve>CVE-2026-54515</cve>
         <cve>CVE-2026-53914</cve>
+        <cve>CVE-2026-54399</cve>
+        <cve>CVE-2026-54428</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Jira link

N/A

### Change description

Bumped [org.apache.httpcomponents.core5](https://hc.apache.org/httpcomponents-core-ga/) `5.3.6` -> `5.4.3`

Also added CVEs to suppression because there is another Maven artifact for httpcomponents v4: https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore, which makes the CVEs false positive on versions below 5.

### Testing done

Pipeline passes

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
