### PR TITLE
Added suppression for active mq and tomcat CVE's as we are already on latest and no patch is available

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,5 +24,8 @@
         <cve>CVE-2026-55831</cve>
         <cve>CVE-2026-63263</cve>
         <cve>CVE-2026-63144</cve>
+        <cve>CVE-2026-59878</cve>
+        <cve>CVE-2026-61487</cve>
+        <cve>CVE-2026-66299</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
No patch is available as of now

> activemq-client 6.2.7
> CVE-2026-59878
> CVE-2026-61487
> 
> tomcat-embed-core             11.0.24
> tomcat-embed-websocket  11.0.24
> CVE-2026-66299
> 