### PR TITLE
SSCSCI - upgrade netty

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -134,7 +134,7 @@ withPipeline(type, product, component) {
     enableHighLevelDataSetup()
     loadVaultSecrets(secrets)
     enableSlackNotifications('#sscs-tech')
-    syncBranchesWithMaster(['demo', 'ithc', 'perftest'])
+    syncBranchesWithMaster(['ithc', 'perftest'])
 
     env.DOCUMENT_MANAGEMENT_URL = "http://dm-store-aat.service.core-compute-aat.internal"
     env.TEST_DOCUMENT_MANAGEMENT_URL = "http://dm-store-aat.service.core-compute-aat.internal"

--- a/build.gradle
+++ b/build.gradle
@@ -318,7 +318,7 @@ dependencyManagement {
 
 ext {
     set('activemq.version', '6.2.7')
-    set('netty.version', '4.2.15.Final')
+    set('netty.version', '4.2.16.Final')
     set('log4j2.version', '2.26.1')
     set('commons-lang3.version', '3.20.0')
     set('kotlin.version', '2.2.21')

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -19,5 +19,8 @@
         <cve>CVE-2026-53914</cve>
         <cve>CVE-2026-54399</cve>
         <cve>CVE-2026-54428</cve>
+        <cve>CVE-2026-55833</cve>
+        <cve>CVE-2026-44891</cve>
+        <cve>CVE-2026-55831</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description

Suppress CVES: CVE-2026-55833, CVE-2026-44891, CVE-2026-55831 which are all caused by Netty. There is no fix for these CVEs yet, but I have upgraded to latest version (4.2.16.Final).

Remove demo sync for testing in demo

### Testing done

Green build

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
