### PR TITLE
Guard the NINO render in both halves of the bilingual PDF templates

### DIFF
--- a/src/main/resources/templates/evidenceDescriptionWelsh.html
+++ b/src/main/resources/templates/evidenceDescriptionWelsh.html
@@ -103,6 +103,7 @@
                             {{ pdfSummary.appealDetails.surname }}
                         </dd>
                     </div>
+                    {% if pdfSummary.appealDetails.hideNino == false  %}
                     <div>
                         <dt class="cya-question">
                             Rhif Yswiriant Gwladol
@@ -111,6 +112,7 @@
                             {{ pdfSummary.appealDetails.nino }}
                         </dd>
                     </div>
+                    {% endif %}
                     <div>
                         <dt class="cya-question">
                             Cyfeirnod yr apêl

--- a/src/main/resources/templates/onlineHearingSummary.html
+++ b/src/main/resources/templates/onlineHearingSummary.html
@@ -129,6 +129,7 @@
                             {{ pdfSummary.appealDetails.surname }}
                         </dd>
                     </div>
+                    {% if pdfSummary.appealDetails.hideNino == false  %}
                     <div>
                         <dt class="cya-question">
                             NINO
@@ -137,6 +138,7 @@
                             {{ pdfSummary.appealDetails.nino }}
                         </dd>
                     </div>
+                    {% endif %}
                     <!--<div>
                       <dt class="cya-question">
                        Benefit type

--- a/src/main/resources/templates/personalStatementWelsh.html
+++ b/src/main/resources/templates/personalStatementWelsh.html
@@ -174,6 +174,7 @@
                             {{ pdfSummary.appealDetails.surname }}
                         </dd>
                     </div>
+                    {% if pdfSummary.appealDetails.hideNino == false  %}
                     <div>
                         <dt class="cya-question">
                             NINO
@@ -182,6 +183,7 @@
                             {{ pdfSummary.appealDetails.nino }}
                         </dd>
                     </div>
+                    {% endif %}
                     <div>
                         <dt class="cya-question">
                             Appeal reference number

