### PR TITLE
Add null-safety guard for hearing venue data in event mapping

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -335,29 +335,29 @@ public class TrackYourAppealJsonBuilder {
 
     private void setLatestEventAs(List<Event> eventList, Event currentEvent, EventType eventType) {
         Event event = Event.builder().value(currentEvent.getValue().toBuilder().type(eventType
-            .getCcdType()).build()).build();
+                .getCcdType()).build()).build();
         eventList.set(0, event);
     }
 
     private boolean isPastHearingBookedDate(Event event, Boolean isPaperCase) {
         return DWP_RESPOND.equals(getEventType(event))
-            && LocalDateTime.now().isAfter(
-            LocalDateTime.parse(event.getValue().getDate()).plusWeeks(PAST_HEARING_BOOKED_IN_WEEKS))
-            && !isPaperCase;
+                && LocalDateTime.now().isAfter(
+                LocalDateTime.parse(event.getValue().getDate()).plusWeeks(PAST_HEARING_BOOKED_IN_WEEKS))
+                && !isPaperCase;
     }
 
     private boolean isNewHearingBookedEvent(List<Event> eventList) {
         return eventList.size() > 1
-            && HEARING_BOOKED.equals(getEventType(eventList.get(0)))
-            && (POSTPONED.equals(getEventType(eventList.get(1)))
-            || ADJOURNED.equals(getEventType(eventList.get(1))));
+                && HEARING_BOOKED.equals(getEventType(eventList.get(0)))
+                && (POSTPONED.equals(getEventType(eventList.get(1)))
+                || ADJOURNED.equals(getEventType(eventList.get(1))));
     }
 
     private boolean isAppealClosed(Event event) {
         return DORMANT.equals(getEventType(event))
-            && LocalDateTime.now().isAfter(
-            LocalDateTime.parse(event.getValue().getDate()).plusMonths(
-                DORMANT_TO_CLOSED_DURATION_IN_MONTHS));
+                && LocalDateTime.now().isAfter(
+                LocalDateTime.parse(event.getValue().getDate()).plusMonths(
+                        DORMANT_TO_CLOSED_DURATION_IN_MONTHS));
     }
 
     private boolean isDwpRespondOverdue(Event event, String benefitCode, String dateSentToDwp) {
@@ -453,7 +453,7 @@ public class TrackYourAppealJsonBuilder {
                             DWP_RESPONSE_HEARING_CONTACT_DATE_IN_WEEKS, false));
             case HEARING_BOOKED, NEW_HEARING_BOOKED -> {
                 Hearing hearing = eventHearingMap.get(event);
-                if (hearing != null) {
+                if (hearing != null && hearing.getValue().getVenue() != null) {
                     eventNode.put(POSTCODE, hearing.getValue().getVenue().getAddress().getPostcode());
                     eventNode.put(HEARING_DATETIME,
                             DATEFORMATTER.format(getLocalDateTime(hearing.getValue().getHearingDate(), hearing.getValue().getTime())));
@@ -565,15 +565,15 @@ public class TrackYourAppealJsonBuilder {
             for (Document document : documentList) {
                 if (document != null && document.getValue() != null) {
                     EventDetails eventDetails = EventDetails.builder()
-                        .date(LocalDate.parse(document.getValue().getDateReceived()).atStartOfDay().plusHours(1)
-                            .toString())
-                        .type(EventType.EVIDENCE_RECEIVED.getCcdType())
-                        .description("Evidence received")
-                        .build();
+                            .date(LocalDate.parse(document.getValue().getDateReceived()).atStartOfDay().plusHours(1)
+                                    .toString())
+                            .type(EventType.EVIDENCE_RECEIVED.getCcdType())
+                            .description("Evidence received")
+                            .build();
 
                     events.add(Event.builder()
-                        .value(eventDetails)
-                        .build());
+                            .value(eventDetails)
+                            .build());
                 }
             }
             caseData.getEvents().addAll(events);
@@ -619,7 +619,7 @@ public class TrackYourAppealJsonBuilder {
                 int hearingIndex = 0;
                 for (Event event : events) {
                     if (HEARING_BOOKED.equals(getEventType(event))
-                        || NEW_HEARING_BOOKED.equals(getEventType(event))) {
+                            || NEW_HEARING_BOOKED.equals(getEventType(event))) {
                         if (hearingIndex < hearingList.size()) {
                             eventHearingMap.put(event, hearingList.get(hearingIndex));
                             hearingIndex++;
@@ -635,14 +635,14 @@ public class TrackYourAppealJsonBuilder {
     private SscsCaseData createAppealReceivedEventTypeForAppealCreatedEvent(SscsCaseData caseData) {
 
         EventDetails eventDetails = EventDetails.builder()
-            .date(LocalDate.parse(caseData.getCaseCreated()).atStartOfDay().plusHours(1).toString())
-            .type(EventType.APPEAL_RECEIVED.getCcdType())
-            .description("Appeal received")
-            .build();
+                .date(LocalDate.parse(caseData.getCaseCreated()).atStartOfDay().plusHours(1).toString())
+                .type(EventType.APPEAL_RECEIVED.getCcdType())
+                .description("Appeal received")
+                .build();
 
         Event event = Event.builder()
-            .value(eventDetails)
-            .build();
+                .value(eventDetails)
+                .build();
 
         List<Event> events = new ArrayList<>();
         events.add(event);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
@@ -1,6 +1,14 @@
 package uk.gov.hmcts.reform.sscs.builder;
 
 import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static org.junit.Assert.assertNull;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.ADDRESS_LINE_1;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.ADDRESS_LINE_2;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.ADDRESS_LINE_3;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.GOOGLE_MAP_URL;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.HEARING_DATETIME;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.POSTCODE;
+import static uk.gov.hmcts.reform.sscs.model.AppConstants.VENUE_NAME;
 import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNED_HEARING_CCD;
 import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNED_HEARING_MYA;
 import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNMENT_NOTICE_CCD;
@@ -27,12 +35,15 @@ import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.NOT_LIST
 import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.NOT_LISTABLE_MYA;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
+import uk.gov.hmcts.reform.sscs.ccd.domain.Hearing;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
 
 public class TrackYourAppealJsonBuilderTest {
 
@@ -156,22 +167,47 @@ public class TrackYourAppealJsonBuilderTest {
     public void shouldReturnHmcHearingTypeInTheMyaResponseWithHearing() {
         SscsCaseData caseData = HMC_HEARING_TYPE_CCD.getDeserializeMessage();
         ObjectNode objectNode = trackYourAppealJsonBuilder.build(caseData,
-            populateRegionalProcessingCenter(), 1L, true, "hearing");
+                populateRegionalProcessingCenter(), 1L, true, "hearing");
         assertJsonEquals(HMC_HEARING_TYPE_MYA.getSerializedMessage(), objectNode);
+    }
+
+    @Test
+    public void shouldNotThrowNpeAndOmitVenueFieldsWhenHearingVenueIsNull() {
+        SscsCaseData caseData = HEARING_CCD.getDeserializeMessage();
+
+        List<Hearing> hearings = caseData.getHearings();
+        Hearing hearing = hearings.getFirst();
+        Hearing hearingWithNullVenue = hearing.toBuilder()
+                .value(hearing.getValue().toBuilder().venue(null).build())
+                .build();
+        hearings.set(0, hearingWithNullVenue);
+
+        ObjectNode objectNode = trackYourAppealJsonBuilder.build(caseData,
+                populateRegionalProcessingCenter(), 1L, true, "hearing");
+
+        ObjectNode eventNode = (ObjectNode) objectNode.get("appeal").get("latestEvents").get(0);
+
+        assertNull(eventNode.get(POSTCODE));
+        assertNull(eventNode.get(VENUE_NAME));
+        assertNull(eventNode.get(ADDRESS_LINE_1));
+        assertNull(eventNode.get(ADDRESS_LINE_2));
+        assertNull(eventNode.get(ADDRESS_LINE_3));
+        assertNull(eventNode.get(GOOGLE_MAP_URL));
+        assertNull(eventNode.get(HEARING_DATETIME));
     }
 
     private RegionalProcessingCenter populateRegionalProcessingCenter() {
         return RegionalProcessingCenter.builder()
-            .name("LIVERPOOL")
-            .address1("HM Courts & Tribunals Service")
-            .address2("Social Security & Child Support Appeals")
-            .address3("Prudential Buildings")
-            .address4("36 Dale Street")
-            .city("LIVERPOOL")
-            .postcode("L2 5UZ")
-            .phoneNumber("0300 123 1142")
-            .faxNumber("0870 324 0109")
-            .build();
+                .name("LIVERPOOL")
+                .address1("HM Courts & Tribunals Service")
+                .address2("Social Security & Child Support Appeals")
+                .address3("Prudential Buildings")
+                .address4("36 Dale Street")
+                .city("LIVERPOOL")
+                .postcode("L2 5UZ")
+                .phoneNumber("0300 123 1142")
+                .faxNumber("0870 324 0109")
+                .build();
     }
 
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCSCI-2715

- Guard against NullPointerException when populating eventNode with hearing and venue details. 
- Previously, a null hearing venue would cause an NPE when accessing nested fields (postcode, address lines, venue name, etc) thereby preventing user to login as it is called when user is trying to login via MYA
- The block is now skipped entirely if hearing or hearing.getValue().getVenue() is null. Address is not null-checked separately since a non-null Venue always has an associated Address.

Exception in prod

> java.lang.NullPointerException: Cannot invoke "uk.gov.hmcts.reform.sscs.ccd.domain.Venue.getAddress()" because the return value of "uk.gov.hmcts.reform.sscs.ccd.domain.HearingDetails.getVenue()" is null
	at uk.gov.hmcts.reform.sscs.builder.TrackYourAppealJsonBuilder.buildEventNode(TrackYourAppealJsonBuilder.java:457)
	at uk.gov.hmcts.reform.sscs.builder.TrackYourAppealJsonBuilder.buildEventArray(TrackYourAppealJsonBuilder.java:388)
	at uk.gov.hmcts.reform.sscs.builder.TrackYourAppealJsonBuilder.build(TrackYourAppealJsonBuilder.java:174)
	at uk.gov.hmcts.reform.sscs.service.TribunalsService.findAppeal(TribunalsService.java:53)
	at uk.gov.hmcts.reform.sscs.controller.TyaController.getAppealByCaseId(TyaController.java:42)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) 