### PR TITLE
Keep the CCD diff report green on a pull request from a fork

### DIFF
--- a/.github/workflows/ccd-diff.yaml
+++ b/.github/workflows/ccd-diff.yaml
@@ -33,6 +33,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     needs: [buildBranch, buildMaster]
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -54,9 +57,20 @@ jobs:
       - name: Display
         run: |
           cat report.txt
+      # The run summary needs no token, so it works for every pull request
+      # including one from a fork. It is the report's reliable home; the comment
+      # below is a convenience on top of it.
+      - name: Publish report to the run summary
+        run: cat report.txt >> "$GITHUB_STEP_SUMMARY"
+      # A pull request from a fork is given a read-only GITHUB_TOKEN, and no
+      # `permissions:` block can raise it, so this step fails with "Resource not
+      # accessible by integration" and turns the run red for a change that may be
+      # perfectly good. Skipping it there costs nothing: the report is in the run
+      # summary above either way.
       - name: Add report
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: thollander/actions-comment-pull-request@v3
         with:
           file-path: report.txt
           comment-tag: CCD_diff_report
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Split out of #5440, where this surfaced.

The `report` job in `.github/workflows/ccd-diff.yaml` ends by posting the CCD diff as a PR comment. A
pull request **from a fork** is given a read-only `GITHUB_TOKEN`, so that step fails:

```
##[error]Resource not accessible by integration
  https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

and the whole run goes red for a change that may be perfectly good — as it did on #5440, where
`buildMaster` and `buildBranch` both passed and only the comment failed. No `permissions:` block can
fix this: a fork PR's token cannot be granted write, by design.

It has not come up before because #5440 is the only fork pull request in the last 60 in this
repository. Every other one comes from a branch here, where the token does have write access. So as
things stand the repo cannot accept an external contribution without a red check.

## The change

- **The report goes to `$GITHUB_STEP_SUMMARY`.** That needs no token, so it works for every pull
  request including a fork's. The run summary becomes the report's reliable home and the comment
  becomes a convenience on top of it, rather than the only way to see the diff.
- **The comment step is skipped when the head repo is not this repo**, so a fork PR no longer fails
  on it.
- **The `report` job declares the scopes it needs** (`contents: read`, `pull-requests: write`) instead
  of inheriting the default, and the action's token input is renamed `GITHUB_TOKEN` → `github-token`.
  The old name has not been a valid input since v3 and every run currently logs
  `Unexpected input(s) 'GITHUB_TOKEN', valid inputs are [... 'github-token' ...]`.

## Two things I deliberately did not do

- **Not `pull_request_target`.** It would give the job a write token, but it runs in the base repo's
  context with the fork's code checked out — that is the standard way to leak a privileged token to an
  untrusted contributor. Not worth it to tidy a check.
- **Not `continue-on-error: true`.** That would hide a genuine failure of the comment step as
  readily as a spurious one. The point is to not attempt an impossible write, not to ignore a failed
  one.

## Verification

This PR is itself from a fork, so its own run exercises the change: the comment step should be skipped
and `report` should pass, with the diff visible in the run summary instead. If the `report` job on
this PR is green, the fix is demonstrated by the thing that would previously have failed.

Worth a reviewer's eye on one point: an internal PR should be completely unaffected — the `if`
evaluates true there and the comment posts exactly as now. I cannot exercise that path from a fork, so
the first internal PR after this merges is the real confirmation.
