### PR TITLE
SSCSCI: Bump postgresql

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -410,7 +410,7 @@ dependencies {
     implementation group: 'com.mchange', name: 'c3p0', version: '0.13.0'
     implementation group: 'org.flywaydb', name: 'flyway-core', version: '11.8.2'
     implementation group: 'org.flywaydb', name: 'flyway-database-postgresql', version: '11.8.2'
-    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.11'
+    implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.12'
     implementation group: 'org.quartz-scheduler', name: 'quartz', version: '2.5.0'
 
     implementation group: 'io.projectreactor', name: 'reactor-core', version: '3.7.6'


### PR DESCRIPTION
### Change description

Bump postgresql from `42.7.11` to `42.7.12` to fix CVE-2026-54291

### Testing done

Pipeline passes

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

CVE-2025-21199
CVE-2026-23907
CVE-2026-33929
CVE-2023-36415
CVE-2024-35255
CVE-2025-15104
CVE-2026-33117
CVE-2025-7962
CVE-2026-49157
CVE-2026-46605
CVE-2026-45505
CVE-2026-49270
CVE-2026-42253
CVE-2026-42588
CVE-2026-54515
CVE-2026-53914
CVE-2026-54399
CVE-2026-54428

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
