### PR TITLE
Httpclient and Apache Tika upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -400,7 +400,7 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.58'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
 
-    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '6.1.0-RELEASE'
+    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.2.1-RELEASE'
 
     implementation group: 'com.azure', name: 'azure-core', version: '1.55.3'
     implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.11'

--- a/build.gradle
+++ b/build.gradle
@@ -309,6 +309,8 @@ dependencyManagement {
 
         // CVE-2026-66274, CVE-2026-66273, CVE-2026-63140, CVE-2026-66276, CVE-2026-66275, CVE-2026-66277, CVE-2026-66257
         dependency group: 'org.apache.qpid', name: 'proton-j', version: '0.35.0'
+        dependency group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.6.3'
+        dependency group: 'io.github.openfeign', name: 'feign-httpclient', version: '13.13'
 
         // CVE-2026-54399, CVE-2026-54428
         dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
@@ -335,7 +337,7 @@ def versions = [
         jackson        : '2.22.1',
         lombok         : '1.18.38',
         commonsio      : '2.19.0',
-        openfeign      : '13.6'
+        openfeign      : '13.13'
 ]
 
 dependencies {
@@ -398,7 +400,7 @@ dependencies {
     implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.58'
     implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
 
-    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '5.2.1-RELEASE'
+    implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '6.1.0-RELEASE'
 
     implementation group: 'com.azure', name: 'azure-core', version: '1.55.3'
     implementation group: 'com.azure', name: 'azure-messaging-servicebus', version: '7.17.11'
@@ -441,8 +443,8 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.15.0'
     implementation group: 'org.apache.pdfbox', name: 'pdfbox', version: '3.0.7'
     implementation group: 'org.apache.pdfbox', name: 'xmpbox', version: '3.0.7'
-    implementation group: 'org.apache.tika', name: 'tika-core', version: '3.2.3'
-    implementation group: 'org.apache.tika', name: 'tika-parsers', version: '3.2.3'
+    implementation group: 'org.apache.tika', name: 'tika-core', version: '3.3.2'
+    implementation group: 'org.apache.tika', name: 'tika-parsers', version: '3.3.2'
     implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.24'
 
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
@@ -468,7 +470,7 @@ dependencies {
         exclude group: 'commons-io', module: 'commons-io'
     }
 
-    testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5-fluent', version: '5.5'
+    testImplementation group: 'org.apache.httpcomponents.client5', name: 'httpclient5-fluent', version: '5.6.3'
 
     testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '4.1.1'
     testImplementation group: 'net.javacrumbs.json-unit', name: 'json-unit-assertj', version: '4.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,6 @@ dependencyManagement {
         // CVE-2026-66274, CVE-2026-66273, CVE-2026-63140, CVE-2026-66276, CVE-2026-66275, CVE-2026-66277, CVE-2026-66257
         dependency group: 'org.apache.qpid', name: 'proton-j', version: '0.35.0'
         dependency group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: '5.6.3'
-        dependency group: 'io.github.openfeign', name: 'feign-httpclient', version: '13.13'
 
         // CVE-2026-54399, CVE-2026-54428
         dependencySet(group: 'org.apache.httpcomponents.core5', version: '5.4.3') {
@@ -337,7 +336,7 @@ def versions = [
         jackson        : '2.22.1',
         lombok         : '1.18.38',
         commonsio      : '2.19.0',
-        openfeign      : '13.13'
+        openfeign      : '13.6'
 ]
 
 dependencies {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -28,5 +28,6 @@
         <cve>CVE-2026-61487</cve>
         <cve>CVE-2026-66299</cve>
         <cve>CVE-2026-63140</cve>
+        <cve>CVE-2026-64607</cve>
     </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description

Upgrade apache tika from 3.2.3 to 3.3.2
upgrade apache httpclient5-fluent from 5.5 to 5.6.3

Suppress CVE-2026-64607 which affects httpClient through to version through 5.6.2. I have upgraded httpClient5 to 5.6.3 however version 4.5.14 is being used through notifications-java-client and feign-httpclient. 
Forcing use of version 5.6.3 by upgrading notifications-java-client to Version 6.2.0-RELEASE and feign-httpclient to 13.13  causes all integration tests to fail. Suppressing as this cve is medium.

### Testing done

Green build

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
