### PR TITLE
Exclude cancelled hearings from the list of hearings used when mapping hearing events in MYA

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -44,7 +44,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 import net.objectlab.kit.datecalc.common.DateCalculator;
 import net.objectlab.kit.datecalc.jdk8.LocalDateKitCalculatorsFactory;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -43,6 +43,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import net.objectlab.kit.datecalc.common.DateCalculator;
 import net.objectlab.kit.datecalc.jdk8.LocalDateKitCalculatorsFactory;
@@ -613,7 +615,9 @@ public class TrackYourAppealJsonBuilder {
         if (hearingList != null && !hearingList.isEmpty()) {
             hearingList = hearingList.stream()
                     .filter(hearing -> hearing.getValue().getHearingStatus() != HearingStatus.CANCELLED)
-                    .toList();
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            hearingList.sort(Comparator.reverseOrder());
 
             List<Event> events = caseData.getEvents();
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilder.java
@@ -611,9 +611,11 @@ public class TrackYourAppealJsonBuilder {
         List<Hearing> hearingList = caseData.getHearings();
 
         if (hearingList != null && !hearingList.isEmpty()) {
-            List<Event> events = caseData.getEvents();
+            hearingList = hearingList.stream()
+                    .filter(hearing -> hearing.getValue().getHearingStatus() != HearingStatus.CANCELLED)
+                    .toList();
 
-            hearingList.sort(Comparator.reverseOrder());
+            List<Event> events = caseData.getEvents();
 
             if (null != events && !events.isEmpty()) {
                 int hearingIndex = 0;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
@@ -1,31 +1,5 @@
 package uk.gov.hmcts.reform.sscs.builder;
 
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNED_HEARING_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNED_HEARING_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNMENT_NOTICE_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.ADJOURNMENT_NOTICE_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED_CHILD_SUPPORT_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED_CHILD_SUPPORT_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.APPEAL_RECEIVED_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.AUDIO_VIDEO_EVIDENCE_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.AUDIO_VIDEO_EVIDENCE_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.DORMANT_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.DORMANT_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.DWP_RESPOND_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.DWP_RESPOND_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.DWP_RESPOND_MYA_FOR_PAPER_HEARING_TYPE;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.FINAL_DECISION_NOTICE_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.FINAL_DECISION_NOTICE_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.HEARING_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.HEARING_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.HEARING_PAPER_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.HMC_HEARING_TYPE_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.HMC_HEARING_TYPE_MYA;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.NOT_LISTABLE_CCD;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.NOT_LISTABLE_MYA;
-
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +7,10 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
+
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.*;
 
 public class TrackYourAppealJsonBuilderTest {
 
@@ -160,6 +138,19 @@ public class TrackYourAppealJsonBuilderTest {
         assertJsonEquals(HMC_HEARING_TYPE_MYA.getSerializedMessage(), objectNode);
     }
 
+    @Test
+    public void shouldMapHearingWithDateBeforeHearingWithoutDate() {
+        SscsCaseData caseData = HEARING_CCD_GAPS_LA.getDeserializeMessage();
+
+        ObjectNode objectNode = trackYourAppealJsonBuilder.build(
+                caseData,
+                populateRegionalProcessingCenter(),
+                1L,
+                true,
+                "hearing"
+        );
+        assertThat(objectNode.at("/appeal/latestEvents/0/hearingDateTime").asText()).containsOnlyOnce("2026-09-04T15:15:00.000Z");
+    }
     private RegionalProcessingCenter populateRegionalProcessingCenter() {
         return RegionalProcessingCenter.builder()
             .name("LIVERPOOL")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/builder/TrackYourAppealJsonBuilderTest.java
@@ -1,5 +1,9 @@
 package uk.gov.hmcts.reform.sscs.builder;
 
+import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.*;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
@@ -7,10 +11,6 @@ import uk.gov.hmcts.reform.sscs.ccd.domain.DocumentLink;
 import uk.gov.hmcts.reform.sscs.ccd.domain.HearingType;
 import uk.gov.hmcts.reform.sscs.ccd.domain.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.ccd.domain.SscsCaseData;
-
-import static net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals;
-import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.reform.sscs.util.SerializeJsonMessageManager.*;
 
 public class TrackYourAppealJsonBuilderTest {
 
@@ -151,6 +151,7 @@ public class TrackYourAppealJsonBuilderTest {
         );
         assertThat(objectNode.at("/appeal/latestEvents/0/hearingDateTime").asText()).containsOnlyOnce("2026-09-04T15:15:00.000Z");
     }
+
     private RegionalProcessingCenter populateRegionalProcessingCenter() {
         return RegionalProcessingCenter.builder()
             .name("LIVERPOOL")

--- a/src/test/java/uk/gov/hmcts/reform/sscs/util/SerializeJsonMessageManager.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/util/SerializeJsonMessageManager.java
@@ -36,6 +36,7 @@ public enum SerializeJsonMessageManager {
     HEARING_MYA("tya/hearingMya.json"),
     HEARING_PAPER_MYA("tya/hearingPaperMya.json"),
     HEARING_CCD("tya/hearingCcd.json"),
+    HEARING_CCD_GAPS_LA("tya/hearingsWithCancelledListAssistAndGapsHearingBooked.json"),
     NOT_LISTABLE_MYA("tya/notListableMya.json"),
     NOT_LISTABLE_CCD("tya/notListableCcd.json"),
     ADJOURNED_HEARING_MYA("tya/hearingAdjournedMya.json"),

--- a/src/test/resources/tya/hearingsWithCancelledListAssistAndGapsHearingBooked.json
+++ b/src/test/resources/tya/hearingsWithCancelledListAssistAndGapsHearingBooked.json
@@ -1,0 +1,80 @@
+{
+  "caseId": "1",
+  "caseReference": "SC333/33/33333",
+  "appeal": {
+    "appellant": {
+      "name": {
+        "title": "Mr.",
+        "lastName": "Charlie",
+        "firstName": "C"
+      }
+    },
+    "benefitType": {
+      "code": "PIP"
+    },
+    "hearingOptions": {
+      "wantsToAttend": "Yes"
+    }
+  },
+  "hearings": [
+    {
+      "id": "33cf0f87-5796-4958-b16c-5b13e7586bdd",
+      "value": {
+        "hearingId": "3000252004",
+        "hearingStatus": "CANCELLED",
+        "versionNumber": 1
+      }
+    },
+    {
+      "id": "56e87418-bdfa-4ffa-abd6-acf0779ac338",
+      "value": {
+        "time": "15:15:00",
+        "venue": {
+          "name": "Prudential House",
+          "address": {
+            "line1": "36 Dale Street",
+            "line2": "",
+            "town": "Liverpool",
+            "postcode": "L2 5UZ"
+          },
+          "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+        },
+        "venueId": "96",
+        "adjourned": "No",
+        "hearingId": "6158952",
+        "hearingDate": "2026-09-04"
+      }
+    }
+  ],
+  "events": [
+    {
+      "id": "cfa54d4c-4417-4bfb-91f9-5dd837ec30a1",
+      "value": {
+        "date": "2026-08-04T11:30:57.507",
+        "type": "hearingBooked",
+        "description": "Hearing booked"
+      }
+    },
+    {
+      "id": "e231943e-68af-4017-9552-1caae99b5c71",
+      "value": {
+        "date": "2026-07-01T16:23:38.310",
+        "type": "responseReceived",
+        "description": "Response received"
+      }
+    },
+    {
+      "id": "6bf39830-65d9-4a02-a48a-2e2933bb2611",
+      "value": {
+        "date": "2026-07-01T16:22:52.373",
+        "type": "appealReceived",
+        "description": "Appeal received"
+      }
+    }
+  ],
+  "subscriptions": {
+    "appellantSubscription": {
+      "tya": "abcde12345"
+    }
+  }
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCSCI-2715

> The hearing list is now filtered to remove hearings with a CANCELLED status before they are processed:

```
List<Hearing> hearingList = caseData.getHearings().stream()
    .filter(hearing -> hearing.getValue().getHearingStatus() != HearingStatus.CANCELLED)
    .toList();

```

Why

> Previously, cancelled hearings could be included in the hearing-to-event mapping and potentially result in cancelled hearing details being displayed to users. This change ensures that only non-cancelled hearings are considered.

Testing

> Verified that cancelled hearings are excluded from the hearing list used for event mapping.
> Existing hearing processing behaviour remains unchanged for non-cancelled hearings.