--- a/src/test/java/uk/gov/hmcts/reform/sscs/service/pdf/PdfTemplateNinoGuardTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/service/pdf/PdfTemplateNinoGuardTest.java
@@ -1,0 +1,79 @@
+package uk.gov.hmcts.reform.sscs.service.pdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Every NINO render in a PDF template must sit inside a hideNino guard.
+ *
+ * <p>The Welsh templates are hand-duplicated markup rather than a translation lookup, so each
+ * guard has to be added twice. Three renders had escaped: the Welsh half of
+ * evidenceDescriptionWelsh, the English half of personalStatementWelsh, and the only render in
+ * onlineHearingSummary. A spot-check would not have found them, because in each case a sibling
+ * render in the same file was correctly guarded.
+ *
+ * <p>This walks the guard structure rather than counting, so a guard around some unrelated block
+ * cannot satisfy it.
+ */
+class PdfTemplateNinoGuardTest {
+
+    private static final Path TEMPLATES = Path.of("src/main/resources/templates");
+    private static final String NINO_RENDER = "pdfSummary.appealDetails.nino";
+    private static final String GUARD_SUBJECT = "hideNino";
+
+    @Test
+    void everyNinoRenderSitsInsideAHideNinoGuard() throws IOException {
+        List<String> unguarded = new ArrayList<>();
+        int rendersChecked = 0;
+        int templatesScanned = 0;
+
+        try (Stream<Path> templates = Files.list(TEMPLATES)) {
+            for (Path template : templates.filter(p -> p.toString().endsWith(".html")).toList()) {
+                templatesScanned++;
+                List<String> lines = Files.readAllLines(template);
+                Deque<Boolean> openGuards = new ArrayDeque<>();
+
+                for (int i = 0; i < lines.size(); i++) {
+                    String line = lines.get(i);
+
+                    if (line.contains("{% if ")) {
+                        openGuards.push(line.contains(GUARD_SUBJECT));
+                    }
+
+                    if (line.contains(NINO_RENDER) && !line.contains("{% if ")) {
+                        rendersChecked++;
+                        if (!openGuards.contains(Boolean.TRUE)) {
+                            unguarded.add(template.getFileName() + " line " + (i + 1));
+                        }
+                    }
+
+                    if (line.contains("{% endif %}") && !openGuards.isEmpty()) {
+                        openGuards.pop();
+                    }
+                }
+            }
+        }
+
+        // Without these the test passes when the templates are renamed or moved, which is the
+        // failure mode a guard test is least able to notice about itself.
+        assertThat(templatesScanned)
+                .as("no templates found under %s - has the directory moved?", TEMPLATES)
+                .isPositive();
+        assertThat(rendersChecked)
+                .as("no NINO renders found in any template - has the field been renamed?")
+                .isPositive();
+
+        assertThat(unguarded)
+                .as("NINO rendered outside a hideNino guard, so it prints for child-support appeals")
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
Fixes #5438.

An appellant's National Insurance number is meant to be hidden on child-support PDFs. Three renders
were not guarded:

| template | line | which half |
|---|---|---|
| `evidenceDescriptionWelsh.html` | 111 | the Welsh half |
| `personalStatementWelsh.html` | 182 | the English half |
| `onlineHearingSummary.html` | 137 | the only render in the file |

In the two bilingual templates the guard was present in one half and missing in the other — **and it
was a different half in each file** — so the NINO appeared for appellants who chose Welsh and not for
those who chose English.

`StorePdfService` is doing the right thing: it sets `hideNino` for child-support appeals and passes it
into both the Welsh and the English `PdfAppealDetails`. The gap was entirely in the templates.

## The change

Six lines. Each guard wraps the whole NINO `<div>`, matching the two templates that already had one:

```
{% if pdfSummary.appealDetails.hideNino == false  %}
<div>
    <dt class="cya-question">Rhif Yswiriant Gwladol</dt>
    <dd class="cya-answer">{{ pdfSummary.appealDetails.nino }}</dd>
</div>
{% endif %}
```

## Why a test, and why this shape

The Welsh templates are duplicated markup rather than a translation lookup — an `i18n` object is
passed to every template but no template references it, and there is no `cy.json` — so every guard
has to be added twice by hand and can drift apart again. `PdfTemplateNinoGuardTest` walks the guard
structure of every template and asserts that no `appealDetails.nino` render sits outside a `hideNino`
guard.

Two deliberate choices:

- **Structure, not counting.** A renders-equals-guards count would pass if a guard sat around some
  unrelated block. This tracks the open `{% if %}` stack, so it only passes if each render is
  genuinely inside one.
- **It asserts it found something.** `templatesScanned` and `rendersChecked` must both be positive,
  otherwise renaming the directory or the field would make the test pass silently — the failure a
  guard test is least able to notice about itself.

## Verification

Run against the **unfixed** templates the test fails and names exactly the three locations above;
against the fixed templates it passes. I could not run it through Gradle locally — the build needs a
Java 21 toolchain and this machine has 22 and 26, with no toolchain download repository configured —
so it was compiled and executed standalone on the JUnit 5 platform. It has no dependencies beyond
JUnit and AssertJ and reads only files, so that run is faithful, but **CI is the real check** and I'd
ask a reviewer to confirm it there.

## Left alone deliberately

- The four templates with no NINO render at all (`appellant_appeal_template.html`,
  `appellant_appeal_welsh_template.html`, `sent_notification.html`, and the letter templates) — the
  test covers them, so if a render is ever added without a guard it will fail.
- A real translation lookup for the bilingual templates, which is the actual fix for the drift. Worth
  doing, too large for this PR, and noted in #5438.

## One thing a reviewer can answer better than I can

`onlineHearingSummary.html` has no Welsh counterpart, so its unguarded render may have affected every
language rather than Welsh only. It looks like it belongs to a continuous-online-hearing flow
(`AnswerState` carries COH wire strings) — if that flow is retired, this part may be moot. I could not
establish from the source whether any affected documents were actually generated.
